### PR TITLE
Add more display flip modes (for #99)

### DIFF
--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -55,7 +55,7 @@ struct BoardOptions
 	bool hasI2CDisplay;
 	int displayI2CAddress;
 	uint8_t displaySize;
-	bool displayFlip;
+	uint8_t displayFlip;
 	bool displayInvert;
 	int displaySaverTimeout;
 	char boardVersion[32]; // 32-char limit to board name

--- a/lib/OneBitDisplay/OneBitDisplay.cpp
+++ b/lib/OneBitDisplay/OneBitDisplay.cpp
@@ -373,12 +373,16 @@ void obdSPIInit(OBDISP *pOBD, int iType, int iDC, int iCS, int iReset, int iMOSI
 		}
 		if (bFlip) // rotate display 180
 		{
-			uc[0] = 0; // command
-			uc[1] = 0xa0;
-			_I2CWrite(pOBD, uc, 2);
-			uc[0] = 0;
-			uc[1] = 0xc0;
-			_I2CWrite(pOBD, uc, 2);
+			if (bFlip == FLIP_HORIZONTAL || bFlip == FLIP_BOTH) {
+				uc[0] = 0; // command
+				uc[1] = 0xa0;
+				_I2CWrite(pOBD, uc, 2);
+			}
+			if (bFlip == FLIP_VERTICAL || bFlip == FLIP_BOTH) {
+				uc[0] = 0;
+				uc[1] = 0xc0;
+				_I2CWrite(pOBD, uc, 2);
+			}
 		}
 	} // OLED
 	if (iType == LCD_UC1701 || iType == LCD_HX1230)
@@ -393,8 +397,12 @@ void obdSPIInit(OBDISP *pOBD, int iType, int iDC, int iCS, int iReset, int iMOSI
 		}
 		if (bFlip) // flip horizontal + vertical
 		{
-			obdWriteCommand(pOBD, 0xa1); // set SEG direction (A1 to flip horizontal)
-			obdWriteCommand(pOBD, cCOM); // set COM direction (C0 to flip vert)
+			if (bFlip == FLIP_HORIZONTAL || bFlip == FLIP_BOTH) {
+				obdWriteCommand(pOBD, 0xa1); // set SEG direction (A1 to flip horizontal)
+			}
+			if (bFlip == FLIP_VERTICAL || bFlip == FLIP_BOTH) {
+				obdWriteCommand(pOBD, cCOM); // set COM direction (C0 to flip vert)
+			}
 		}
 		if (bInvert)
 		{
@@ -413,8 +421,12 @@ void obdSPIInit(OBDISP *pOBD, int iType, int iDC, int iCS, int iReset, int iMOSI
 		obdWriteCommand(pOBD, 0xaf); // display enable
 		if (bFlip)                   // flip horizontal + vertical
 		{
-			obdWriteCommand(pOBD, 0xa1); // set SEG direction (A1 to flip horizontal)
-			obdWriteCommand(pOBD, 0xc2); // set COM direction (C0 to flip vert)
+			if (bFlip == FLIP_HORIZONTAL || bFlip == FLIP_BOTH) {
+				obdWriteCommand(pOBD, 0xa1); // set SEG direction (A1 to flip horizontal)
+			}
+			if (bFlip == FLIP_VERTICAL || bFlip == FLIP_BOTH) {
+				obdWriteCommand(pOBD, 0xc2); // set COM direction (C0 to flip vert)
+			}
 		}
 		if (bInvert)
 		{
@@ -534,10 +546,14 @@ int obdI2CInit(OBDISP *pOBD, int iType, int iAddr, int bFlip, int bInvert, int b
 	if (bFlip) // rotate display 180
 	{
 		uc[0] = 0; // command
-		uc[1] = 0xa0;
-		_I2CWrite(pOBD, uc, 2);
-		uc[1] = 0xc0;
-		_I2CWrite(pOBD, uc, 2);
+		if (bFlip == FLIP_HORIZONTAL || bFlip == FLIP_BOTH) {
+			uc[1] = 0xa0;
+			_I2CWrite(pOBD, uc, 2);
+		}
+		if (bFlip == FLIP_VERTICAL || bFlip == FLIP_BOTH) {
+			uc[1] = 0xc0;
+			_I2CWrite(pOBD, uc, 2);
+		}
 	}
 	pOBD->width = 128; // assume 128x64
 	pOBD->height = 64;

--- a/lib/OneBitDisplay/OneBitDisplay.h
+++ b/lib/OneBitDisplay/OneBitDisplay.h
@@ -137,6 +137,13 @@ enum {
   ANGLE_FLIPY
 };
 
+enum {
+  FLIP_NONE=0,
+  FLIP_BOTH,
+  FLIP_HORIZONTAL,
+  FLIP_VERTICAL
+};
+
 // Return value from obd obdI2CInit()
 enum {
   OLED_NOT_FOUND = -1, // no display found


### PR DESCRIPTION
The following changes address issue: #99

Two new modes have been added with the regular Flip mode.
![image](https://user-images.githubusercontent.com/77402236/219059750-ae44ae2a-9ab9-4e91-8f0c-3ef950b3ebd9.png)

This should help address issues with screens that have their displays flipped by default.