### PR TITLE
Fixed inversion X and Y axis on upgrade (0.6.0->0.6.1)

### DIFF
--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -122,7 +122,7 @@ void Gamepad::read()
 /* Gamepad stuffs */
 void GamepadStorage::start()
 {
-	EEPROM.start();
+	//EEPROM.start();
 }
 
 void GamepadStorage::save()
@@ -146,6 +146,8 @@ GamepadOptions GamepadStorage::getGamepadOptions()
 #else
 		options.socdMode = SOCD_MODE_NEUTRAL;
 #endif
+		options.invertXAxis = false;
+		options.invertYAxis = false;
 		setGamepadOptions(options);
 	}
 


### PR DESCRIPTION
This will fix the inversion X and Y axis issue on upgrade

The gamepad storage was not properly setting default values for invert X/Y

Additionally, MPG was updated to place the CRC32 in the correct position