### PR TITLE
assign A2 button to a button event in HID mode

### DIFF
--- a/headers/gamepad/descriptors/HIDDescriptors.h
+++ b/headers/gamepad/descriptors/HIDDescriptors.h
@@ -83,6 +83,7 @@ typedef struct __attribute((packed, aligned(1)))
 	uint8_t r3_btn : 1;
 	
 	uint8_t ps_btn : 1;
+	uint8_t tp_btn : 1;
 //	uint8_t l2_btn_alt : 1;
 	
 //	uint8_t r2_btn_alt : 1;

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -24,7 +24,7 @@ static HIDReport hidReport
 {
 	.square_btn = 0, .cross_btn = 0, .circle_btn = 0, .triangle_btn = 0,
 	.l1_btn = 0, .r1_btn = 0, .l2_btn = 0, .r2_btn = 0,
-	.select_btn = 0, .start_btn = 0, .l3_btn = 0, .r3_btn = 0, .ps_btn = 0,
+	.select_btn = 0, .start_btn = 0, .l3_btn = 0, .r3_btn = 0, .ps_btn = 0, .tp_btn = 0,
 	.direction = 0x08,
 	.l_x_axis = 0x80, .l_y_axis = 0x80, .r_x_axis = 0x80, .r_y_axis = 0x80,
 	.right_axis = 0x00, .left_axis = 0x00, .up_axis = 0x00, .down_axis = 0x00,
@@ -362,7 +362,7 @@ HIDReport *Gamepad::getHIDReport()
 	hidReport.l3_btn       = pressedL3();
 	hidReport.r3_btn       = pressedR3();
 	hidReport.ps_btn       = pressedA1();
-//	hidReport.cross_btn = pressedA2();
+	hidReport.tp_btn       = pressedA2();
 
 	hidReport.l_x_axis = static_cast<uint8_t>(state.lx >> 8);
 	hidReport.l_y_axis = static_cast<uint8_t>(state.ly >> 8);


### PR DESCRIPTION
we declare 14 buttons (all active in Switch mode), but D-Input mode only declares 13 input descriptors and ignores the A2 event. this button won't do anything on a PS3, but Linux (or MiSTer, etc.) could use this button for something.

"tp" name chosen by PlayStation convention, since on a DS4 the touchpad registers as button 14.