### PR TITLE
Fix addon web data truncation via payload limit

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -49,7 +49,7 @@
 #endif
 #define API_REBOOT "/api/reboot"
 
-#define LWIP_HTTPD_POST_MAX_PAYLOAD_LEN 2048
+#define LWIP_HTTPD_POST_MAX_PAYLOAD_LEN 4096
 
 using namespace std;
 


### PR DESCRIPTION
This solves some addons settings data from being truncated as the payload size for it has gotten significantly larger due to recent development.

This has also been reported here: https://github.com/OpenStickCommunity/GP2040-CE/issues/196

Besides this, better and future-proof solution to this would be to only send what has been changed instead of every field.