### PR TITLE
 Reenable buzzer addon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ src/addons/dualdirectional.cpp
 src/addons/reverse.cpp
 src/addons/i2canalog1219.cpp
 src/addons/bootsel_button.cpp
+src/addons/buzzerspeaker.cpp
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}_${CMAKE_PROJECT_VERSION}_${GP2040_BOARDCONFIG})

--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -215,4 +215,13 @@
 // BOOTSEL Button Add-on setting
 #define BOOTSEL_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
 
+// This is the Buzzer Speaker section.  
+// In this section you can specify if Buzzer Speaker will be active, and, if active, which pin will be used for them.
+// The default is `BUZZER_ENABLED` which will turn the Buzzer Speaker off.
+// The default pin for Buzzer Speaker is `-1` which will turn the Buzzer Speaker off.  
+// The default volume for Buzzer Speaker is 100 (max).  
+#define BUZZER_ENABLED 0
+#define BUZZER_PIN -1
+#define BUZZER_VOLUME 100
+
 #endif

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -103,7 +103,7 @@ struct AddonOptions {
 	//bool PlayerLEDAddonEnabled; // PlayerLED is special case
 	uint8_t ReverseInputEnabled;
 	uint8_t TurboInputEnabled;
-	bool BuzzerEnabled;
+	uint8_t BuzzerEnabled;
 	uint32_t checksum;
 };
 

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -89,6 +89,8 @@ struct AddonOptions {
 	uint8_t analogAdcPinX;
 	uint8_t analogAdcPinY;
 	uint16_t bootselButtonMap;
+	uint8_t buzzerPin;
+	uint8_t buzzerVolume;
 	uint8_t AnalogInputEnabled;
 	uint8_t BoardLedAddonEnabled;
 	uint8_t BootselButtonAddonEnabled;
@@ -101,6 +103,7 @@ struct AddonOptions {
 	//bool PlayerLEDAddonEnabled; // PlayerLED is special case
 	uint8_t ReverseInputEnabled;
 	uint8_t TurboInputEnabled;
+	bool BuzzerEnabled;
 	uint32_t checksum;
 };
 

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -103,7 +103,6 @@ struct AddonOptions {
 	//bool PlayerLEDAddonEnabled; // PlayerLED is special case
 	uint8_t ReverseInputEnabled;
 	uint8_t TurboInputEnabled;
-	uint8_t BuzzerEnabled;
 	uint32_t checksum;
 };
 

--- a/src/addons/buzzerspeaker.cpp
+++ b/src/addons/buzzerspeaker.cpp
@@ -8,7 +8,7 @@
 bool BuzzerSpeakerAddon::available() {
 	AddonOptions options = Storage::getInstance().getAddonOptions();
 	buzzerPin = options.buzzerPin;
-	return options.BuzzerSpeakerEnabled &&
+	return options.BuzzerSpeakerAddonEnabled &&
 		buzzerPin != (uint8_t)-1;
 }
 

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -384,6 +384,8 @@ std::string getLedOptions()
 		usedPins.add(addonOptions.analogAdcPinX);
 	if (addonOptions.analogAdcPinY != -1)
 		usedPins.add(addonOptions.analogAdcPinY);
+	if (addonOptions.buzzerPin != -1)
+		usedPins.add(addonOptions.buzzerPin);
 
 	return serialize_json(doc);
 }
@@ -476,6 +478,8 @@ std::string setAddonOptions()
 	addonOptions.analogAdcPinX = doc["analogAdcPinX"] == -1 ? 0xFF : doc["analogAdcPinX"];
 	addonOptions.analogAdcPinY = doc["analogAdcPinY"] == -1 ? 0xFF : doc["analogAdcPinY"];
 	addonOptions.bootselButtonMap = doc["bootselButtonMap"];
+	addonOptions.buzzerPin        = doc["buzzerPin"] == -1 ? 0xFF : doc["buzzerPin"];
+	addonOptions.buzzerVolume     = doc["buzzerVolume"];
 	addonOptions.AnalogInputEnabled = doc["AnalogInputEnabled"];
 	addonOptions.BoardLedAddonEnabled = doc["BoardLedAddonEnabled"];
 	addonOptions.BuzzerSpeakerAddonEnabled = doc["BuzzerSpeakerAddonEnabled"];
@@ -521,6 +525,8 @@ std::string getAddonOptions()
 	doc["analogAdcPinX"] = addonOptions.analogAdcPinX == 0xFF ? -1 : addonOptions.analogAdcPinX;
 	doc["analogAdcPinY"] = addonOptions.analogAdcPinY == 0xFF ? -1 : addonOptions.analogAdcPinY;
 	doc["bootselButtonMap"] = addonOptions.bootselButtonMap;
+	doc["buzzerPin"] = addonOptions.buzzerPin == 0xFF ? -1 : addonOptions.buzzerPin;
+	doc["buzzerVolume"] = addonOptions.buzzerVolume;
 	doc["AnalogInputEnabled"] = addonOptions.AnalogInputEnabled;
 	doc["BoardLedAddonEnabled"] = addonOptions.BoardLedAddonEnabled;
 	doc["BuzzerSpeakerAddonEnabled"] = addonOptions.BuzzerSpeakerAddonEnabled;

--- a/src/gp2040aux.cpp
+++ b/src/gp2040aux.cpp
@@ -9,6 +9,7 @@
 #include "addons/neopicoleds.h"
 #include "addons/pleds.h"
 #include "addons/board_led.h"
+#include "addons/buzzerspeaker.h"
 
 #include <iterator>
 
@@ -23,6 +24,7 @@ void GP2040Aux::setup() {
 	addons.LoadAddon(new NeoPicoLEDAddon(), CORE1_LOOP);
 	addons.LoadAddon(new PlayerLEDAddon(), CORE1_LOOP);
 	addons.LoadAddon(new BoardLedAddon(), CORE1_LOOP);
+	addons.LoadAddon(new BuzzerSpeakerAddon(), CORE1_LOOP);
 }
 
 void GP2040Aux::run() {

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -150,6 +150,8 @@ void Storage::setDefaultAddonOptions()
 	addonOptions.analogAdcPinX      	= ANALOG_ADC_VRX;
 	addonOptions.analogAdcPinY      	= ANALOG_ADC_VRY;
 	addonOptions.bootselButtonMap		= BOOTSEL_BUTTON_MASK;
+	addonOptions.buzzerPin              = BUZZER_PIN;
+	addonOptions.buzzerVolume           = BUZZER_VOLUME;
 	addonOptions.AnalogInputEnabled     = ANALOG_INPUT_ENABLED;
 	addonOptions.BoardLedAddonEnabled   = BOARD_LED_ENABLED;
 	addonOptions.BootselButtonAddonEnabled = BOOTSEL_BUTTON_ENABLED;


### PR DESCRIPTION
This PR enables the previously removed Buzzer addon due to M1 issues.