### PR TITLE
Removing MPG from GP2040-CE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "www"]
 	path = www
 	url = https://github.com/OpenStickCommunity/WebConfigurator.git
-[submodule "MPG"]
-	path = MPG
-	url = https://github.com/OpenStickCommunity/MPG.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ FetchContent_MakeAvailable(ArduinoJson)
 # initialize the Raspberry Pi Pico SDK
 pico_sdk_init()
 add_subdirectory(lib)
-add_subdirectory(MPG)
 
 add_executable(${PROJECT_NAME}
 src/main.cpp
@@ -122,6 +121,8 @@ src/addons/playerleds.cpp
 src/addons/reverse.cpp
 src/addons/turbo.cpp
 src/addons/slider_socd.cpp
+src/gamepad/GamepadDebouncer.cpp
+src/gamepad/GamepadDescriptors.cpp
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}_${CMAKE_PROJECT_VERSION}_${GP2040_BOARDCONFIG})
@@ -130,7 +131,6 @@ pico_set_program_name(GP2040-CE "GP2040-CE")
 pico_set_program_version(GP2040-CE "0.6.2")
 
 target_link_libraries(${PROJECT_NAME} 
-MPG
 pico_stdlib
 pico_bootsel_via_double_reset
 AnimationStation
@@ -149,6 +149,8 @@ hardware_adc
 target_include_directories(${PROJECT_NAME} PUBLIC
 headers
 headers/addons
+headers/configs
+headers/gamepad
 configs/${GP2040_BOARDCONFIG}
 )
 

--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -3,7 +3,15 @@
 
 #include "BoardConfig.h"
 #include <string.h>
-#include <MPGS.h>
+
+#include "gamepad/GamepadDebouncer.h"
+#include "gamepad/GamepadOptions.h"
+#include "gamepad/GamepadState.h"
+#include "gamepad/GamepadStorage.h"
+#include "gamepad/descriptors/HIDDescriptors.h"
+#include "gamepad/descriptors/SwitchDescriptors.h"
+#include "gamepad/descriptors/XInputDescriptors.h"
+
 #include "pico/stdlib.h"
 
 // MUST BE DEFINED FOR MPG
@@ -30,25 +38,87 @@ struct GamepadButtonMapping
 	}
 };
 
