### PR TITLE
Player Number Fix

### DIFF
--- a/src/addons/playernum.cpp
+++ b/src/addons/playernum.cpp
@@ -46,7 +46,8 @@ void PlayerNumAddon::process()
 
 void PlayerNumAddon::handleLED(int num) {
     if ( playerNum != num ) {
-        sleep_ms(2000 * (playerNum-1));
+        tud_disconnect();
+        sleep_ms(2000 * playerNum);
         System::reboot(System::BootMode::GAMEPAD);
     } else {
         assigned = 1;


### PR DESCRIPTION
Disconnect USB while we wait for reboot, this should allow the lower player numbers to connect while the uppers are disconnected