### PR TITLE
Switch extra button Dpad mask to defines instead of magic numbers

### DIFF
--- a/configs/BentoBox/BoardConfig.h
+++ b/configs/BentoBox/BoardConfig.h
@@ -210,6 +210,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/DURAL/BoardConfig.h
+++ b/configs/DURAL/BoardConfig.h
@@ -210,6 +210,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/FightboardV3/BoardConfig.h
+++ b/configs/FightboardV3/BoardConfig.h
@@ -224,6 +224,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/FightboardV3Mirrored/BoardConfig.h
+++ b/configs/FightboardV3Mirrored/BoardConfig.h
@@ -224,6 +224,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/FlatboxRev4/BoardConfig.h
+++ b/configs/FlatboxRev4/BoardConfig.h
@@ -211,6 +211,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/FlatboxRev5/BoardConfig.h
+++ b/configs/FlatboxRev5/BoardConfig.h
@@ -211,6 +211,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/MavercadeKeebfighter/BoardConfig.h
+++ b/configs/MavercadeKeebfighter/BoardConfig.h
@@ -230,7 +230,8 @@
 // Extra Button Add-on setting
 
 #define EXTRA_BUTTON_ENABLED 1
-#define EXTRA_BUTTON_MASK (1U << 14) // 0 means none, get other mask from GamepadState.h
+#define EXTRA_BUTTON_MASK GAMEPAD_MASK_DU // 0 means none, get other mask from GamepadState.h
+                                          // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN 1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -226,6 +226,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/PicoAnn/BoardConfig.h
+++ b/configs/PicoAnn/BoardConfig.h
@@ -210,6 +210,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/PicoFightingBoard/BoardConfig.h
+++ b/configs/PicoFightingBoard/BoardConfig.h
@@ -223,6 +223,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/SparkFunProMicro/BoardConfig.h
+++ b/configs/SparkFunProMicro/BoardConfig.h
@@ -201,6 +201,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/configs/WaveshareZero/BoardConfig.h
+++ b/configs/WaveshareZero/BoardConfig.h
@@ -210,6 +210,7 @@
 
 // Extra Button Add-on setting
 #define EXTRA_BUTTON_MASK 0 // 0 means none, get other mask from GamepadState.h
+                            // For directions, use GAMEPAD_MASK_DU, GAMEPAD_MASK_DD, GAMEPAD_MASK_DL and GAMEPAD_MASK_DR
 #define EXTRA_BUTTON_PIN -1
 
 #define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -113,7 +113,7 @@ struct AddonOptions {
 	uint8_t analogAdcPinY;
 	uint16_t bootselButtonMap;
 	uint8_t extraButtonPin;
-	uint16_t extraButtonMap;
+	uint32_t extraButtonMap;
 	uint8_t buzzerPin;
 	uint8_t buzzerVolume;
 	uint8_t playerNumber;

--- a/src/addons/extra_button.cpp
+++ b/src/addons/extra_button.cpp
@@ -22,16 +22,16 @@ void ExtraButtonAddon::process() {
 	if (!gpio_get(extraButtonPin)) {
 		if (extraButtonMap > (GAMEPAD_MASK_A2)) {
 			switch (extraButtonMap) {
-				case (1U << 14):
+				case (GAMEPAD_MASK_DU):
 					gamepad->state.dpad |= GAMEPAD_MASK_UP;
 					break;
-				case (1U << 15):
+				case (GAMEPAD_MASK_DD):
 					gamepad->state.dpad |= GAMEPAD_MASK_DOWN;
 					break;
-				case (1U << 16):
+				case (GAMEPAD_MASK_DL):
 					gamepad->state.dpad |= GAMEPAD_MASK_LEFT;
 					break;
-				case (1U << 17):
+				case (GAMEPAD_MASK_DR):
 					gamepad->state.dpad |= GAMEPAD_MASK_RIGHT;
 					break;
 			}


### PR DESCRIPTION
This does away with magic numbers for Dpad related defines in BoardConfig.h.
This also fixes a bug that would have occurred with Right Dpad button.

The defines are located in GamepadState.h and are:

GAMEPAD_MASK_DU
GAMEPAD_MASK_DD
GAMEPAD_MASK_DL
GAMEPAD_MASK_DR