### PR TITLE
Fix default splash duration value

### DIFF
--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -93,7 +93,7 @@ void Storage::setDefaultBoardOptions()
 	boardOptions.buttonLayoutRight = BUTTON_LAYOUT_RIGHT;
 	boardOptions.splashMode        = SPLASH_MODE;
 	boardOptions.splashChoice      = SPLASH_CHOICE;
-	boardOptions.splashDuration    = SPLASH_DURATION;
+	boardOptions.splashDuration    = 0; // 0 = BoardConfig splash duration
 	boardOptions.i2cSDAPin         = I2C_SDA_PIN;
 	boardOptions.i2cSCLPin         = I2C_SCL_PIN;
 	boardOptions.i2cBlock          = (I2C_BLOCK == i2c0) ? 0 : 1;


### PR DESCRIPTION
This change fixes the Display Configuration page's default state which is flagged as invalid.