### PR TITLE
Fix slider pins default value

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -36,8 +36,8 @@
 #define PIN_BUTTON_A2   21          // A2 / ~ / Capture / ~ / 14 / ~
 #define PIN_BUTTON_TURBO 14         // Turbo
 #define PIN_BUTTON_REVERSE -1       // UDLR Reverse
-#define PIN_SLIDER_LS    26         // Left Stick Slider
-#define PIN_SLIDER_RS    27         // Right Stick Slider
+#define PIN_SLIDER_LS    -1         // Left Stick Slider
+#define PIN_SLIDER_RS    -1         // Right Stick Slider
 
 
 // This is the SOCD section.


### PR DESCRIPTION
This solves an unintentional setting previously updated by mistake in Pico BoardConfig.h.