### PR TITLE
Shortcuts and formatting updates for docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ Full results can be found in the [GP2040-CE Firmware Latency Test Results](https
 
 Prebuilt MicroPython `UF2` files are available in the [Releases](https://github.com/OpenStickCommunity/GP2040-CE/releases) section.
 
-The default pinout for GP2040-CE is based on an official RaspBerry Pi Pico. That pinout can be found [HERE](configs/Pico/assets/PinMapping.png).  This can be found in the [Releases](https://github.com/OpenStickCommunity/GP2040-CE/releases) section under Pico.
+The default pinout for GP2040-CE is based on an official RaspBerry Pi Pico. That pinout can be found [HERE](https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/Pico/assets/PinMapping.png).  This can be found in the [Releases](https://github.com/OpenStickCommunity/GP2040-CE/releases) section under Pico.
 
 In addition to the default UF2 we also offer pre-compiled UF2s from community members that have verified operation with their own devices. Some of these additional configurations include:
 
 > * [Pico Fighting Board](https://github.com/FeralAI/GP2040-Config-PicoFightingBoard/)
-> * [Crush Counter](configs/CrushCounter) (formerly the [OSFRD](configs/OSFRD))
 > * [DURAL](configs/DURAL)
-> * [Flatbox Rev 4/Rev 5](configs/FlatboxRev4)
-> * [WaveShare RP2040 Zero](configs/WaveshareZero)
+> * [Flatbox Rev 4](https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/FlatboxRev4)
+> * [Flatbox Rev 5](https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/FlatboxRev5)
+> * [WaveShare RP2040 Zero](https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/WaveshareZero)
 
 The instructions will slightly vary based on your device. These instructions are for a Raspberry Pi Pico.
 
-> If the device has been previously used for something other than GP2040-CE, please flash this file first to clear the on-board storage: [flash_nuke.uf2](docs/downloads/flash_nuke.uf2). After flashing the nuke file, wait a minute for the clear program to run and the RPI-RP2 drive to reappear.
+> If the device has been previously used for something other than GP2040-CE, please flash this file first to clear the on-board storage: [flash_nuke.uf2](https://raw.githubusercontent.com/OpenStickCommunity/GP2040-CE/main/docs/downloads/flash_nuke.uf2). After flashing the nuke file, wait a minute for the clear program to run and the RPI-RP2 drive to reappear.
 
 1. Download the latest `GP2040-CE.uf2` file from the [Releases](https://github.com/OpenStickCommunity/GP2040-CE/releases) section for your board (e.g. `GP2040-CE-PicoFightingBoard_vX.X.X.uf2` for the Raspberry Pi Pico).
 1. Unplug your Pico.
@@ -59,7 +59,7 @@ The instructions will slightly vary based on your device. These instructions are
 
 ## Support
 
-If you would like to discuss features, issues or anything else related to GP2040 please [create an issue](issues/new) or join the [OpenStick GP2040-CE Discord channel](https://discord.gg/k2pxhke7q8).
+If you would like to discuss features, issues or anything else related to GP2040 please [create an issue](https://github.com/OpenStickCommunity/GP2040-CE/issues/new) or join the [OpenStick GP2040-CE Discord channel](https://discord.gg/k2pxhke7q8).
 
 ### Frequently Asked Questions
 

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,5 +1,6 @@
 * [Home](/)
 * [Usage](usage)
 * [GP2040-CE Shortcuts](gp2040-shortcuts)
-* [Configuration](web-configurator)
+* [Web Configurator](web-configurator)
 * [Development](development)
+* [FAQ](https://gp2040-ce.info/#/?id=frequently-asked-questions)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,6 +14,10 @@ GP2040-CE will work on PS4 games that implement support for legacy PS3 controlle
 
 These consoles implement security measures that prevent unauthorized accessories from being used. The process of cracking or bypassing that security may not be legal everywhere. These consoles could be supported in the future if a user-friendly and completely legal implementation method is found.
 
+### Does GP2040-CE support wireless connectivity?
+
+Not yet! But it is being worked on. We're afriad we can't provide any timeline on when support will be implimented into the firmware, or any info regarding latency.
+
 ### Can I use multiple controllers on the same system?
 
 Yes! Each GP2040-CE device is treated as a separate controller. However, you will only be able to run the embedded web configurator on one device at a time.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ These consoles implement security measures that prevent unauthorized accessories
 
 ### Does GP2040-CE support wireless connectivity?
 
-Not yet! But it is being worked on. We're afriad we can't provide any timeline on when support will be implimented into the firmware, or any info regarding latency.
+Not yet! But the team is working on a proof of concept for the Raspberry Pi Pico W.  We cannot provice any timeline on when support will be implimented into the firmware, or any info regarding latency.  Plese also note that the normal Pico configuration will not work on the Pico W.
 
 ### Can I use multiple controllers on the same system?
 

--- a/docs/gp2040-shortcuts.md
+++ b/docs/gp2040-shortcuts.md
@@ -66,3 +66,16 @@ SOCD mode **while the controller is in use by pressing one of the following comb
 
 
 Invert the Y-axis input of the D-pad.  Press <hotkey v-bind:buttons='["S2", "A1", "Right"]'></hotkey>.
+
+## LED Control Kotkeys
+
+| Hotkey | Description |
+| - | - |
+| <hotkey v-bind:buttons='["S1", "S2", "B3"]'></hotkey> | Next Animation |
+| <hotkey v-bind:buttons='["S1", "S2", "B1"]'></hotkey> | Previous Animation |
+| <hotkey v-bind:buttons='["S1", "S2", "B4"]'></hotkey> | Brightness Up |
+| <hotkey v-bind:buttons='["S1", "S2", "B2"]'></hotkey> | Brightness Down |
+| <hotkey v-bind:buttons='["S1", "S2", "R1"]'></hotkey> | LED Parameter Up |
+| <hotkey v-bind:buttons='["S1", "S2", "R2"]'></hotkey> | LED Parameter Down |
+| <hotkey v-bind:buttons='["S1", "S2", "L1"]'></hotkey> | Pressed Parameter Up |
+| <hotkey v-bind:buttons='["S1", "S2", "L2"]'></hotkey> | Pressed Parameter Down |

--- a/docs/gp2040-shortcuts.md
+++ b/docs/gp2040-shortcuts.md
@@ -21,9 +21,14 @@ Select the button labels to be displayed in the usage guide: <label-selector></l
 | A1      | Guide  | Home    | -            | 13           | -      | 9           |
 | A2      | -      | Capture | -            | 14           | -      | F2          |
 
+## Button Input Hotkeys
+
+The RGB LED hotkeys can be found [HERE](https://gp2040-ce.info/#/usage?id=rgb-led-hotkeys).
+
 Home button shortcut if you do not have a Home button - <hotkey v-bind:buttons='["S1", "S2", "Up"]'></hotkey>.
 
 Unlike other controllers, Keyboard gets different keys for directional buttons.
+
 | Direction | Keyboard   |
 | --------- | ---------- |
 | Up        | Up Arrow   |
@@ -61,17 +66,3 @@ SOCD mode **while the controller is in use by pressing one of the following comb
 
 
 Invert the Y-axis input of the D-pad.  Press <hotkey v-bind:buttons='["S2", "A1", "Right"]'></hotkey>.
-
-
-RGB LED hotkeys
-
-| Hotkey | Description |
-| - | - |
-| <hotkey v-bind:buttons='["S1", "S2", "B3"]'></hotkey> | Next Animation |
-| <hotkey v-bind:buttons='["S1", "S2", "B1"]'></hotkey> | Previous Animation |
-| <hotkey v-bind:buttons='["S1", "S2", "B4"]'></hotkey> | Brightness Up |
-| <hotkey v-bind:buttons='["S1", "S2", "B2"]'></hotkey> | Brightness Down |
-| <hotkey v-bind:buttons='["S1", "S2", "R1"]'></hotkey> | LED Parameter Up |
-| <hotkey v-bind:buttons='["S1", "S2", "R2"]'></hotkey> | LED Parameter Down |
-| <hotkey v-bind:buttons='["S1", "S2", "L1"]'></hotkey> | Pressed Parameter Up |
-| <hotkey v-bind:buttons='["S1", "S2", "L2"]'></hotkey> | Pressed Parameter Down |


### PR DESCRIPTION
Changes made on docs pages:

README.md
- Update Pico pinout link - 
https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/Pico/assets/PinMapping.png
- Remove Crush Counter (Configs no longer avalible)
- Update DURAL link
https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/DURAL
- Update Flatbox Rev 4 link
https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/FlatboxRev4
- Update Flatbox Rev 5 link
https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/FlatboxRev5
- Update WaveShare RP2040-Zero link
https://github.com/OpenStickCommunity/GP2040-CE/tree/main/configs/WaveshareZero
- Update flash_nuke.uf2 link
https://raw.githubusercontent.com/OpenStickCommunity/GP2040-CE/main/docs/downloads/flash_nuke.uf2
- Update create an issue link
https://github.com/OpenStickCommunity/GP2040-CE/issues/new

_navbar.md
- Update 'Configuration' to say 'Web Configurator'
- Add shortcut to FAQ on README.md
https://gp2040-ce.info/#/?id=frequently-asked-questions

gp2040-shortcuts.md
- Add title for 'Button Input Hotkeys'
- Remove 'RGB LED hotkeys'section and added link to https://gp2040-ce.info/#/usage?id=rgb-led-hotkeys as it was duplicated.

faq.md
- Add new section regarding wireless connectivity