### PR TITLE
Removed multicore workarounds not needed with Pico SDK 1.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ include(CMakePrintHelpers)
 # note: this must happen before project()
 include(pico_sdk_import.cmake)
 
-if (PICO_SDK_VERSION_STRING VERSION_LESS "1.4.0")
-  message(FATAL_ERROR "Raspberry Pi Pico SDK version 1.4.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
+if (PICO_SDK_VERSION_STRING VERSION_LESS "1.5.0")
+  message(FATAL_ERROR "Raspberry Pi Pico SDK version 1.5.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
 endif()
 
 project(GP2040-CE LANGUAGES C CXX ASM VERSION 0.6.1)

--- a/lib/FlashPROM/src/FlashPROM.cpp
+++ b/lib/FlashPROM/src/FlashPROM.cpp
@@ -13,9 +13,7 @@ int64_t writeToFlash(alarm_id_t id, void *flashCache)
 {
 	while (is_spin_locked(flashLock));
 
-	// We use a very long timeout (> 30,000 years) instead of multicore_lockout_start_blocking() because the latter
-	// asserts in debug builds.
-	multicore_lockout_start_timeout_us(0xfffffffffffffff);
+	multicore_lockout_start_blocking();
 	uint32_t interrupts = spin_lock_blocking(flashLock);
 
 	flash_range_erase((intptr_t)EEPROM_ADDRESS_START - (intptr_t)XIP_BASE, EEPROM_SIZE_BYTES);
@@ -23,9 +21,7 @@ int64_t writeToFlash(alarm_id_t id, void *flashCache)
 
 	flashWriteAlarm = 0;
 
-	// We use a very long timeout (> 30,000 years) instead of multicore_lockout_end_blocking() because the latter
-	// asserts in debug builds.
-	multicore_lockout_end_timeout_us(0xfffffffffffffff);
+	multicore_lockout_end_blocking();
 	spin_unlock(flashLock, interrupts);
 
 	return 0;


### PR DESCRIPTION
I removed the multicore lockout workarounds that are no longer needed with Pi Pico SDK 1.5.0. I also updated the required SDK version in `CMakeLists.txt`.