### PR TITLE
Add SOCD First Input Priority to hotkeys list

### DIFF
--- a/headers/gamepad/GamepadEnums.h
+++ b/headers/gamepad/GamepadEnums.h
@@ -59,4 +59,5 @@ typedef enum
 	HOTKEY_SOCD_LAST_INPUT   = (1U << 7),
 	HOTKEY_INVERT_X_AXIS     = (1U << 8),
 	HOTKEY_INVERT_Y_AXIS     = (1U << 9),
+	HOTKEY_SOCD_FIRST_INPUT  = (1U << 10),
 } GamepadHotkey;

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -257,6 +257,7 @@ GamepadHotkey Gamepad::hotkey()
 		case HOTKEY_SOCD_UP_PRIORITY  : options.socdMode = SOCD_MODE_UP_PRIORITY; break;
 		case HOTKEY_SOCD_NEUTRAL      : options.socdMode = SOCD_MODE_NEUTRAL; break;
 		case HOTKEY_SOCD_LAST_INPUT   : options.socdMode = SOCD_MODE_SECOND_INPUT_PRIORITY; break;
+		case HOTKEY_SOCD_FIRST_INPUT  : options.socdMode = SOCD_MODE_FIRST_INPUT_PRIORITY; break;
 		case HOTKEY_INVERT_X_AXIS     : break;
 		case HOTKEY_INVERT_Y_AXIS     :
 			if (lastAction != HOTKEY_INVERT_Y_AXIS)


### PR DESCRIPTION
With the addition of the First Input Priority SOCD type, the hotkeys configuration list also needs to be updated. This PR addresses that.

Please review and merge, thank you!