### PR TITLE
Add a way to get defaults for input and D-Pad mode

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -49,6 +49,8 @@
 // 3 - `SOCD_MODE_SECOND_INPUT_PRIORITY` - This is last priority SOCD.  EG. when you press and hold `up` then press `down` `down` will be registered.
 
 #define DEFAULT_SOCD_MODE SOCD_MODE_NEUTRAL
+#define DEFAULT_INPUT_MODE INPUT_MODE_XINPUT //INPUT_MODE_XINPUT (XInput), INPUT_MODE_SWITCH (Nintendo Switch), INPUT_MODE_HID (D-Input), INPUT_MODE_KEYBOARD (Keyboard)
+#define DEFAULT_DPAD_MODE DPAD_MODE_DIGITAL  //DPAD_MODE_DIGITAL, DPAD_MODE_LEFT_ANALOG, DPAD_MODE_RIGHT_ANALOG, 
 
 // This is the LEDs section.
 // The default `TURBO_LED_PIN` pin is set to `15` ( it is recommended to run through 3V3(OUT) with a resistor)

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -531,13 +531,21 @@ GamepadOptions GamepadStorage::getGamepadOptions()
 	options.checksum = CHECKSUM_MAGIC;
 	if (CRC32::calculate(&options) != lastCRC)
 	{
+		#ifdef DEFAULT_INPUT_MODE
+		options.inputMode = DEFAULT_INPUT_MODE;
+		#else
 		options.inputMode = InputMode::INPUT_MODE_XINPUT; // Default?
+		#endif
+		#ifdef DEFAULT_DPAD_MODE
+		options.dpadMode = DEFAULT_DPAD_MODE;
+		#else
 		options.dpadMode = DpadMode::DPAD_MODE_DIGITAL; // Default?
-#ifdef DEFAULT_SOCD_MODE
+		#endif
+		#ifdef DEFAULT_SOCD_MODE
 		options.socdMode = DEFAULT_SOCD_MODE;
-#else
+		#else
 		options.socdMode = SOCD_MODE_NEUTRAL;
-#endif
+		#endif
 		options.invertXAxis = false;
 		options.invertYAxis = false;
 		options.keyDpadUp    = KEY_DPAD_UP;


### PR DESCRIPTION
This adds a method to define default parameters for Input and D-Pad mode in `BoardConfig.h`, which is optional.
Please accept if we want to support this.