### PR TITLE
Expand our FlashPROM flash size from 4kb to 128kb

### DIFF
--- a/lib/FlashPROM/src/FlashPROM.h
+++ b/lib/FlashPROM/src/FlashPROM.h
@@ -13,8 +13,11 @@
 #include <hardware/flash.h>
 #include <hardware/timer.h>
 
-#define EEPROM_SIZE_BYTES    4096           // Reserve 4k of flash memory (ensure this value is divisible by 256)
-#define EEPROM_ADDRESS_START _u(0x101FF000) // The arduino-pico EEPROM lib starts here, so we'll do the same
+#define EEPROM_SIZE_BYTES (128*1024)          // Reserve 128k of flash memory
+#define EEPROM_ADDRESS_START _u(0x101E0000)   // Offset is XIP + (2MB-size of eeprom)
+
+//#define EEPROM_SIZE_BYTES    4096           // Reserve 4k of flash memory (ensure this value is divisible by 256)
+//#define EEPROM_ADDRESS_START _u(0x101FF000) // The arduino-pico EEPROM lib starts here, so we'll do the same
 // Warning: If the write wait is too long it can stall other processes
 #define EEPROM_WRITE_WAIT    50             // Amount of time in ms to wait before blocking core1 and committing to flash
 


### PR DESCRIPTION
Expand our FlashPROM flash size from 4kb to 128kb to give our settings and addons more save room.