-class Gamepad : public MPGS
-{
+#define GAMEPAD_DIGITAL_INPUT_COUNT 18 // Total number of buttons, including D-pad
+
+class Gamepad {
 public:
-	Gamepad(int debounceMS = 5, GamepadStorage *storage = &GamepadStore)
-			: MPGS(debounceMS, storage) {}
+	Gamepad(int debounceMS = 5, GamepadStorage *storage = &GamepadStore) :
+			debounceMS(debounceMS)
+			, f1Mask((GAMEPAD_MASK_S1 | GAMEPAD_MASK_S2))
+			, f2Mask((GAMEPAD_MASK_L3 | GAMEPAD_MASK_R3))
+			, debouncer(debounceMS)
+			, mpgStorage(storage)
+	{}
 
 	void setup();
 	void process();
 	void read();
+	void save();
+	void debounce();
+	
+	GamepadHotkey hotkey();
 
-	inline bool __attribute__((always_inline)) pressedF1()
-	{
-#ifdef PIN_SETTINGS
-		return state.aux & (1 << 0);
-#else
-		return MPGS::pressedF1();
-#endif
+	/**
+	 * @brief Flag to indicate analog trigger support.
+	 */
+	bool hasAnalogTriggers {false};
+
+	/**
+	 * @brief Flag to indicate Left analog stick support.
+	 */
+	bool hasLeftAnalogStick {false};
+
+	/**
+	 * @brief Flag to indicate Right analog stick support.
+	 */
+	bool hasRightAnalogStick {false};
+
+	void *getReport();
+	uint16_t getReportSize();
+	HIDReport *getHIDReport();
+	SwitchReport *getSwitchReport();
+	XInputReport *getXInputReport();
+
+	/**
+	 * @brief Check for a button press. Used by `pressed[Button]` helper methods.
+	 */
+	inline bool __attribute__((always_inline)) pressedButton(const uint16_t mask) {
+		return (state.buttons & mask) == mask;
 	}
+
+	/**
+	 * @brief Check for a dpad press. Used by `pressed[Dpad]` helper methods.
+	 */
+	inline bool __attribute__((always_inline)) pressedDpad(const uint8_t mask) { return (state.dpad & mask) == mask; }
+
+	inline bool __attribute__((always_inline)) pressedUp()    { return pressedDpad(GAMEPAD_MASK_UP); }
+	inline bool __attribute__((always_inline)) pressedDown()  { return pressedDpad(GAMEPAD_MASK_DOWN); }
+	inline bool __attribute__((always_inline)) pressedLeft()  { return pressedDpad(GAMEPAD_MASK_LEFT); }
+	inline bool __attribute__((always_inline)) pressedRight() { return pressedDpad(GAMEPAD_MASK_RIGHT); }
+	inline bool __attribute__((always_inline)) pressedB1()    { return pressedButton(GAMEPAD_MASK_B1); }
+	inline bool __attribute__((always_inline)) pressedB2()    { return pressedButton(GAMEPAD_MASK_B2); }
+	inline bool __attribute__((always_inline)) pressedB3()    { return pressedButton(GAMEPAD_MASK_B3); }
+	inline bool __attribute__((always_inline)) pressedB4()    { return pressedButton(GAMEPAD_MASK_B4); }
+	inline bool __attribute__((always_inline)) pressedL1()    { return pressedButton(GAMEPAD_MASK_L1); }
+	inline bool __attribute__((always_inline)) pressedR1()    { return pressedButton(GAMEPAD_MASK_R1); }
+	inline bool __attribute__((always_inline)) pressedL2()    { return pressedButton(GAMEPAD_MASK_L2); }
+	inline bool __attribute__((always_inline)) pressedR2()    { return pressedButton(GAMEPAD_MASK_R2); }
+	inline bool __attribute__((always_inline)) pressedS1()    { return pressedButton(GAMEPAD_MASK_S1); }
+	inline bool __attribute__((always_inline)) pressedS2()    { return pressedButton(GAMEPAD_MASK_S2); }
+	inline bool __attribute__((always_inline)) pressedL3()    { return pressedButton(GAMEPAD_MASK_L3); }
+	inline bool __attribute__((always_inline)) pressedR3()    { return pressedButton(GAMEPAD_MASK_R3); }
+	inline bool __attribute__((always_inline)) pressedA1()    { return pressedButton(GAMEPAD_MASK_A1); }
+	inline bool __attribute__((always_inline)) pressedA2()    { return pressedButton(GAMEPAD_MASK_A2); }
+	inline bool __attribute__((always_inline)) pressedF1()    { return pressedButton(f1Mask); }
+	inline bool __attribute__((always_inline)) pressedF2()    { return pressedButton(f2Mask); }
+	GamepadDebouncer debouncer;
+	GamepadStorage *mpgStorage;
+	const uint8_t debounceMS;
+	uint16_t f1Mask;
+	uint16_t f2Mask;
+	GamepadOptions options;
 	GamepadState rawState;
+	GamepadState state;
 	GamepadButtonMapping *mapDpadUp;
 	GamepadButtonMapping *mapDpadDown;
 	GamepadButtonMapping *mapDpadLeft;

--- a/headers/gamepad/GamepadConfig.h
+++ b/headers/gamepad/GamepadConfig.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#ifndef DEFAULT_SOCD_MODE
+#define DEFAULT_SOCD_MODE SOCD_MODE_NEUTRAL
+#endif
+
+#ifndef DEFAULT_DPAD_MODE
+#define DEFAULT_DPAD_MODE DPAD_MODE_DIGITAL
+#endif
+
+#ifndef DEFAULT_INPUT_MODE
+#define DEFAULT_INPUT_MODE INPUT_MODE_XINPUT
+#endif

--- a/headers/gamepad/GamepadDebouncer.h
+++ b/headers/gamepad/GamepadDebouncer.h
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#include <string.h>
+#include <stdint.h>
+#include "GamepadState.h"
+
+// Implement this wrapper function for your platform
+// TODO: Make this a pure virtual member instead.
+uint32_t getMillis();
+
+class GamepadDebouncer
+{
+	public:
+		GamepadDebouncer(const uint8_t debounceMS = 5) : debounceMS(debounceMS) { }
+
+		void debounce(GamepadState *state);
+
+		const uint8_t debounceMS;
+		GamepadState debounceState;
+		uint32_t dpadTime[4];
+		uint32_t buttonTime[GAMEPAD_BUTTON_COUNT];
+};

--- a/headers/gamepad/GamepadDescriptors.h
+++ b/headers/gamepad/GamepadDescriptors.h
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#include <string.h>
+#include "GamepadEnums.h"
+#include "descriptors/HIDDescriptors.h"
+#include "descriptors/SwitchDescriptors.h"
+#include "descriptors/XInputDescriptors.h"
+
+// Default value used for networking, override if necessary
+static uint8_t macAddress[6] = { 0x02, 0x02, 0x84, 0x6A, 0x96, 0x00 };
+
+static const uint8_t *getConfigurationDescriptor(uint16_t *size, InputMode mode)
+{
+	switch (mode)
+	{
+		case INPUT_MODE_XINPUT:
+			*size = sizeof(xinput_configuration_descriptor);
+			return xinput_configuration_descriptor;
+
+		case INPUT_MODE_SWITCH:
+			*size = sizeof(switch_configuration_descriptor);
+			return switch_configuration_descriptor;
+
+		default:
+			*size = sizeof(hid_configuration_descriptor);
+			return hid_configuration_descriptor;
+	}
+}
+
+static const uint8_t *getDeviceDescriptor(uint16_t *size, InputMode mode)
+{
+	switch (mode)
+	{
+		case INPUT_MODE_XINPUT:
+			*size = sizeof(xinput_device_descriptor);
+			return xinput_device_descriptor;
+
+		case INPUT_MODE_SWITCH:
+			*size = sizeof(switch_device_descriptor);
+			return switch_device_descriptor;
+
+		default:
+			*size = sizeof(hid_device_descriptor);
+			return hid_device_descriptor;
+	}
+}
+
+static const uint8_t *getHIDDescriptor(uint16_t *size, InputMode mode)
+{
+	switch (mode)
+	{
+		case INPUT_MODE_SWITCH:
+			*size = sizeof(switch_hid_descriptor);
+			return switch_hid_descriptor;
+
+		default:
+			*size = sizeof(hid_hid_descriptor);
+			return hid_hid_descriptor;
+	}
+}
+
+static const uint8_t *getHIDReport(uint16_t *size, InputMode mode)
+{
+	switch (mode)
+	{
+		case INPUT_MODE_SWITCH:
+			*size = sizeof(switch_report_descriptor);
+			return switch_report_descriptor;
+
+		default:
+			*size = sizeof(hid_report_descriptor);
+			return hid_report_descriptor;
+	}
+}
+
+// Convert ASCII string into UTF-16
+static const uint16_t *convertStringDescriptor(uint16_t *payloadSize, const char *str, int charCount)
+{
+	static uint16_t payload[32];
+
+	// Cap at max char
+	if (charCount > 31)
+		charCount = 31;
+
+	for (uint8_t i = 0; i < charCount; i++)
+		payload[1 + i] = str[i];
+
+	// first byte is length (including header), second byte is string type
+	*payloadSize = (2 * charCount + 2);
+	payload[0] = (0x03 << 8) | *payloadSize;
+	return payload;
+}
+
+static const uint16_t *getStringDescriptor(uint16_t *size, InputMode mode, uint8_t index)
+{
+	uint8_t charCount;
+	char *str;
+
+	if (index == 0)
+	{
+		str = (char *)xinput_string_descriptors[0];
+		charCount = 1;
+	}
+	else if (index == 5)
+	{
+		// Convert MAC address into UTF-16
+		for (int i = 0; i < 6; i++)
+		{
+			str[1 + charCount++] = "0123456789ABCDEF"[(macAddress[i] >> 4) & 0xf];
+			str[1 + charCount++] = "0123456789ABCDEF"[(macAddress[i] >> 0) & 0xf];
+		}
+	}
+	else
+	{
+		switch (mode)
+		{
+			case INPUT_MODE_XINPUT:
+				str = (char *)xinput_string_descriptors[index];
+				break;
+
+			case INPUT_MODE_SWITCH:
+				str = (char *)switch_string_descriptors[index];
+				break;
+
+			default:
+				str = (char *)hid_string_descriptors[index];
+				break;
+		}
+
+		charCount = strlen(str);
+	}
+
+	return convertStringDescriptor(size, str, charCount);
+}

--- a/headers/gamepad/GamepadEnums.h
+++ b/headers/gamepad/GamepadEnums.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+// The available input modes
+// TODO: Think about making enums "class enum" instead. This will keep them out of the global namespace
+// and provide strong type assurance instead of being treated as ints. Also, modern c++ would tend towards
+// using Pascal-case naming for the individual declarations.
+typedef enum
+{
+	INPUT_MODE_XINPUT,
+	INPUT_MODE_SWITCH,
+	INPUT_MODE_HID,
+	INPUT_MODE_CONFIG = 255,
+} InputMode;
+
+// The available stick emulation modes
+typedef enum
+{
+	DPAD_MODE_DIGITAL,
+	DPAD_MODE_LEFT_ANALOG,
+	DPAD_MODE_RIGHT_ANALOG,
+} DpadMode;
+
+// The available SOCD cleaning methods
+typedef enum
+{
+	SOCD_MODE_UP_PRIORITY,           // U+D=U, L+R=N
+	SOCD_MODE_NEUTRAL,               // U+D=N, L+R=N
+	SOCD_MODE_SECOND_INPUT_PRIORITY, // U>D=D, L>R=R (Last Input Priority, aka Last Win)
+} SOCDMode;
+
+// Enum for tracking last direction state of Second Input SOCD method
+typedef enum
+{
+	DIRECTION_NONE,
+	DIRECTION_UP,
+	DIRECTION_DOWN,
+	DIRECTION_LEFT,
+	DIRECTION_RIGHT
+} DpadDirection;
+
+// The available hotkey actions
+typedef enum
+{
+	HOTKEY_NONE              = 0x00,
+	HOTKEY_DPAD_DIGITAL      = (1U << 0),
+	HOTKEY_DPAD_LEFT_ANALOG  = (1U << 1),
+	HOTKEY_DPAD_RIGHT_ANALOG = (1U << 2),
+	HOTKEY_HOME_BUTTON       = (1U << 3),
+	HOTKEY_CAPTURE_BUTTON    = (1U << 4),
+	HOTKEY_SOCD_UP_PRIORITY  = (1U << 5),
+	HOTKEY_SOCD_NEUTRAL      = (1U << 6),
+	HOTKEY_SOCD_LAST_INPUT   = (1U << 7),
+	HOTKEY_INVERT_X_AXIS     = (1U << 8),
+	HOTKEY_INVERT_Y_AXIS     = (1U << 9),
+} GamepadHotkey;

--- a/headers/gamepad/GamepadOptions.h
+++ b/headers/gamepad/GamepadOptions.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "GamepadEnums.h"
+
+struct GamepadOptions
+{
+	InputMode inputMode {InputMode::INPUT_MODE_XINPUT}; 
+	DpadMode dpadMode {DpadMode::DPAD_MODE_DIGITAL};
+	SOCDMode socdMode {SOCDMode::SOCD_MODE_NEUTRAL};
+	bool invertXAxis;
+	bool invertYAxis;
+	uint32_t checksum;
+};

--- a/headers/gamepad/GamepadState.h
+++ b/headers/gamepad/GamepadState.h
@@ -1,0 +1,214 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "GamepadEnums.h"
+
+#define GAMEPAD_BUTTON_COUNT 14
+
+/*
+	Gamepad button mapping table:
+
+	+--------+--------+---------+----------+----------+--------+
+	| GP2040 | XInput | Switch  | PS3      | DInput   | Arcade |
+	+--------+--------+---------+----------|----------+--------+
+	| B1     | A      | B       | Cross    | 2        | K1     |
+	| B2     | B      | A       | Circle   | 3        | K2     |
+	| B3     | X      | Y       | Square   | 1        | P1     |
+	| B4     | Y      | X       | Triangle | 4        | P2     |
+	| L1     | LB     | L       | L1       | 5        | P4     |
+	| R1     | RB     | R       | R1       | 6        | P3     |
+	| L2     | LT     | ZL      | L2       | 7        | K4     |
+	| R2     | RT     | ZR      | R2       | 8        | K3     |
+	| S1     | Back   | -       | Select   | 9        | Coin   |
+	| S2     | Start  | +       | Start    | 10       | Start  |
+	| L3     | LS     | LS      | L3       | 11       | LS     |
+	| R3     | RS     | RS      | R3       | 12       | RS     |
+	| A1     | Guide  | Home    | -        | 13       | -      |
+	| A2     | -      | Capture | -        | 14       | -      |
+	+--------+--------+---------+----------+----------+--------+
+*/
+
+#define GAMEPAD_MASK_UP    (1U << 0)
+#define GAMEPAD_MASK_DOWN  (1U << 1)
+#define GAMEPAD_MASK_LEFT  (1U << 2)
+#define GAMEPAD_MASK_RIGHT (1U << 3)
+
+#define GAMEPAD_MASK_B1    (1U << 0)
+#define GAMEPAD_MASK_B2    (1U << 1)
+#define GAMEPAD_MASK_B3    (1U << 2)
+#define GAMEPAD_MASK_B4    (1U << 3)
+#define GAMEPAD_MASK_L1    (1U << 4)
+#define GAMEPAD_MASK_R1    (1U << 5)
+#define GAMEPAD_MASK_L2    (1U << 6)
+#define GAMEPAD_MASK_R2    (1U << 7)
+#define GAMEPAD_MASK_S1    (1U << 8)
+#define GAMEPAD_MASK_S2    (1U << 9)
+#define GAMEPAD_MASK_L3    (1U << 10)
+#define GAMEPAD_MASK_R3    (1U << 11)
+#define GAMEPAD_MASK_A1    (1U << 12)
+#define GAMEPAD_MASK_A2    (1U << 13)
+
+// For detecting dpad as buttons
+
+#define GAMEPAD_MASK_DU    (1UL << 16)
+#define GAMEPAD_MASK_DD    (1UL << 17)
+#define GAMEPAD_MASK_DL    (1UL << 18)
+#define GAMEPAD_MASK_DR    (1UL << 19)
+
+// For detecting analog sticks as buttons
+
+#define GAMEPAD_MASK_LX    (1UL << 20)
+#define GAMEPAD_MASK_LY    (1UL << 21)
+#define GAMEPAD_MASK_RX    (1UL << 22)
+#define GAMEPAD_MASK_RY    (1UL << 23)
+
+#define GAMEPAD_MASK_DPAD (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN | GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT)
+
+#define GAMEPAD_JOYSTICK_MIN 0
+#define GAMEPAD_JOYSTICK_MID 0x7FFF
+#define GAMEPAD_JOYSTICK_MAX 0xFFFF
+
+const uint8_t dpadMasks[] =
+{
+	GAMEPAD_MASK_UP,
+	GAMEPAD_MASK_DOWN,
+	GAMEPAD_MASK_LEFT,
+	GAMEPAD_MASK_RIGHT,
+};
+
+const uint16_t buttonMasks[] =
+{
+	GAMEPAD_MASK_B1,
+	GAMEPAD_MASK_B2,
+	GAMEPAD_MASK_B3,
+	GAMEPAD_MASK_B4,
+	GAMEPAD_MASK_L1,
+	GAMEPAD_MASK_R1,
+	GAMEPAD_MASK_L2,
+	GAMEPAD_MASK_R2,
+	GAMEPAD_MASK_S1,
+	GAMEPAD_MASK_S2,
+	GAMEPAD_MASK_L3,
+	GAMEPAD_MASK_R3,
+	GAMEPAD_MASK_A1,
+	GAMEPAD_MASK_A2,
+};
+
+struct GamepadState
+{
+	uint8_t dpad {0};
+	uint16_t buttons {0};
+	uint16_t aux {0};
+	uint16_t lx {GAMEPAD_JOYSTICK_MID};
+	uint16_t ly {GAMEPAD_JOYSTICK_MID};
+	uint16_t rx {GAMEPAD_JOYSTICK_MID};
+	uint16_t ry {GAMEPAD_JOYSTICK_MID};
+	uint8_t lt {0};
+	uint8_t rt {0};
+};
+
+// Convert the horizontal GamepadState dpad axis value into an analog value
+inline uint16_t dpadToAnalogX(uint8_t dpad)
+{
+	switch (dpad & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT))
+	{
+		case GAMEPAD_MASK_LEFT:
+			return GAMEPAD_JOYSTICK_MIN;
+
+		case GAMEPAD_MASK_RIGHT:
+			return GAMEPAD_JOYSTICK_MAX;
+
+		default:
+			return GAMEPAD_JOYSTICK_MID;
+	}
+}
+
+// Convert the vertical GamepadState dpad axis value into an analog value
+inline uint16_t dpadToAnalogY(uint8_t dpad)
+{
+	switch (dpad & (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN))
+	{
+		case GAMEPAD_MASK_UP:
+			return GAMEPAD_JOYSTICK_MIN;
+
+		case GAMEPAD_MASK_DOWN:
+			return GAMEPAD_JOYSTICK_MAX;
+
+		default:
+			return GAMEPAD_JOYSTICK_MID;
+	}
+}
+
+/**
+ * @brief Run SOCD cleaning against a D-pad value.
+ *
+ * @param mode The SOCD cleaning mode.
+ * @param dpad The GamepadState.dpad value.
+ * @return uint8_t The clean D-pad value.
+ */
+inline uint8_t runSOCDCleaner(SOCDMode mode, uint8_t dpad)
+{
+	static DpadDirection lastUD = DIRECTION_NONE;
+	static DpadDirection lastLR = DIRECTION_NONE;
+	uint8_t newDpad = 0;
+
+	switch (dpad & (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN))
+	{
+		case (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN):
+			if (mode == SOCD_MODE_UP_PRIORITY)
+			{
+				newDpad |= GAMEPAD_MASK_UP;
+				lastUD = DIRECTION_UP;
+			}
+			else if (mode == SOCD_MODE_SECOND_INPUT_PRIORITY && lastUD != DIRECTION_NONE)
+				newDpad |= (lastUD == DIRECTION_UP) ? GAMEPAD_MASK_DOWN : GAMEPAD_MASK_UP;
+			else
+				lastUD = DIRECTION_NONE;
+			break;
+
+		case GAMEPAD_MASK_UP:
+			newDpad |= GAMEPAD_MASK_UP;
+			lastUD = DIRECTION_UP;
+			break;
+
+		case GAMEPAD_MASK_DOWN:
+			newDpad |= GAMEPAD_MASK_DOWN;
+			lastUD = DIRECTION_DOWN;
+			break;
+
+		default:
+			lastUD = DIRECTION_NONE;
+			break;
+	}
+
+	switch (dpad & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT))
+	{
+		case (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT):
+			if (mode == SOCD_MODE_SECOND_INPUT_PRIORITY && lastLR != DIRECTION_NONE)
+				newDpad |= (lastLR == DIRECTION_LEFT) ? GAMEPAD_MASK_RIGHT : GAMEPAD_MASK_LEFT;
+			else
+				lastLR = DIRECTION_NONE;
+			break;
+
+		case GAMEPAD_MASK_LEFT:
+			newDpad |= GAMEPAD_MASK_LEFT;
+			lastLR = DIRECTION_LEFT;
+			break;
+
+		case GAMEPAD_MASK_RIGHT:
+			newDpad |= GAMEPAD_MASK_RIGHT;
+			lastLR = DIRECTION_RIGHT;
+			break;
+
+		default:
+			lastLR = DIRECTION_NONE;
+			break;
+	}
+
+	return newDpad;
+}

--- a/headers/gamepad/GamepadStorage.h
+++ b/headers/gamepad/GamepadStorage.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "GamepadOptions.h"
+
+#define STORAGE_FIRST_AVAILBLE_INDEX 2048
+
+class GamepadStorage
+{
+	public:
+		virtual void start(); // TODO: Should be pure virtual.
+		virtual void save(); // TODO: Should be pure virtual.
+
+		GamepadOptions getGamepadOptions();
+		void setGamepadOptions(GamepadOptions options);
+};
+
+static GamepadStorage GamepadStore;

--- a/headers/gamepad/descriptors/HIDDescriptors.h
+++ b/headers/gamepad/descriptors/HIDDescriptors.h
@@ -1,0 +1,263 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#define HID_ENDPOINT_SIZE 64
+
+// Mac OS-X and Linux automatically load the correct drivers.  On
+// Windows, even though the driver is supplied by Microsoft, an
+// INF file is needed to load the driver.  These numbers need to
+// match the INF file.
+#define VENDOR_ID		0x10C4
+#define PRODUCT_ID		0x82C0
+
+/**************************************************************************
+ *
+ *  Endpoint Buffer Configuration
+ *
+ **************************************************************************/
+
+#define ENDPOINT0_SIZE	64
+
+#define GAMEPAD_INTERFACE	0
+#define GAMEPAD_ENDPOINT	1
+#define GAMEPAD_SIZE		64
+
+#define LSB(n) (n & 255)
+#define MSB(n) ((n >> 8) & 255)
+
+// HAT report (4 bits)
+#define HID_HAT_UP        0x00
+#define HID_HAT_UPRIGHT   0x01
+#define HID_HAT_RIGHT     0x02
+#define HID_HAT_DOWNRIGHT 0x03
+#define HID_HAT_DOWN      0x04
+#define HID_HAT_DOWNLEFT  0x05
+#define HID_HAT_LEFT      0x06
+#define HID_HAT_UPLEFT    0x07
+#define HID_HAT_NOTHING   0x08
+
+// Button report (16 bits)
+#define HID_MASK_SQUARE   (1U <<  0)
+#define HID_MASK_CROSS    (1U <<  1)
+#define HID_MASK_CIRCLE   (1U <<  2)
+#define HID_MASK_TRIANGLE (1U <<  3)
+#define HID_MASK_L1       (1U <<  4)
+#define HID_MASK_R1       (1U <<  5)
+#define HID_MASK_L2       (1U <<  6)
+#define HID_MASK_R2       (1U <<  7)
+#define HID_MASK_SELECT   (1U <<  8)
+#define HID_MASK_START    (1U <<  9)
+#define HID_MASK_L3       (1U << 10)
+#define HID_MASK_R3       (1U << 11)
+#define HID_MASK_PS       (1U << 12)
+#define HID_MASK_TP       (1U << 13)
+
+// Switch analog sticks only report 8 bits
+#define HID_JOYSTICK_MIN 0x00
+#define HID_JOYSTICK_MID 0x80
+#define HID_JOYSTICK_MAX 0xFF
+
+typedef struct __attribute((packed, aligned(1)))
+{
+	// digital buttons, 0 = off, 1 = on
+
+	uint8_t square_btn : 1;
+	uint8_t cross_btn : 1;
+	uint8_t circle_btn : 1;
+	uint8_t triangle_btn : 1;
+
+	uint8_t l1_btn : 1;
+	uint8_t r1_btn : 1;
+	uint8_t l2_btn : 1;
+	uint8_t r2_btn : 1;
+
+	uint8_t select_btn : 1;
+	uint8_t start_btn : 1;
+	uint8_t l3_btn : 1;
+	uint8_t r3_btn : 1;
+	
+	uint8_t ps_btn : 1;
+//	uint8_t l2_btn_alt : 1;
+	
+//	uint8_t r2_btn_alt : 1;
+	uint8_t : 2;
+
+	// digital direction, use the dir_* constants(enum)
+	// 8 = center, 0 = up, 1 = up/right, 2 = right, 3 = right/down
+	// 4 = down, 5 = down/left, 6 = left, 7 = left/up
+
+	uint8_t direction;
+
+	// left and right analog sticks, 0x00 left/up, 0x80 middle, 0xff right/down
+
+	uint8_t l_x_axis;
+	uint8_t l_y_axis;
+	uint8_t r_x_axis;
+	uint8_t r_y_axis;
+
+	// Gonna assume these are button analog values for the d-pad.
+	// NOTE: NOT EVEN SURE THIS IS RIGHT, OR IN THE CORRECT ORDER
+	uint8_t right_axis;
+	uint8_t left_axis;
+	uint8_t up_axis;
+	uint8_t down_axis;
+
+	// button axis, 0x00 = unpressed, 0xff = fully pressed
+
+	uint8_t triangle_axis;
+	uint8_t circle_axis;
+	uint8_t cross_axis;
+	uint8_t square_axis;
+
+	uint8_t l1_axis;
+	uint8_t r1_axis;
+	uint8_t l2_axis;
+	uint8_t r2_axis;
+} HIDReport;
+
+static const uint8_t hid_string_language[]     = { 0x09, 0x04 };
+static const uint8_t hid_string_manufacturer[] = "Open Stick Community";
+static const uint8_t hid_string_product[]      = "GP2040-CE (D-Input)";
+static const uint8_t hid_string_version[]      = "1.0";
+
+static const uint8_t *hid_string_descriptors[] =
+{
+	hid_string_language,
+	hid_string_manufacturer,
+	hid_string_product,
+	hid_string_version
+};
+
+static const uint8_t hid_device_descriptor[] =
+{
+		18,								  // bLength
+		1,								  // bDescriptorType
+		0x00, 0x02,						  // bcdUSB
+		0,								  // bDeviceClass
+		0,								  // bDeviceSubClass
+		0,								  // bDeviceProtocol
+		ENDPOINT0_SIZE,					  // bMaxPacketSize0
+		LSB(VENDOR_ID), MSB(VENDOR_ID),	  // idVendor
+		LSB(PRODUCT_ID), MSB(PRODUCT_ID), // idProduct
+		0x00, 0x01,						  // bcdDevice
+		1,								  // iManufacturer
+		2,								  // iProduct
+		0,								  // iSerialNumber
+		1								  // bNumConfigurations
+};
+
+static const uint8_t hid_report_descriptor[] =
+{
+	0x05, 0x01,        // USAGE_PAGE (Generic Desktop)
+	0x09, 0x05,        // USAGE (Gamepad)
+	0xa1, 0x01,        // COLLECTION (Application)
+	0x15, 0x00,        //   LOGICAL_MINIMUM (0)
+	0x25, 0x01,        //   LOGICAL_MAXIMUM (1)
+	0x35, 0x00,        //   PHYSICAL_MINIMUM (0)
+	0x45, 0x01,        //   PHYSICAL_MAXIMUM (1)
+	0x75, 0x01,        //   REPORT_SIZE (1)
+	0x95, 0x0e,        //   REPORT_COUNT (13)
+	0x05, 0x09,        //   USAGE_PAGE (Button)
+	0x19, 0x01,        //   USAGE_MINIMUM (Button 1)
+	0x29, 0x0e,        //   USAGE_MAXIMUM (Button 13)
+	0x81, 0x02,        //   INPUT (Data,Var,Abs)
+	0x95, 0x02,        //   REPORT_COUNT (3)
+	0x81, 0x01,        //   INPUT (Cnst,Ary,Abs)
+	0x05, 0x01,        //   USAGE_PAGE (Generic Desktop)
+	0x25, 0x07,        //   LOGICAL_MAXIMUM (7)
+	0x46, 0x3b, 0x01,  //   PHYSICAL_MAXIMUM (315)
+	0x75, 0x04,        //   REPORT_SIZE (4)
+	0x95, 0x01,        //   REPORT_COUNT (1)
+	0x65, 0x14,        //   UNIT (Eng Rot:Angular Pos)
+	0x09, 0x39,        //   USAGE (Hat switch)
+	0x81, 0x42,        //   INPUT (Data,Var,Abs,Null)
+	0x65, 0x00,        //   UNIT (None)
+	0x95, 0x01,        //   REPORT_COUNT (1)
+	0x81, 0x01,        //   INPUT (Cnst,Ary,Abs)
+	0x26, 0xff, 0x00,  //   LOGICAL_MAXIMUM (255)
+	0x46, 0xff, 0x00,  //   PHYSICAL_MAXIMUM (255)
+	0x09, 0x30,        //   USAGE (X)
+	0x09, 0x31,        //   USAGE (Y)
+	0x09, 0x32,        //   USAGE (Z)
+	0x09, 0x35,        //   USAGE (Rz)
+	0x75, 0x08,        //   REPORT_SIZE (8)
+	0x95, 0x04,        //   REPORT_COUNT (6)
+	0x81, 0x02,        //   INPUT (Data,Var,Abs)
+	0x06, 0x00, 0xff,  //   USAGE_PAGE (Vendor Specific)
+	0x09, 0x20,        //   Unknown
+	0x09, 0x21,        //   Unknown
+	0x09, 0x22,        //   Unknown
+	0x09, 0x23,        //   Unknown
+	0x09, 0x24,        //   Unknown
+	0x09, 0x25,        //   Unknown
+	0x09, 0x26,        //   Unknown
+	0x09, 0x27,        //   Unknown
+	0x09, 0x28,        //   Unknown
+	0x09, 0x29,        //   Unknown
+	0x09, 0x2a,        //   Unknown
+	0x09, 0x2b,        //   Unknown
+	0x95, 0x0c,        //   REPORT_COUNT (12)
+	0x81, 0x02,        //   INPUT (Data,Var,Abs)
+	0x0a, 0x21, 0x26,  //   Unknown
+	0x95, 0x08,        //   REPORT_COUNT (8)
+	0xb1, 0x02,        //   FEATURE (Data,Var,Abs)
+	0xc0               // END_COLLECTION
+};
+
+static const uint8_t hid_hid_descriptor[] =
+{
+		0x09,								 // bLength
+		0x21,								 // bDescriptorType (HID)
+		0x11, 0x01,							 // bcdHID 1.11
+		0x00,								 // bCountryCode
+		0x01,								 // bNumDescriptors
+		0x22,								 // bDescriptorType[0] (HID)
+		sizeof(hid_report_descriptor), 0x00, // wDescriptorLength[0] 90
+};
+
+#define CONFIG1_DESC_SIZE		(9+9+9+7)
+static const uint8_t hid_configuration_descriptor[] =
+{
+	    // configuration descriptor, USB spec 9.6.3, page 264-266, Table 9-10
+	9,						       // bLength;
+	2,						       // bDescriptorType;
+	LSB(CONFIG1_DESC_SIZE),        // wTotalLength
+	MSB(CONFIG1_DESC_SIZE),
+	1,	                           // bNumInterfaces
+	1,	                           // bConfigurationValue
+	0,	                           // iConfiguration
+	0x80,                          // bmAttributes
+	50,	                           // bMaxPower
+		// interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
+	9,				               // bLength
+	4,				               // bDescriptorType
+	GAMEPAD_INTERFACE,             // bInterfaceNumber
+	0,				               // bAlternateSetting
+	1,				               // bNumEndpoints
+	0x03,			               // bInterfaceClass (0x03 = HID)
+	0x00,			               // bInterfaceSubClass (0x00 = No Boot)
+	0x00,			               // bInterfaceProtocol (0x00 = No Protocol)
+	0,				               // iInterface
+		// HID interface descriptor, HID 1.11 spec, section 6.2.1
+	9,							   // bLength
+	0x21,						   // bDescriptorType
+	0x11, 0x01,					   // bcdHID
+	0,							   // bCountryCode
+	1,							   // bNumDescriptors
+	0x22,						   // bDescriptorType
+	sizeof(hid_report_descriptor), // wDescriptorLength
+	0,
+		// endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+	7,						 	   // bLength
+	5,						       // bDescriptorType
+	GAMEPAD_ENDPOINT | 0x80,       // bEndpointAddress
+	0x03,					       // bmAttributes (0x03=intr)
+	GAMEPAD_SIZE, 0,		       // wMaxPacketSize
+	1						       // bInterval (1 ms)
+};

--- a/headers/gamepad/descriptors/SwitchDescriptors.h
+++ b/headers/gamepad/descriptors/SwitchDescriptors.h
@@ -1,0 +1,194 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#define SWITCH_ENDPOINT_SIZE 64
+
+// HAT report (4 bits)
+#define SWITCH_HAT_UP        0x00
+#define SWITCH_HAT_UPRIGHT   0x01
+#define SWITCH_HAT_RIGHT     0x02
+#define SWITCH_HAT_DOWNRIGHT 0x03
+#define SWITCH_HAT_DOWN      0x04
+#define SWITCH_HAT_DOWNLEFT  0x05
+#define SWITCH_HAT_LEFT      0x06
+#define SWITCH_HAT_UPLEFT    0x07
+#define SWITCH_HAT_NOTHING   0x08
+
+// Button report (16 bits)
+#define SWITCH_MASK_Y       (1U <<  0)
+#define SWITCH_MASK_B       (1U <<  1)
+#define SWITCH_MASK_A       (1U <<  2)
+#define SWITCH_MASK_X       (1U <<  3)
+#define SWITCH_MASK_L       (1U <<  4)
+#define SWITCH_MASK_R       (1U <<  5)
+#define SWITCH_MASK_ZL      (1U <<  6)
+#define SWITCH_MASK_ZR      (1U <<  7)
+#define SWITCH_MASK_MINUS   (1U <<  8)
+#define SWITCH_MASK_PLUS    (1U <<  9)
+#define SWITCH_MASK_L3      (1U << 10)
+#define SWITCH_MASK_R3      (1U << 11)
+#define SWITCH_MASK_HOME    (1U << 12)
+#define SWITCH_MASK_CAPTURE (1U << 13)
+
+// Switch analog sticks only report 8 bits
+#define SWITCH_JOYSTICK_MIN 0x00
+#define SWITCH_JOYSTICK_MID 0x80
+#define SWITCH_JOYSTICK_MAX 0xFF
+
+typedef struct __attribute((packed, aligned(1)))
+{
+	uint16_t buttons;
+	uint8_t hat;
+	uint8_t lx;
+	uint8_t ly;
+	uint8_t rx;
+	uint8_t ry;
+	uint8_t vendor;
+} SwitchReport;
+
+typedef struct
+{
+	uint16_t buttons;
+	uint8_t hat;
+	uint8_t lx;
+	uint8_t ly;
+	uint8_t rx;
+	uint8_t ry;
+} SwitchOutReport;
+
+static const uint8_t switch_string_language[]     = { 0x09, 0x04 };
+static const uint8_t switch_string_manufacturer[] = "HORI CO.,LTD.";
+static const uint8_t switch_string_product[]      = "POKKEN CONTROLLER";
+static const uint8_t switch_string_version[]      = "1.0";
+
+static const uint8_t *switch_string_descriptors[] =
+{
+	switch_string_language,
+	switch_string_manufacturer,
+	switch_string_product,
+	switch_string_version
+};
+
+static const uint8_t switch_device_descriptor[] =
+{
+	0x12,        // bLength
+	0x01,        // bDescriptorType (Device)
+	0x00, 0x02,  // bcdUSB 2.00
+	0x00,        // bDeviceClass (Use class information in the Interface Descriptors)
+	0x00,        // bDeviceSubClass
+	0x00,        // bDeviceProtocol
+	0x40,        // bMaxPacketSize0 64
+	0x0D, 0x0F,  // idVendor 0x0F0D
+	0x92, 0x00,  // idProduct 0x92
+	0x00, 0x01,  // bcdDevice 2.00
+	0x01,        // iManufacturer (String Index)
+	0x02,        // iProduct (String Index)
+	0x00,        // iSerialNumber (String Index)
+	0x01,        // bNumConfigurations 1
+};
+
+static const uint8_t switch_hid_descriptor[] =
+{
+	0x09,        // bLength
+	0x21,        // bDescriptorType (HID)
+	0x11, 0x01,  // bcdHID 1.11
+	0x00,        // bCountryCode
+	0x01,        // bNumDescriptors
+	0x22,        // bDescriptorType[0] (HID)
+	0x56, 0x00,  // wDescriptorLength[0] 86
+};
+
+static const uint8_t switch_configuration_descriptor[] =
+{
+	0x09,        // bLength
+	0x02,        // bDescriptorType (Configuration)
+	0x29, 0x00,  // wTotalLength 41
+	0x01,        // bNumInterfaces 1
+	0x01,        // bConfigurationValue
+	0x00,        // iConfiguration (String Index)
+	0x80,        // bmAttributes
+	0xFA,        // bMaxPower 500mA
+
+	0x09,        // bLength
+	0x04,        // bDescriptorType (Interface)
+	0x00,        // bInterfaceNumber 0
+	0x00,        // bAlternateSetting
+	0x02,        // bNumEndpoints 2
+	0x03,        // bInterfaceClass
+	0x00,        // bInterfaceSubClass
+	0x00,        // bInterfaceProtocol
+	0x00,        // iInterface (String Index)
+
+	0x09,        // bLength
+	0x21,        // bDescriptorType (HID)
+	0x11, 0x01,  // bcdHID 1.11
+	0x00,        // bCountryCode
+	0x01,        // bNumDescriptors
+	0x22,        // bDescriptorType[0] (HID)
+	0x56, 0x00,  // wDescriptorLength[0] 86
+
+	0x07,        // bLength
+	0x05,        // bDescriptorType (Endpoint)
+	0x02,        // bEndpointAddress (OUT/H2D)
+	0x03,        // bmAttributes (Interrupt)
+	0x40, 0x00,  // wMaxPacketSize 64
+	0x01,        // bInterval 1 (unit depends on device speed)
+
+	0x07,        // bLength
+	0x05,        // bDescriptorType (Endpoint)
+	0x81,        // bEndpointAddress (IN/D2H)
+	0x03,        // bmAttributes (Interrupt)
+	0x40, 0x00,  // wMaxPacketSize 64
+	0x01,        // bInterval 1 (unit depends on device speed)
+};
+
+static const uint8_t switch_report_descriptor[] =
+{
+	0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+	0x09, 0x05,        // Usage (Game Pad)
+	0xA1, 0x01,        // Collection (Application)
+	0x15, 0x00,        //   Logical Minimum (0)
+	0x25, 0x01,        //   Logical Maximum (1)
+	0x35, 0x00,        //   Physical Minimum (0)
+	0x45, 0x01,        //   Physical Maximum (1)
+	0x75, 0x01,        //   Report Size (1)
+	0x95, 0x10,        //   Report Count (16)
+	0x05, 0x09,        //   Usage Page (Button)
+	0x19, 0x01,        //   Usage Minimum (0x01)
+	0x29, 0x10,        //   Usage Maximum (0x10)
+	0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+	0x05, 0x01,        //   Usage Page (Generic Desktop Ctrls)
+	0x25, 0x07,        //   Logical Maximum (7)
+	0x46, 0x3B, 0x01,  //   Physical Maximum (315)
+	0x75, 0x04,        //   Report Size (4)
+	0x95, 0x01,        //   Report Count (1)
+	0x65, 0x14,        //   Unit (System: English Rotation, Length: Centimeter)
+	0x09, 0x39,        //   Usage (Hat switch)
+	0x81, 0x42,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,Null State)
+	0x65, 0x00,        //   Unit (None)
+	0x95, 0x01,        //   Report Count (1)
+	0x81, 0x01,        //   Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+	0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+	0x46, 0xFF, 0x00,  //   Physical Maximum (255)
+	0x09, 0x30,        //   Usage (X)
+	0x09, 0x31,        //   Usage (Y)
+	0x09, 0x32,        //   Usage (Z)
+	0x09, 0x35,        //   Usage (Rz)
+	0x75, 0x08,        //   Report Size (8)
+	0x95, 0x04,        //   Report Count (4)
+	0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+	0x06, 0x00, 0xFF,  //   Usage Page (Vendor Defined 0xFF00)
+	0x09, 0x20,        //   Usage (0x20)
+	0x95, 0x01,        //   Report Count (1)
+	0x81, 0x02,        //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+	0x0A, 0x21, 0x26,  //   Usage (0x2621)
+	0x95, 0x08,        //   Report Count (8)
+	0x91, 0x02,        //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+	0xC0,              // End Collection
+};

