### PR TITLE
Disable turbo by default

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -34,7 +34,7 @@
 #define PIN_BUTTON_R3   19          // R3 / RS / RS / R3 / 12 / RS
 #define PIN_BUTTON_A1   20          // A1 / Guide / Home / PS / 13 / ~
 #define PIN_BUTTON_A2   21          // A2 / ~ / Capture / ~ / 14 / ~
-#define PIN_BUTTON_TURBO 14         // Turbo
+#define PIN_BUTTON_TURBO -1         // Turbo
 #define PIN_BUTTON_REVERSE -1       // UDLR Reverse
 #define PIN_SLIDER_LS    -1         // Left Stick Slider
 #define PIN_SLIDER_RS    -1         // Right Stick Slider
@@ -72,8 +72,7 @@
 // The default LEDS_[BUTTON] is an order and has nothing to do with what GPIO pin something is connected to.
 // Unless you are planning on running custom animations I would recommmend you leave this as is.
 
-#define TURBO_ENABLED 1
-#define TURBO_LED_PIN 15
+#define TURBO_LED_PIN -1
 
 #define BOARD_LEDS_PIN 28
 

--- a/configs/PicoAnn/BoardConfig.h
+++ b/configs/PicoAnn/BoardConfig.h
@@ -33,7 +33,7 @@
 #define PIN_BUTTON_R3     22        // R3 / RS / RS / R3 / 12 / RS
 #define PIN_BUTTON_A1     4         // A1 / Guide / Home / PS / 13 / ~
 #define PIN_BUTTON_A2     20        // A2 / ~ / Capture / ~ / 14 / ~
-#define PIN_BUTTON_TURBO  28        // Turbo
+#define PIN_BUTTON_TURBO  -1        // Turbo
 #define PIN_BUTTON_REVERSE -1       // UDLR Reverse
 #define PIN_SLIDER_LS    -1         // Left Stick Slider
 #define PIN_SLIDER_RS    -1         // Right Stick Slider
@@ -73,8 +73,7 @@
 // The default LEDS_[BUTTON] is an order and has nothing to do with what GPIO pin something is connected to.
 // Unless you are planning on running custom animations I would recommmend you leave this as is.
 
-#define TURBO_ENABLED 1
-#define TURBO_LED_PIN 25
+#define TURBO_LED_PIN -1
 
 #define BOARD_LEDS_PIN 15
 

--- a/configs/SparkFunProMicro/BoardConfig.h
+++ b/configs/SparkFunProMicro/BoardConfig.h
@@ -31,7 +31,7 @@
 #define PIN_BUTTON_A1 7    // A1 / Guide / Home    / PS       / 13 / ~
 #define PIN_BUTTON_A2 8    // A2 / ~     / Capture / ~        / 14 / ~
 #define PIN_BUTTON_REVERSE -1 // UDLR Reverse
-#define PIN_BUTTON_TURBO 9 // Turbo
+#define PIN_BUTTON_TURBO -1 // Turbo
 #define PIN_SLIDER_LS -1   // Left Stick Slider
 #define PIN_SLIDER_RS -1   // Right Stick Slider
 
@@ -66,8 +66,7 @@
 // The default LEDS_[BUTTON] is an order and has nothing to do with what GPIO pin something is connected to.
 // Unless you are planning on running custom animations I would recommmend you leave this as is.
 
-#define TURBO_ENABLED 1
-#define TURBO_LED_PIN 17
+#define TURBO_LED_PIN -1
 
 #define BOARD_LEDS_PIN 16
 

--- a/configs/WaveshareZero/BoardConfig.h
+++ b/configs/WaveshareZero/BoardConfig.h
@@ -33,7 +33,7 @@
 #define PIN_BUTTON_R3   27          // R3 / RS / RS / R3 / 12 / RS
 #define PIN_BUTTON_A1   14          // A1 / Guide / Home / PS / 13 / ~
 #define PIN_BUTTON_A2   15          // A2 / ~ / Capture / ~ / 14 / ~
-#define PIN_BUTTON_TURBO 29         // Turbo
+#define PIN_BUTTON_TURBO -1         // Turbo
 #define PIN_BUTTON_REVERSE -1       // UDLR Reverse
 #define PIN_SLIDER_LS    -1         // Left Stick Slider
 #define PIN_SLIDER_RS    -1         // Right Stick Slider
@@ -73,7 +73,6 @@
 // The default LEDS_[BUTTON] is an order and has nothing to do with what GPIO pin something is connected to.
 // Unless you are planning on running custom animations I would recommmend you leave this as is.
 
-#define TURBO_ENABLED 1
 #define TURBO_LED_PIN -1
 
 #define BOARD_LEDS_PIN 28


### PR DESCRIPTION
This PR disables Turbo by default in the following configs:

Pico
PicoAnn
SparkFunProMicro
WaveshareZero
