### PR TITLE
Add reference to an optional custom CMake script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ configs/MyBoard
 build/
 
 lib/httpd/fsdata.c
+modules/Custom.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ else()
   include(${CMAKE_SOURCE_DIR}/modules/FindNPM.cmake)
   if(NODEJS_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/www")
     if(NPM_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/www/package.json")
-      execute_process(COMMAND ${NPM_EXECUTABLE} ci 
+      execute_process(COMMAND ${NPM_EXECUTABLE} ci
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/www
                       RESULT_VARIABLE NPM_CI_RESULT)
       if(NOT NPM_CI_RESULT EQUAL "0")
@@ -130,7 +130,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}_${C
 pico_set_program_name(GP2040-CE "GP2040-CE")
 pico_set_program_version(GP2040-CE "0.6.3")
 
-target_link_libraries(${PROJECT_NAME} 
+target_link_libraries(${PROJECT_NAME}
 pico_stdlib
 pico_bootsel_via_double_reset
 AnimationStation
@@ -177,3 +177,7 @@ add_compile_options(-Wall
     ${CMAKE_CURRENT_LIST_DIR}/README.md
     DESTINATION .
 )
+
+if (NOT (DEFINED ENV(CI)) AND (EXISTS ${CMAKE_SOURCE_DIR}/modules/Custom.cmake))
+	include(${CMAKE_SOURCE_DIR}/modules/Custom.cmake)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,5 +179,6 @@ add_compile_options(-Wall
 )
 
 if (NOT (DEFINED ENV(CI)) AND (EXISTS ${CMAKE_SOURCE_DIR}/modules/Custom.cmake))
+  message(STATUS "Found custom script.")
 	include(${CMAKE_SOURCE_DIR}/modules/Custom.cmake)
 endif()


### PR DESCRIPTION
It would be nice to run certain commands before or after the build. This PR adds a reference to an optional file which only gets called in a non-CI environment.

Please review if this addition is OK. Thanks!