### PR TITLE
Dual Directional SOCD Fix Issue#24

### DIFF
--- a/headers/addons/dualdirectional.h
+++ b/headers/addons/dualdirectional.h
@@ -50,6 +50,11 @@ public:
     virtual std::string name() { return DualDirectionalName; }
 private:
     void debounce();
+    uint8_t gpadToBinary(DpadMode, GamepadState);
+    void SOCDDualClean(SOCDMode);
+    uint8_t SOCDCombine(SOCDMode, uint8_t);
+    uint8_t SOCDGamepadClean(uint8_t);
+    void OverrideGamepad(Gamepad *, DpadMode, uint8_t);
     uint8_t dDebState;          // Debounce State (stored)
     uint8_t dualState;          // Dual Directional State
     DpadDirection lastGPUD; // Gamepad Last Up-Down

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -76,7 +76,7 @@ struct BoardOptions
 	uint8_t pinDualDirDown;
 	uint8_t pinDualDirLeft;
 	uint8_t pinDualDirRight;
-	uint8_t dualDirDpadMode;    // LS/DP/RS
+	DpadMode dualDirDpadMode;    // LS/DP/RS
 	uint8_t dualDirCombineMode; // Mix/Gamepad/Dual/None
 	OnBoardLedMode onBoardLedMode;
 	char boardVersion[32]; // 32-char limit to board name


### PR DESCRIPTION
Mixed (Up-Win or Neutral) -
  (Gamepad OR Dual) Left + (Gamepad OR Dual) Right = Neutral in Up-Win & Neutral
  (Gamepad OR Dual) Up + (Gamepad OR Dual) Down = Up in Up-Win, Neutral in Neutral
  Hold (Dual) Right -> Add and Hold (Gamepad) Left -> Add and Hold (Gamepad) Right = Right in Up-Win & Neutral
  Hold (Dual) Right -> Add and Hold (Gamepad) Left -> Add and Hold (Gamepad) Right -> Add and Hold (Dual) Left = Neutral in Up-Win & Neutral
  Hold (Dual) Down -> Add and Hold (Gamepad) Up -> Add and Hold (Gamepad) Down = Up in Up-Win, Neutral in Neutral

Mixed (Last-Win) -
  (Gamepad or Dual) Left -> (Gamepad or Dual) Left + (Gamepad or Dual) Right = Right
  Hold (Gamepad) Left -> Add and Hold (Dual) Right -> Add and Hold (Dual) Left -> Add and Hold (Gamepad) Right = Right