--- a/headers/gamepad/descriptors/XInputDescriptors.h
+++ b/headers/gamepad/descriptors/XInputDescriptors.h
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#define XINPUT_ENDPOINT_SIZE 20
+
+// Buttons 1 (8 bits)
+// TODO: Consider using an enum class here.
+#define XBOX_MASK_UP    (1U << 0)
+#define XBOX_MASK_DOWN  (1U << 1)
+#define XBOX_MASK_LEFT  (1U << 2)
+#define XBOX_MASK_RIGHT (1U << 3)
+#define XBOX_MASK_START (1U << 4)
+#define XBOX_MASK_BACK  (1U << 5)
+#define XBOX_MASK_LS    (1U << 6)
+#define XBOX_MASK_RS    (1U << 7)
+
+// Buttons 2 (8 bits)
+// TODO: Consider using an enum class here.
+#define XBOX_MASK_LB    (1U << 0)
+#define XBOX_MASK_RB    (1U << 1)
+#define XBOX_MASK_HOME  (1U << 2)
+//#define UNUSED        (1U << 3)
+#define XBOX_MASK_A     (1U << 4)
+#define XBOX_MASK_B     (1U << 5)
+#define XBOX_MASK_X     (1U << 6)
+#define XBOX_MASK_Y     (1U << 7)
+
+typedef struct __attribute((packed, aligned(1)))
+{
+	uint8_t report_id;
+	uint8_t report_size;
+	uint8_t buttons1;
+	uint8_t buttons2;
+	uint8_t lt;
+	uint8_t rt;
+	int16_t lx;
+	int16_t ly;
+	int16_t rx;
+	int16_t ry;
+	uint8_t _reserved[6];
+} XInputReport;
+
+static const uint8_t xinput_string_language[]    = { 0x09, 0x04 };
+static const uint8_t xinput_string_manfacturer[] = "Microsoft";
+static const uint8_t xinput_string_product[]     = "XInput STANDARD GAMEPAD";
+static const uint8_t xinput_string_version[]     = "1.0";
+
+static const uint8_t *xinput_string_descriptors[] =
+{
+	xinput_string_language,
+	xinput_string_manfacturer,
+	xinput_string_product,
+	xinput_string_version
+};
+
+static const uint8_t xinput_device_descriptor[] =
+{
+	0x12,       // bLength
+	0x01,       // bDescriptorType (Device)
+	0x00, 0x02, // bcdUSB 2.00
+	0xFF,	      // bDeviceClass
+	0xFF,	      // bDeviceSubClass
+	0xFF,	      // bDeviceProtocol
+	0x40,	      // bMaxPacketSize0 64
+	0x5E, 0x04, // idVendor 0x045E
+	0x8E, 0x02, // idProduct 0x028E
+	0x14, 0x01, // bcdDevice 2.14
+	0x01,       // iManufacturer (String Index)
+	0x02,       // iProduct (String Index)
+	0x03,       // iSerialNumber (String Index)
+	0x01,       // bNumConfigurations 1
+};
+
+static const uint8_t xinput_configuration_descriptor[] =
+{
+	0x09,        // bLength
+	0x02,        // bDescriptorType (Configuration)
+	0x30, 0x00,  // wTotalLength 48
+	0x01,        // bNumInterfaces 1
+	0x01,        // bConfigurationValue
+	0x00,        // iConfiguration (String Index)
+	0x80,        // bmAttributes
+	0xFA,        // bMaxPower 500mA
+
+	0x09,        // bLength
+	0x04,        // bDescriptorType (Interface)
+	0x00,        // bInterfaceNumber 0
+	0x00,        // bAlternateSetting
+	0x02,        // bNumEndpoints 2
+	0xFF,        // bInterfaceClass
+	0x5D,        // bInterfaceSubClass
+	0x01,        // bInterfaceProtocol
+	0x00,        // iInterface (String Index)
+
+	0x10,        // bLength
+	0x21,        // bDescriptorType (HID)
+	0x10, 0x01,  // bcdHID 1.10
+	0x01,        // bCountryCode
+	0x24,        // bNumDescriptors
+	0x81,        // bDescriptorType[0] (Unknown 0x81)
+	0x14, 0x03,  // wDescriptorLength[0] 788
+	0x00,        // bDescriptorType[1] (Unknown 0x00)
+	0x03, 0x13,  // wDescriptorLength[1] 4867
+	0x01,        // bDescriptorType[2] (Unknown 0x02)
+	0x00, 0x03,  // wDescriptorLength[2] 768
+	0x00,        // bDescriptorType[3] (Unknown 0x00)
+
+	0x07,        // bLength
+	0x05,        // bDescriptorType (Endpoint)
+	0x81,        // bEndpointAddress (IN/D2H)
+	0x03,        // bmAttributes (Interrupt)
+	0x20, 0x00,  // wMaxPacketSize 32
+	0x01,        // bInterval 1 (unit depends on device speed)
+
+	0x07,        // bLength
+	0x05,        // bDescriptorType (Endpoint)
+	0x01,        // bEndpointAddress (OUT/H2D)
+	0x03,        // bmAttributes (Interrupt)
+	0x20, 0x00,  // wMaxPacketSize 32
+	0x08,        // bInterval 8 (unit depends on device speed)
+};

