### PR TITLE
Implemented memory report endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ src/gamepad.cpp
 src/addonmanager.cpp
 src/configmanager.cpp
 src/storagemanager.cpp
+src/system.cpp
 src/configs/webconfig.cpp
 src/addons/analog.cpp
 src/addons/turbo.cpp

--- a/headers/system.h
+++ b/headers/system.h
@@ -1,0 +1,19 @@
+#ifndef SYSTEM_H_
+#define SYSTEM_H_
+
+#include <cstdint>
+
+namespace System {
+    // Returns the size of on-board flash memory in bytes
+    uint32_t getTotalFlash();
+    // Returns the amount of on-board flash memory used by the firmware in bytes
+    uint32_t getUsedFlash();
+    // Returns the amount of memory used for static allocations in bytes
+    uint32_t getStaticAllocs();
+    // Returns the total size of heap memory in bytes
+    uint32_t getTotalHeap();
+    // Returns the about of heap memory currently allocated in bytes
+    uint32_t getUsedHeap();
+}
+
+#endif

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -2,6 +2,7 @@
 
 #include "storagemanager.h"
 #include "configmanager.h"
+#include "system.h"
 
 #include <cstring>
 #include <string>
@@ -35,6 +36,7 @@
 #define API_GET_SPLASH_IMAGE "/api/getSplashImage"
 #define API_SET_SPLASH_IMAGE "/api/setSplashImage"
 #define API_GET_FIRMWARE_VERSION "/api/getFirmwareVersion"
+#define API_GET_MEMORY_REPORT "/api/getMemoryReport"
 
 #define LWIP_HTTPD_POST_MAX_URI_LEN 128
 #define LWIP_HTTPD_POST_MAX_PAYLOAD_LEN 2048
@@ -524,6 +526,17 @@ std::string getFirmwareVersion()
 	return serialize_json(doc);
 }
 
+std::string getMemoryReport()
+{
+	DynamicJsonDocument doc(LWIP_HTTPD_POST_MAX_PAYLOAD_LEN);
+	doc["totalFlash"] = System::getTotalFlash();
+	doc["usedFlash"] = System::getUsedFlash();
+	doc["staticAllocs"] = System::getStaticAllocs();
+	doc["totalHeap"] = System::getTotalHeap();
+	doc["usedHeap"] = System::getUsedHeap();
+	return serialize_json(doc);
+}
+
 // This should be a storage feature
 std::string resetSettings()
 {
@@ -568,6 +581,8 @@ int fs_open_custom(struct fs_file *file, const char *name)
 			return set_file_data(file, getSplashImage());
 		if (!memcmp(name, API_GET_FIRMWARE_VERSION, sizeof(API_GET_FIRMWARE_VERSION)))
 			return set_file_data(file, getFirmwareVersion());
+		if (!memcmp(name, API_GET_MEMORY_REPORT, sizeof(API_GET_MEMORY_REPORT)))
+			return set_file_data(file, getMemoryReport());
 	}
 
 	bool isExclude = false;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1,0 +1,37 @@
+#include "system.h"
+
+#include <hardware/flash.h>
+#include <malloc.h>
+
+extern char __flash_binary_start;
+extern char __flash_binary_end;
+extern char __bss_end__;
+extern char __StackLimit;
+extern char __StackTop;
+
+uint32_t System::getTotalFlash() {
+#if defined(PICO_FLASH_SIZE_BYTES)
+    return PICO_FLASH_SIZE_BYTES;
+#else
+    #warning PICO_FLASH_SIZE_BYTES is not set, defaulting to 2MB
+    return 2 * 1024 * 1024;
+#endif
+}
+
+uint32_t System::getUsedFlash() {
+    return &__flash_binary_end - &__flash_binary_start;
+}
+
+uint32_t System::getStaticAllocs() {
+    const uint32_t inMemorySegmentsSize = reinterpret_cast<uint32_t>(&__bss_end__) - SRAM_BASE;
+    const uint32_t stackSize = &__StackTop - &__StackLimit;
+    return inMemorySegmentsSize + stackSize;
+}
+
+uint32_t System::getTotalHeap() {
+    return &__StackLimit  - &__bss_end__;
+}
+
+uint32_t System::getUsedHeap() {
+    return mallinfo().uordblks;
+}


### PR DESCRIPTION
This is my attempt at implementing #60.

I implemented various memory-diagnostic functions in a new `System` namespace:

- `System::getTotalFlash()` - Returns the size of on-board flash memory
- `System::getUsedFlash()` - Returns the amount of on-board flash memory used by the firmware. This only includes flash memory used by the firmware, not the memory used by `FlashPROM`.
- `System::getStaticAllocs()` - Returns the amount of memory used for static allocations (e.g. static variables, static arrays, the stack for both cores, and code placed into memory for speed purposes)
- `System::getTotalHeap()` - Returns the total amount of memory used for dynamic allocations
- `System::getUsedHeap()` - Returns the amount of dynamically allocated memory

I also implemented an API endpoint for the Web Config Server. Navigate to [http://192.168.7.1/api/getMemoryReport](http://192.168.7.1/api/getMemoryReport) while in Web Config Mode to see the raw JSON data.

Of couse this will have to be properly integrated into the WebConfig project after this PR is merged. I am no webdev, so maybe someone else can do this.