### PR TITLE
Fixed multiple compiler warnings

### DIFF
--- a/headers/addonmanager.h
+++ b/headers/addonmanager.h
@@ -6,12 +6,12 @@
 #include <vector>
 #include <pico/mutex.h>
 
-typedef enum ADDON_PROCESS {
+enum ADDON_PROCESS {
     CORE0_INPUT,
     CORE1_LOOP
-} _ADDON_PROCESS;
+};
 
-typedef struct AddonBlock {
+struct AddonBlock {
     GPAddon * ptr;
     ADDON_PROCESS process;
     bool enabled;

--- a/lib/AnimationStation/src/Animation.hpp
+++ b/lib/AnimationStation/src/Animation.hpp
@@ -69,6 +69,9 @@ struct RGB {
             | (uint32_t)(w * brightnessX);
       }
     }
+
+    assert(false);
+    return 0;
   }
 };
 

--- a/src/addonmanager.cpp
+++ b/src/addonmanager.cpp
@@ -36,4 +36,5 @@ GPAddon * AddonManager::GetAddon(std::string name) { // hack for NeoPicoLED
         if ( (*it)->ptr->name() == name )
             return (*it)->ptr;
     }
+    return nullptr;
 }

--- a/src/addons/neopicoleds.cpp
+++ b/src/addons/neopicoleds.cpp
@@ -373,6 +373,9 @@ std::vector<std::vector<Pixel>> NeoPicoLEDAddon::createLEDLayout(ButtonLayout la
 		case BUTTON_LAYOUT_VLXA:
 			return generatedLEDButtons(&positions);
 	}
+
+	assert(false);
+	return std::vector<std::vector<Pixel>>();
 }
 
 uint8_t NeoPicoLEDAddon::setupButtonPositions()


### PR DESCRIPTION
I fixed compiler warnings that were at least triggered with my build setup (Arm GNU Toolchain 12.2.Rel1 (Build arm-12.24)). In more detail, this is what I did:

- Removed `typedef`s from `addonmanager.h`. These triggered the `'typedef' was ignored in this declaration` warning. `typedef`s are pretty much useless in C++ (as opposed to C) anyway.
- I fixed multiple instances of `warning: control reaches end of non-void function`. I added `assert(false)` where the code path should be unreachable. But at least in the case of `AddonManager::GetAddon()` this was an actual issue. Calling this function with an unknown addon name would cause undefined behaviour.

There are still some compiler warnings left in `httpd.c`.  I did not touch those as this is external code.

Also there are some linker warnings, but I think those are to be expected because the libc implementation of gcc-arm-none-eabi is incomplete.