### PR TITLE
Fix for gamepad descriptors in PS4.

### DIFF
--- a/headers/gamepad/GamepadDescriptors.h
+++ b/headers/gamepad/GamepadDescriptors.h
@@ -167,6 +167,7 @@ static const uint16_t *getStringDescriptor(uint16_t *size, InputMode mode, uint8
 
 			case INPUT_MODE_PS4:
 				str = (char *)ps4_string_descriptors[index];
+				break;
 
 			default:
 				str = (char *)hid_string_descriptors[index];


### PR DESCRIPTION
Quick fix for gamepad descriptors