--- a/headers/themes.h
+++ b/headers/themes.h
@@ -8,7 +8,6 @@
 
 #include "BoardConfig.h"
 #include <vector>
-#include <MPG.h>
 #include "AnimationStation.hpp"
 #include "helper.h"
 

--- a/lib/TinyUSB_Gamepad/CMakeLists.txt
+++ b/lib/TinyUSB_Gamepad/CMakeLists.txt
@@ -12,6 +12,5 @@ ${CMAKE_SOURCE_DIR}/headers
 target_link_libraries(TinyUSB_Gamepad 
 pico_stdlib
 tinyusb_device
-MPG
 rndis
 )

--- a/lib/TinyUSB_Gamepad/library.json
+++ b/lib/TinyUSB_Gamepad/library.json
@@ -9,8 +9,5 @@
 			"url": "https://mytechtoybox.com"
 		}
 	],
-	"dependencies": {
-		"MPG": "https://github.com/FeralAI/MPG.git#e529c802b679b2bee8ec93b2ac4ed72edb9cf369"
-	},
 	"license": "MIT"
 }

--- a/lib/TinyUSB_Gamepad/src/hid_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/hid_driver.cpp
@@ -9,7 +9,7 @@
 
 #include "device/usbd_pvt.h"
 #include "class/hid/hid_device.h"
