### PR TITLE
Add compiler warning -Wtype-limits, fix comparison bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,8 @@ FetchContent_MakeAvailable(ArduinoJson)
 pico_sdk_init()
 add_subdirectory(lib)
 
+add_compile_options(-Wtype-limits)
+
 add_executable(${PROJECT_NAME}
 src/main.cpp
 src/gp2040.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,6 @@ FetchContent_MakeAvailable(ArduinoJson)
 pico_sdk_init()
 add_subdirectory(lib)
 
-add_compile_options(-Wtype-limits)
-
 add_executable(${PROJECT_NAME}
 src/main.cpp
 src/gp2040.cpp
@@ -168,6 +166,7 @@ target_include_directories(${PROJECT_NAME}  PRIVATE
 pico_add_extra_outputs(${PROJECT_NAME})
 
 add_compile_options(-Wall
+        -Wtype-limits
         -Wno-format          # int != int32_t as far as the compiler is concerned because gcc has int32_t as long int
         -Wno-unused-function # we have some for the docs that aren't called
         -Wno-maybe-uninitialized

--- a/src/addons/turbo.cpp
+++ b/src/addons/turbo.cpp
@@ -92,7 +92,7 @@ void TurboInput::read(AddonOptions & options)
     if ( options.shmupMode == 1 ) {
         chargeState = 0;
         for (uint8_t i = 0; i < 4; i++) {
-            if ( shmupBtnPin[i] != -1 ) { // if pin, get the GPIO
+            if ( shmupBtnPin[i] != (uint8_t)-1 ) { // if pin, get the GPIO
                 chargeState |= (!gpio_get(shmupBtnPin[i]) ? shmupBtnMask[i] : 0);
             }
         }


### PR DESCRIPTION
This fixes one more `(uint8_t)val != -1` bug that wasn't caught before v0.6.3.

I also added a compiler warning flag `-Wtype-limits`, to help prevent this category of bug from recurring in the future. This warning flag emitted one warning with my bugfix commit reverted, and otherwise adds zero new warnings.

- `-Wtype-limits` is my favorite compiler warning not enabled in `-Wall -Wextra`; it's good (not perfect) at catching unsigned int bugs, and has never raised a false positive warning in all my use so far.
- [ ] Do you want to merge this warning or not? (I placed it in its own commit, so it can be dropped independently, or reverted until you merge it with the existing `add_compile_options` call.)

## Fixing comparisons with -1

I find casting -1 to uint8_t to be ~~quite a messy way~~ of testing a variable for "not present". Alternatives include:

- Leave it as-is, and rely on compiler warnings to catch missing casts.
- replace with `std::optional` (takes up 2 bytes of RAM, might break web configurator?)
- switching variables to signed `int8_t` (hopefully fine for GPIO pin numbers, since they're always < 32? not sure if the Pico GPIO APIs expect `uint8_t` always)
- Replace comparisons with `template<typename T> isInvalid(T x) { return x == (T)-1; }`

All options have their own pros and cons.

## Properly enabling compiler warnings

CMakeLists.txt already has a `add_compile_options` call, but since it's placed *after* `add_executable`, it isn't actually passed to the compiler. You can add any warnings to the old call, nothing takes effect, adding `-Wbepis` (not a valid warning) doesn't trigger a CMake rebuild and forcing a rebuild doesn't even make the compiler bat an eye.

If you move the existing call up in the file (or replace it with `target_compile_options`), suddenly you get 110 warnings that need to be fixed or silenced. This will be done in a separate PR since it creates so much warning noise. Unfortuately it causes a CMakeLists.txt conflict, so I'll have to open the PR after this one is merged.

In my personal projects I also like to add `-Wconversion -Wsign-conversion` to my code, and sometimes to dependencies as well. However this has false positives, requiring you edit the source code with explicit casts or silence the warnings selectively.