### PR TITLE
Auto-detect SH1106 OLED displays

### DIFF
--- a/headers/addons/i2cdisplay.h
+++ b/headers/addons/i2cdisplay.h
@@ -65,6 +65,8 @@ public:
 	virtual void process();
 	virtual std::string name() { return I2CDisplayName; }
 private:
+	int initDisplay(int typeOverride);
+	bool isSH1106(int detectedDisplay);
 	void clearScreen(int render); // DisplayModule
 	void drawStickless(int startX, int startY, int buttonRadius, int buttonPadding);
 	void drawWasdBox(int startX, int startY, int buttonRadius, int buttonPadding);

--- a/src/addons/i2cdisplay.cpp
+++ b/src/addons/i2cdisplay.cpp
@@ -18,24 +18,18 @@ bool I2CDisplayAddon::available() {
 }
 
 void I2CDisplayAddon::setup() {
-	BoardOptions boardOptions = Storage::getInstance().getBoardOptions();
-	obdI2CInit(&obd,
-	    boardOptions.displaySize,
-		boardOptions.displayI2CAddress,
-		boardOptions.displayFlip,
-		boardOptions.displayInvert,
-		DISPLAY_USEWIRE,
-		boardOptions.i2cSDAPin,
-		boardOptions.i2cSCLPin,
-		boardOptions.i2cBlock == 0 ? i2c0 : i2c1,
-		-1,
-		boardOptions.i2cSpeed);
+	const int detectedDisplay = initDisplay(0);
+	if (isSH1106(detectedDisplay)) {
+		// The display is actually a SH1106 that was misdetected as a SSD1306 by OneBitDisplay.
+		// Reinitialize as SH1106.
+		initDisplay(OLED_132x64);
+	}
+	
 	obdSetContrast(&obd, 0xFF);
 	obdSetBackBuffer(&obd, ucBackBuffer);
 	clearScreen(1);
 	gamepad = Storage::getInstance().GetGamepad();
 	pGamepad = Storage::getInstance().GetProcessedGamepad();
-
 }
 
 void I2CDisplayAddon::process() {
@@ -155,6 +149,73 @@ void I2CDisplayAddon::process() {
 	}
 
 	obdDumpBuffer(&obd, NULL);
+}
+
+int I2CDisplayAddon::initDisplay(int typeOverride) {
+	BoardOptions boardOptions = Storage::getInstance().getBoardOptions();
+	return obdI2CInit(&obd,
+	    typeOverride > 0 ? typeOverride : boardOptions.displaySize,
+		boardOptions.displayI2CAddress,
+		boardOptions.displayFlip,
+		boardOptions.displayInvert,
+		DISPLAY_USEWIRE,
+		boardOptions.i2cSDAPin,
+		boardOptions.i2cSCLPin,
+		boardOptions.i2cBlock == 0 ? i2c0 : i2c1,
+		-1,
+		boardOptions.i2cSpeed);
+}
+
+bool I2CDisplayAddon::isSH1106(int detectedDisplay) {
+	// Only attempt detection if we think we are using a SSD1306 or if auto-detection failed.
+	if (detectedDisplay != OLED_SSD1306_3C &&
+		detectedDisplay != OLED_SSD1306_3D &&
+		detectedDisplay != OLED_NOT_FOUND) {
+		return false;
+	}
+
+	// To detect an SH1106 we make use of the fact that SH1106 supports read-modify-write operations over I2C, whereas
+	// SSD1306 does not.
+	// We perform a number of read-modify-write operations and check whether the data we read back matches the data we
+	// previously wrote. If it does we can be reasonably confident that we are using a SH1106.
+
+	// We turn the display off for the remainder of this function, we do not want users to observe the random data we
+	// are writing.
+	obdPower(&obd, false);
+
+	const uint8_t RANDOM_DATA[] = { 0xbf, 0x88, 0x13, 0x41, 0x00 };
+	uint8_t buffer[4];
+	int i = 0;
+	for (; i < sizeof(RANDOM_DATA); ++i) {
+		buffer[0] = 0x80; // one command
+		buffer[1] = 0xE0; // read-modify-write
+		buffer[2] = 0xC0; // one data
+		if (I2CWrite(&obd.bbi2c, obd.oled_addr, buffer, 3) == 0) {
+			break;
+		}
+
+		// Read two bytes back, the first byte is a dummy read and the second byte is the byte was actually want.
+		if (I2CRead(&obd.bbi2c, obd.oled_addr, buffer, 2) == 0) {
+			break;
+		}
+
+		// Check whether the byte we read is the byte we previously wrote.
+		if (i > 0 && buffer[1] != RANDOM_DATA[i - 1]) {
+			break;
+		}
+
+		// Write the current byte, we will attempt to read it in the next loop iteration.
+		buffer[0] = 0xc0; // one data
+		buffer[1] = RANDOM_DATA[i]; // data byte
+		buffer[2] = 0x80; // one command
+		buffer[3] = 0xEE; // end read-modify-write
+		if (I2CWrite(&obd.bbi2c, obd.oled_addr, buffer, 4) == 0) {
+			break;
+		}
+	}
+
+	obdPower(&obd, true);
+	return i == sizeof(RANDOM_DATA);
 }
 
 void I2CDisplayAddon::clearScreen(int render) {


### PR DESCRIPTION
This is my attempt at solving #15.

I use the same general strategy as the [FlashFloppy](https://github.com/keirf/flashfloppy/) project for differentiating between SSD1306 and SH1106 displays. SH1106 allows read operations over I2C whereas SSD1306 does not. I do some read-modify-write operations and if I can read back data I previously wrote, I re-initialize the display as SH1106, otherwise I leave it as is.

I tested this with both types of displays and for me this approach works perfectly. Testing with a wider variety of OLEDs would be better, of course. I only own two makes of OLEDs.

I can see the merit of a user-configurable options as well, but I think this is a better default. A manual override option can be added to the web config at any time.