-#include "GamepadDescriptors.h"
+#include "gamepad/GamepadDescriptors.h"
 
 // Magic byte sequence to enable PS button on PS3
 static const uint8_t magic_init_bytes[8] = {0x21, 0x26, 0x01, 0x07, 0x00, 0x00, 0x00, 0x00};

--- a/lib/TinyUSB_Gamepad/src/hid_driver.h
+++ b/lib/TinyUSB_Gamepad/src/hid_driver.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #include "device/usbd_pvt.h"
-#include "descriptors/HIDDescriptors.h"
-#include "descriptors/SwitchDescriptors.h"
+#include "gamepad/descriptors/HIDDescriptors.h"
+#include "gamepad/descriptors/SwitchDescriptors.h"
 
 extern const usbd_class_driver_t hid_driver;
 

--- a/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
@@ -10,7 +10,7 @@
 #include "class/hid/hid.h"
 #include "device/usbd_pvt.h"
 
-#include "GamepadDescriptors.h"
+#include "gamepad/GamepadDescriptors.h"
 
 #include "usb_driver.h"
 #include "net_driver.h"

--- a/lib/TinyUSB_Gamepad/src/usb_descriptors.cpp
+++ b/lib/TinyUSB_Gamepad/src/usb_descriptors.cpp
@@ -7,7 +7,7 @@
 #include <wchar.h>
 #include "tusb.h"
 #include "usb_driver.h"
-#include "GamepadDescriptors.h"
+#include "gamepad/GamepadDescriptors.h"
 #include "webserver_descriptors.h"
 
 // Invoked when received GET STRING DESCRIPTOR request

--- a/lib/TinyUSB_Gamepad/src/usb_driver.h
+++ b/lib/TinyUSB_Gamepad/src/usb_driver.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "GamepadDescriptors.h"
+#include "gamepad/GamepadDescriptors.h"
 
 typedef enum
 {

--- a/lib/TinyUSB_Gamepad/src/xinput_driver.h
+++ b/lib/TinyUSB_Gamepad/src/xinput_driver.h
@@ -9,7 +9,7 @@
 #include "tusb.h"
 #include "device/usbd_pvt.h"
 
-#include "descriptors/XInputDescriptors.h"
+#include "gamepad/descriptors/XInputDescriptors.h"
 
 #define XINPUT_OUT_SIZE 32
 

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -19,9 +19,49 @@ uint64_t getMicro() {
 	return to_us_since_boot(get_absolute_time());
 }
 
+
+static HIDReport hidReport
+{
+	.square_btn = 0, .cross_btn = 0, .circle_btn = 0, .triangle_btn = 0,
+	.l1_btn = 0, .r1_btn = 0, .l2_btn = 0, .r2_btn = 0,
+	.select_btn = 0, .start_btn = 0, .l3_btn = 0, .r3_btn = 0, .ps_btn = 0,
+	.direction = 0x08,
+	.l_x_axis = 0x80, .l_y_axis = 0x80, .r_x_axis = 0x80, .r_y_axis = 0x80,
+	.right_axis = 0x00, .left_axis = 0x00, .up_axis = 0x00, .down_axis = 0x00,
+	.triangle_axis = 0x00, .circle_axis = 0x00, .cross_axis = 0x00, .square_axis = 0x00,
+	.l1_axis = 0x00, .r1_axis = 0x00, .l2_axis = 0x00, .r2_axis = 0x00
+};
+
+static SwitchReport switchReport
+{
+	.buttons = 0,
+	.hat = SWITCH_HAT_NOTHING,
+	.lx = SWITCH_JOYSTICK_MID,
+	.ly = SWITCH_JOYSTICK_MID,
+	.rx = SWITCH_JOYSTICK_MID,
+	.ry = SWITCH_JOYSTICK_MID,
+	.vendor = 0,
+};
+
+static XInputReport xinputReport
+{
+	.report_id = 0,
+	.report_size = XINPUT_ENDPOINT_SIZE,
+	.buttons1 = 0,
+	.buttons2 = 0,
+	.lt = 0,
+	.rt = 0,
+	.lx = GAMEPAD_JOYSTICK_MID,
+	.ly = GAMEPAD_JOYSTICK_MID,
+	.rx = GAMEPAD_JOYSTICK_MID,
+	.ry = GAMEPAD_JOYSTICK_MID,
+	._reserved = { },
+};
+
 void Gamepad::setup()
 {
-	load(); // MPGS loads
+	//load(); // MPGS loads
+	options = mpgStorage->getGamepadOptions();
 
 	// Configure pin mapping
 	f2Mask = (GAMEPAD_MASK_A1 | GAMEPAD_MASK_S2);
@@ -72,7 +112,42 @@ void Gamepad::setup()
 void Gamepad::process()
 {
 	memcpy(&rawState, &state, sizeof(GamepadState));
-	MPGS::process();
+
+	state.dpad = runSOCDCleaner(options.socdMode, state.dpad);
+
+	switch (options.dpadMode)
+	{
+		case DpadMode::DPAD_MODE_LEFT_ANALOG:
+			if (!hasRightAnalogStick) {
+				state.rx = GAMEPAD_JOYSTICK_MID;
+				state.ry = GAMEPAD_JOYSTICK_MID;
+			}
+			state.lx = dpadToAnalogX(state.dpad);
+			state.ly = dpadToAnalogY(state.dpad);
+			state.dpad = 0;
+			break;
+
+		case DpadMode::DPAD_MODE_RIGHT_ANALOG:
+			if (!hasLeftAnalogStick) {
+				state.lx = GAMEPAD_JOYSTICK_MID;
+				state.ly = GAMEPAD_JOYSTICK_MID;
+			}
+			state.rx = dpadToAnalogX(state.dpad);
+			state.ry = dpadToAnalogY(state.dpad);
+			state.dpad = 0;
+			break;
+
+		default:
+			if (!hasLeftAnalogStick) {
+				state.lx = GAMEPAD_JOYSTICK_MID;
+				state.ly = GAMEPAD_JOYSTICK_MID;
+			}
+			if (!hasRightAnalogStick) {
+				state.rx = GAMEPAD_JOYSTICK_MID;
+				state.ry = GAMEPAD_JOYSTICK_MID;
+			}
+			break;
+	}
 }
 
 void Gamepad::read()
@@ -118,6 +193,257 @@ void Gamepad::read()
 	state.rt = 0;
 }
 
+void Gamepad::debounce() {
+	debouncer.debounce(&state);
+}
+
+void Gamepad::save()
+{
+	bool dirty = false;
+	GamepadOptions savedOptions = mpgStorage->getGamepadOptions();
+	if (memcmp(&savedOptions, &options, sizeof(GamepadOptions)))
+	{
+		mpgStorage->setGamepadOptions(options);
+		dirty = true;
+	}
+
+	if (dirty)
+		mpgStorage->save();
+}
+
+GamepadHotkey Gamepad::hotkey()
+{
+	static GamepadHotkey lastAction = HOTKEY_NONE;
+	GamepadHotkey action = HOTKEY_NONE;
+	if (pressedF1())
+	{
+		switch (state.dpad & GAMEPAD_MASK_DPAD)
+		{
+			case GAMEPAD_MASK_LEFT:
+				action = HOTKEY_DPAD_LEFT_ANALOG;
+				options.dpadMode = DPAD_MODE_LEFT_ANALOG;
+				state.dpad = 0;
+				state.buttons &= ~(f1Mask);
+				break;
+
+			case GAMEPAD_MASK_RIGHT:
+				action = HOTKEY_DPAD_RIGHT_ANALOG;
+				options.dpadMode = DPAD_MODE_RIGHT_ANALOG;
+				state.dpad = 0;
+				state.buttons &= ~(f1Mask);
+				break;
+
+			case GAMEPAD_MASK_DOWN:
+				action = HOTKEY_DPAD_DIGITAL;
+				options.dpadMode = DPAD_MODE_DIGITAL;
+				state.dpad = 0;
+				state.buttons &= ~(f1Mask);
+				break;
+
+			case GAMEPAD_MASK_UP:
+				action = HOTKEY_HOME_BUTTON;
+				state.dpad = 0;
+				state.buttons &= ~(f1Mask);
+				state.buttons |= GAMEPAD_MASK_A1; // Press the Home button
+				break;
+		}
+	}
+	else if (pressedF2())
+	{
+		switch (state.dpad & GAMEPAD_MASK_DPAD)
+		{
+			case GAMEPAD_MASK_DOWN:
+				action = HOTKEY_SOCD_NEUTRAL;
+				options.socdMode = SOCD_MODE_NEUTRAL;
+				state.dpad = 0;
+				state.buttons &= ~(f2Mask);
+				break;
+
+			case GAMEPAD_MASK_UP:
+				action = HOTKEY_SOCD_UP_PRIORITY;
+				options.socdMode = SOCD_MODE_UP_PRIORITY;
+				state.dpad = 0;
+				state.buttons &= ~(f2Mask);
+				break;
+
+			case GAMEPAD_MASK_LEFT:
+				action = HOTKEY_SOCD_LAST_INPUT;
+				options.socdMode = SOCD_MODE_SECOND_INPUT_PRIORITY;
+				state.dpad = 0;
+				state.buttons &= ~(f2Mask);
+				break;
+
+			case GAMEPAD_MASK_RIGHT:
+				if (lastAction != HOTKEY_INVERT_Y_AXIS)
+					options.invertYAxis = !options.invertYAxis;
+				action = HOTKEY_INVERT_Y_AXIS;
+				state.dpad = 0;
+				state.buttons &= ~(f2Mask);
+				break;
+		}
+	}
+
+	GamepadHotkey hotkey = action;
+	if (hotkey != GamepadHotkey::HOTKEY_NONE)
+		save();
+
+	return hotkey;
+}
+
+
+void * Gamepad::getReport()
+{
+	switch (options.inputMode)
+	{
+		case INPUT_MODE_XINPUT:
+			return getXInputReport();
+
+		case INPUT_MODE_SWITCH:
+			return getSwitchReport();
+
+		default:
+			return getHIDReport();
+	}
+}
+
+
+uint16_t Gamepad::getReportSize()
+{
+	switch (options.inputMode)
+	{
+		case INPUT_MODE_XINPUT:
+			return sizeof(XInputReport);
+
+		case INPUT_MODE_SWITCH:
+			return sizeof(SwitchReport);
+
+		default:
+			return sizeof(HIDReport);
+	}
+}
+
+
+HIDReport *Gamepad::getHIDReport()
+{
+	switch (state.dpad & GAMEPAD_MASK_DPAD)
+	{
+		case GAMEPAD_MASK_UP:                        hidReport.direction = HID_HAT_UP;        break;
+		case GAMEPAD_MASK_UP | GAMEPAD_MASK_RIGHT:   hidReport.direction = HID_HAT_UPRIGHT;   break;
+		case GAMEPAD_MASK_RIGHT:                     hidReport.direction = HID_HAT_RIGHT;     break;
+		case GAMEPAD_MASK_DOWN | GAMEPAD_MASK_RIGHT: hidReport.direction = HID_HAT_DOWNRIGHT; break;
+		case GAMEPAD_MASK_DOWN:                      hidReport.direction = HID_HAT_DOWN;      break;
+		case GAMEPAD_MASK_DOWN | GAMEPAD_MASK_LEFT:  hidReport.direction = HID_HAT_DOWNLEFT;  break;
+		case GAMEPAD_MASK_LEFT:                      hidReport.direction = HID_HAT_LEFT;      break;
+		case GAMEPAD_MASK_UP | GAMEPAD_MASK_LEFT:    hidReport.direction = HID_HAT_UPLEFT;    break;
+		default:                                     hidReport.direction = HID_HAT_NOTHING;   break;
+	}
+
+	hidReport.cross_btn    = pressedB1();
+	hidReport.circle_btn   = pressedB2();
+	hidReport.square_btn   = pressedB3();
+	hidReport.triangle_btn = pressedB4();
+	hidReport.l1_btn       = pressedL1();
+	hidReport.r1_btn       = pressedR1();
+	hidReport.l2_btn       = pressedL2();
+	hidReport.r2_btn       = pressedR2();
+	hidReport.select_btn   = pressedS1();
+	hidReport.start_btn    = pressedS2();
+	hidReport.l3_btn       = pressedL3();
+	hidReport.r3_btn       = pressedR3();
+	hidReport.ps_btn       = pressedA1();
+//	hidReport.cross_btn = pressedA2();
+
+	hidReport.l_x_axis = static_cast<uint8_t>(state.lx >> 8);
+	hidReport.l_y_axis = static_cast<uint8_t>(state.ly >> 8);
+	hidReport.r_x_axis = static_cast<uint8_t>(state.rx >> 8);
+	hidReport.r_y_axis = static_cast<uint8_t>(state.ry >> 8);
+
+	return &hidReport;
+}
+
+
+SwitchReport *Gamepad::getSwitchReport()
+{
+	switch (state.dpad & GAMEPAD_MASK_DPAD)
+	{
+		case GAMEPAD_MASK_UP:                        switchReport.hat = SWITCH_HAT_UP;        break;
+		case GAMEPAD_MASK_UP | GAMEPAD_MASK_RIGHT:   switchReport.hat = SWITCH_HAT_UPRIGHT;   break;
+		case GAMEPAD_MASK_RIGHT:                     switchReport.hat = SWITCH_HAT_RIGHT;     break;
+		case GAMEPAD_MASK_DOWN | GAMEPAD_MASK_RIGHT: switchReport.hat = SWITCH_HAT_DOWNRIGHT; break;
+		case GAMEPAD_MASK_DOWN:                      switchReport.hat = SWITCH_HAT_DOWN;      break;
+		case GAMEPAD_MASK_DOWN | GAMEPAD_MASK_LEFT:  switchReport.hat = SWITCH_HAT_DOWNLEFT;  break;
+		case GAMEPAD_MASK_LEFT:                      switchReport.hat = SWITCH_HAT_LEFT;      break;
+		case GAMEPAD_MASK_UP | GAMEPAD_MASK_LEFT:    switchReport.hat = SWITCH_HAT_UPLEFT;    break;
+		default:                                     switchReport.hat = SWITCH_HAT_NOTHING;   break;
+	}
+
+	switchReport.buttons = 0
+		| (pressedB1() ? SWITCH_MASK_B       : 0)
+		| (pressedB2() ? SWITCH_MASK_A       : 0)
+		| (pressedB3() ? SWITCH_MASK_Y       : 0)
+		| (pressedB4() ? SWITCH_MASK_X       : 0)
+		| (pressedL1() ? SWITCH_MASK_L       : 0)
+		| (pressedR1() ? SWITCH_MASK_R       : 0)
+		| (pressedL2() ? SWITCH_MASK_ZL      : 0)
+		| (pressedR2() ? SWITCH_MASK_ZR      : 0)
+		| (pressedS1() ? SWITCH_MASK_MINUS   : 0)
+		| (pressedS2() ? SWITCH_MASK_PLUS    : 0)
+		| (pressedL3() ? SWITCH_MASK_L3      : 0)
+		| (pressedR3() ? SWITCH_MASK_R3      : 0)
+		| (pressedA1() ? SWITCH_MASK_HOME    : 0)
+		| (pressedA2() ? SWITCH_MASK_CAPTURE : 0)
+	;
+
+	switchReport.lx = static_cast<uint8_t>(state.lx >> 8);
+	switchReport.ly = static_cast<uint8_t>(state.ly >> 8);
+	switchReport.rx = static_cast<uint8_t>(state.rx >> 8);
+	switchReport.ry = static_cast<uint8_t>(state.ry >> 8);
+
+	return &switchReport;
+}
+
+
+XInputReport *Gamepad::getXInputReport()
+{
+	xinputReport.buttons1 = 0
+		| (pressedUp()    ? XBOX_MASK_UP    : 0)
+		| (pressedDown()  ? XBOX_MASK_DOWN  : 0)
+		| (pressedLeft()  ? XBOX_MASK_LEFT  : 0)
+		| (pressedRight() ? XBOX_MASK_RIGHT : 0)
+		| (pressedS2()    ? XBOX_MASK_START : 0)
+		| (pressedS1()    ? XBOX_MASK_BACK  : 0)
+		| (pressedL3()    ? XBOX_MASK_LS    : 0)
+		| (pressedR3()    ? XBOX_MASK_RS    : 0)
+	;
+
+	xinputReport.buttons2 = 0
+		| (pressedL1() ? XBOX_MASK_LB   : 0)
+		| (pressedR1() ? XBOX_MASK_RB   : 0)
+		| (pressedA1() ? XBOX_MASK_HOME : 0)
+		| (pressedB1() ? XBOX_MASK_A    : 0)
+		| (pressedB2() ? XBOX_MASK_B    : 0)
+		| (pressedB3() ? XBOX_MASK_X    : 0)
+		| (pressedB4() ? XBOX_MASK_Y    : 0)
+	;
+
+	xinputReport.lx = static_cast<int16_t>(state.lx) + INT16_MIN;
+	xinputReport.ly = static_cast<int16_t>(~state.ly) + INT16_MIN;
+	xinputReport.rx = static_cast<int16_t>(state.rx) + INT16_MIN;
+	xinputReport.ry = static_cast<int16_t>(~state.ry) + INT16_MIN;
+
+	if (hasAnalogTriggers)
+	{
+		xinputReport.lt = state.lt;
+		xinputReport.rt = state.rt;
+	}
+	else
+	{
+		xinputReport.lt = pressedL2() ? 0xFF : 0;
+		xinputReport.rt = pressedR2() ? 0xFF : 0;
+	}
+
+	return &xinputReport;
+}
 
 /* Gamepad stuffs */
 void GamepadStorage::start()

--- a/src/gamepad/GamepadDebouncer.cpp
+++ b/src/gamepad/GamepadDebouncer.cpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#include "gamepad/GamepadDebouncer.h"
+
+void GamepadDebouncer::debounce(GamepadState *state)
+{
+	uint32_t now = getMillis();
+
+	for (int i = 0; i < 4; i++)
+	{
+		if ((debounceState.dpad & dpadMasks[i]) != (state->dpad & dpadMasks[i]) && (now - dpadTime[i]) > debounceMS)
+		{
+			debounceState.dpad ^= dpadMasks[i];
+			dpadTime[i] = now;
+		}
+	}
+
+	for (int i = 0; i < GAMEPAD_BUTTON_COUNT; i++)
+	{
+		if ((debounceState.buttons & buttonMasks[i]) != (state->buttons & buttonMasks[i]) && (now - buttonTime[i]) > debounceMS)
+		{
+			debounceState.buttons ^= buttonMasks[i];
+			buttonTime[i] = now;
+		}
+	}
+
+	state->dpad = debounceState.dpad;
+	state->buttons = debounceState.buttons;
+}

--- a/src/gamepad/GamepadDescriptors.cpp
+++ b/src/gamepad/GamepadDescriptors.cpp
@@ -1,0 +1,110 @@
+#include "gamepad/GamepadDescriptors.h"
+
+static uint16_t getConfigurationDescriptor(const uint8_t *buffer, InputMode mode)
+{
+	switch (mode)
+	{
+		case INPUT_MODE_XINPUT:
+			buffer = xinput_configuration_descriptor;
+			return sizeof(xinput_configuration_descriptor);
+
+		case INPUT_MODE_SWITCH:
+			buffer = switch_configuration_descriptor;
+			return sizeof(switch_configuration_descriptor);
+
+		default:
+			buffer = hid_configuration_descriptor;
+			return sizeof(hid_configuration_descriptor);
+	}
+}
+
+static uint16_t getDeviceDescriptor(const uint8_t *buffer, InputMode mode)
+{
+	switch (mode)
+	{
+		case INPUT_MODE_XINPUT:
+			buffer = xinput_device_descriptor;
+			return sizeof(xinput_device_descriptor);
+
+		case INPUT_MODE_SWITCH:
+			buffer = switch_device_descriptor;
+			return sizeof(switch_device_descriptor);
+
+		default:
+			buffer = hid_device_descriptor;
+			return sizeof(hid_device_descriptor);
+	}
+}
+
+static uint16_t getHIDDescriptor(const uint8_t *buffer, InputMode mode)
+{
+	switch (mode)
+	{
+		case INPUT_MODE_SWITCH:
+			buffer = switch_hid_descriptor;
+			return sizeof(switch_hid_descriptor);
+
+		default:
+			buffer = hid_hid_descriptor;
+			return sizeof(hid_hid_descriptor);
+	}
+}
+
+static uint16_t getHIDReport(const uint8_t *buffer, InputMode mode)
+{
+	switch (mode)
+	{
+		case INPUT_MODE_SWITCH:
+			buffer = switch_report_descriptor;
+			return sizeof(switch_report_descriptor);
+
+		default:
+			buffer = hid_report_descriptor;
+			return sizeof(hid_report_descriptor);
+	}
+}
+
+static uint16_t getStringDescriptor(const uint16_t *buffer, InputMode mode, uint8_t index)
+{
+	static uint8_t descriptorStringBuffer[64]; // Max 64 bytes
+
+	const char *value;
+	uint16_t size;
+	uint8_t charCount;
+
+	switch (mode)
+	{
+		case INPUT_MODE_XINPUT:
+			value = (const char *)xinput_string_descriptors[index];
+			size = sizeof(xinput_string_descriptors[index]);
+			break;
+
+		case INPUT_MODE_SWITCH:
+			value = (const char *)switch_string_descriptors[index];
+			size = sizeof(switch_string_descriptors[index]);
+			break;
+
+		default:
+			value = (const char *)hid_string_descriptors[index];
+			size = sizeof(hid_string_descriptors[index]);
+			break;
+	}
+
+	// Cap at max char
+	charCount = strlen(value);
+	if (charCount > 31)
+		charCount = 31;
+
+	for (uint8_t i = 0; i < charCount; i++)
+		descriptorStringBuffer[1 + i] = value[i];
+
+
+	// first byte is length (including header), second byte is string type
+	descriptorStringBuffer[0] = (2 * charCount + 2);
+	descriptorStringBuffer[1] = 0x03;
+
+	// Cast temp buffer to final result
+	buffer = (uint16_t *)descriptorStringBuffer;
+
+	return size;
+}


### PR DESCRIPTION
This cleans the MPG instance from GP2040-CE, using the same code as MPG had but removing the extra layer.

We still need to clean this code as its pretty messy and has WAY too many inlines and statics, but this is the first step!