### PR TITLE
Send only changed values in Addons page to the board

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -51,6 +51,9 @@
 
 #define LWIP_HTTPD_POST_MAX_PAYLOAD_LEN 4096
 
+#define docToPin(pin,name) if (doc.containsKey(name)) { pin = doc[name] == -1 ? 0xFF : doc[name]; }
+#define docToValue(pin,name) if (doc.containsKey(name)) { pin = doc[name]; }
+
 using namespace std;
 
 extern struct fsdata_file file__index_html[];
@@ -586,70 +589,70 @@ std::string setAddonOptions()
 	DynamicJsonDocument doc = get_post_data();
 
 	AddonOptions addonOptions = Storage::getInstance().getAddonOptions();
-	addonOptions.pinButtonTurbo    	= doc["turboPin"] == -1 ? 0xFF : doc["turboPin"];
-	addonOptions.pinTurboLED        = doc["turboPinLED"] == -1 ? 0xFF : doc["turboPinLED"];
-	addonOptions.pinSliderLS  		= doc["sliderLSPin"] == -1 ? 0xFF : doc["sliderLSPin"];
-	addonOptions.pinSliderRS  		= doc["sliderRSPin"] == -1 ? 0xFF : doc["sliderRSPin"];
-	addonOptions.pinSliderSOCDOne  		= doc["sliderSOCDPinOne"] == -1 ? 0xFF : doc["sliderSOCDPinOne"];
-	addonOptions.pinSliderSOCDTwo    = doc["sliderSOCDPinTwo"] == -1 ? 0xFF : doc["sliderSOCDPinTwo"];
-	addonOptions.turboShotCount 	= doc["turboShotCount"];
-	addonOptions.pinButtonReverse  	= doc["reversePin"] == -1 ? 0xFF : doc["reversePin"];
-	addonOptions.pinReverseLED  	= doc["reversePinLED"] == -1 ? 0xFF : doc["reversePinLED"];
-	addonOptions.reverseActionUp  	= doc["reverseActionUp"] == -1 ? 0xFF : doc["reverseActionUp"];
-	addonOptions.reverseActionDown  = doc["reverseActionDown"] == -1 ? 0xFF : doc["reverseActionDown"];
-	addonOptions.reverseActionLeft  = doc["reverseActionLeft"] == -1 ? 0xFF : doc["reverseActionLeft"];
-	addonOptions.reverseActionRight = doc["reverseActionRight"] == -1 ? 0xFF : doc["reverseActionRight"];
-	addonOptions.i2cAnalog1219SDAPin = doc["i2cAnalog1219SDAPin"] == -1 ? 0xFF : doc["i2cAnalog1219SDAPin"];
-	addonOptions.i2cAnalog1219SCLPin = doc["i2cAnalog1219SCLPin"] == -1 ? 0xFF : doc["i2cAnalog1219SCLPin"];
-	addonOptions.i2cAnalog1219Block = doc["i2cAnalog1219Block"];
-	addonOptions.i2cAnalog1219Speed = doc["i2cAnalog1219Speed"];
-	addonOptions.i2cAnalog1219Address = doc["i2cAnalog1219Address"];
-	addonOptions.onBoardLedMode = doc["onBoardLedMode"];
-	addonOptions.pinDualDirDown 	= doc["dualDirDownPin"] == -1 ? 0xFF : doc["dualDirDownPin"];
-	addonOptions.pinDualDirUp 		= doc["dualDirUpPin"] == -1 ? 0xFF : doc["dualDirUpPin"];
-	addonOptions.pinDualDirLeft 	= doc["dualDirLeftPin"] == -1 ? 0xFF : doc["dualDirLeftPin"];
-	addonOptions.pinDualDirRight 	= doc["dualDirRightPin"] == -1 ? 0xFF : doc["dualDirRightPin"];
-	addonOptions.dualDirDpadMode    = doc["dualDirDpadMode"];
-	addonOptions.dualDirCombineMode = doc["dualDirCombineMode"];
-	addonOptions.analogAdcPinX = doc["analogAdcPinX"] == -1 ? 0xFF : doc["analogAdcPinX"];
-	addonOptions.analogAdcPinY = doc["analogAdcPinY"] == -1 ? 0xFF : doc["analogAdcPinY"];
-	addonOptions.bootselButtonMap = doc["bootselButtonMap"];
-	addonOptions.buzzerPin        = doc["buzzerPin"] == -1 ? 0xFF : doc["buzzerPin"];
-	addonOptions.buzzerVolume     = doc["buzzerVolume"];
-	addonOptions.extraButtonPin        = doc["extraButtonPin"] == -1 ? 0xFF : doc["extraButtonPin"];
-	addonOptions.extraButtonMap = doc["extraButtonMap"];
-	addonOptions.playerNumber     = doc["playerNumber"];
-	addonOptions.shmupMode     = doc["shmupMode"];
-	addonOptions.shmupMixMode     = doc["shmupMixMode"];
-	addonOptions.shmupAlwaysOn1     = doc["shmupAlwaysOn1"];
-	addonOptions.shmupAlwaysOn2     = doc["shmupAlwaysOn2"];
-	addonOptions.shmupAlwaysOn3     = doc["shmupAlwaysOn3"];
-	addonOptions.shmupAlwaysOn4     = doc["shmupAlwaysOn4"];
-	addonOptions.pinShmupBtn1     = doc["pinShmupBtn1"] == -1 ? 0xFF : doc["pinShmupBtn1"];
-	addonOptions.pinShmupBtn2     = doc["pinShmupBtn2"] == -1 ? 0xFF : doc["pinShmupBtn2"];
-	addonOptions.pinShmupBtn3     = doc["pinShmupBtn3"] == -1 ? 0xFF : doc["pinShmupBtn3"];
-	addonOptions.pinShmupBtn4     = doc["pinShmupBtn4"] == -1 ? 0xFF : doc["pinShmupBtn4"];
-	addonOptions.shmupBtnMask1     = doc["shmupBtnMask1"];
-	addonOptions.shmupBtnMask2     = doc["shmupBtnMask2"];
-	addonOptions.shmupBtnMask3     = doc["shmupBtnMask3"];
-	addonOptions.shmupBtnMask4     = doc["shmupBtnMask4"];
-	addonOptions.pinShmupDial     = doc["pinShmupDial"] == -1 ? 0xFF : doc["pinShmupDial"];
-	addonOptions.sliderSOCDModeOne     = doc["sliderSOCDModeOne"];
-	addonOptions.sliderSOCDModeTwo     = doc["sliderSOCDModeTwo"];
-	addonOptions.sliderSOCDModeDefault     = doc["sliderSOCDModeDefault"];
-	addonOptions.AnalogInputEnabled = doc["AnalogInputEnabled"];
-	addonOptions.BoardLedAddonEnabled = doc["BoardLedAddonEnabled"];
-	addonOptions.BuzzerSpeakerAddonEnabled = doc["BuzzerSpeakerAddonEnabled"];
-	addonOptions.BootselButtonAddonEnabled = doc["BootselButtonAddonEnabled"];
-	addonOptions.DualDirectionalInputEnabled = doc["DualDirectionalInputEnabled"];
-	addonOptions.ExtraButtonAddonEnabled = doc["ExtraButtonAddonEnabled"];
-	addonOptions.I2CAnalog1219InputEnabled = doc["I2CAnalog1219InputEnabled"];
-	addonOptions.JSliderInputEnabled = doc["JSliderInputEnabled"];
-	addonOptions.SliderSOCDInputEnabled = doc["SliderSOCDInputEnabled"];
-	addonOptions.PlayerNumAddonEnabled = doc["PlayerNumAddonEnabled"];
-	addonOptions.PS4ModeAddonEnabled = doc["PS4ModeAddonEnabled"];
-	addonOptions.ReverseInputEnabled = doc["ReverseInputEnabled"];
-	addonOptions.TurboInputEnabled = doc["TurboInputEnabled"];
+	docToPin(addonOptions.pinButtonTurbo, "turboPin")
+	docToPin(addonOptions.pinTurboLED, "turboPinLED")
+	docToPin(addonOptions.pinSliderLS, "sliderLSPin")
+	docToPin(addonOptions.pinSliderRS, "sliderRSPin")
+	docToPin(addonOptions.pinSliderSOCDOne, "sliderSOCDPinOne")
+	docToPin(addonOptions.pinSliderSOCDTwo, "sliderSOCDPinTwo")
+	docToValue(addonOptions.turboShotCount, "turboShotCount")
+	docToPin(addonOptions.pinButtonReverse, "reversePin")
+	docToPin(addonOptions.pinReverseLED, "reversePinLED")
+	docToPin(addonOptions.reverseActionUp, "reverseActionUp")
+	docToPin(addonOptions.reverseActionDown, "reverseActionDown")
+	docToPin(addonOptions.reverseActionLeft, "reverseActionLeft")
+	docToPin(addonOptions.reverseActionRight, "reverseActionRight")
+	docToPin(addonOptions.i2cAnalog1219SDAPin, "i2cAnalog1219SDAPin")
+	docToPin(addonOptions.i2cAnalog1219SCLPin, "i2cAnalog1219SCLPin")
+	docToValue(addonOptions.i2cAnalog1219Block, "i2cAnalog1219Block")
+	docToValue(addonOptions.i2cAnalog1219Speed, "i2cAnalog1219Speed")
+	docToValue(addonOptions.i2cAnalog1219Address, "i2cAnalog1219Address")
+	docToValue(addonOptions.onBoardLedMode, "onBoardLedMode")
+	docToPin(addonOptions.pinDualDirDown, "dualDirDownPin")
+	docToPin(addonOptions.pinDualDirUp, "dualDirUpPin")
+	docToPin(addonOptions.pinDualDirLeft, "dualDirLeftPin")
+	docToPin(addonOptions.pinDualDirRight, "dualDirRightPin")
+	docToValue(addonOptions.dualDirDpadMode, "dualDirDpadMode")
+	docToValue(addonOptions.dualDirCombineMode, "dualDirCombineMode")
+	docToPin(addonOptions.analogAdcPinX, "analogAdcPinX")
+	docToPin(addonOptions.analogAdcPinY, "analogAdcPinY")
+	docToValue(addonOptions.bootselButtonMap, "bootselButtonMap")
+	docToPin(addonOptions.buzzerPin, "buzzerPin")
+	docToValue(addonOptions.buzzerVolume, "buzzerVolume")
+	docToPin(addonOptions.extraButtonPin, "extraButtonPin")
+	docToValue(addonOptions.extraButtonMap, "extraButtonMap")
+	docToValue(addonOptions.playerNumber, "playerNumber")
+	docToValue(addonOptions.shmupMode, "shmupMode")
+	docToValue(addonOptions.shmupMixMode, "shmupMixMode")
+	docToValue(addonOptions.shmupAlwaysOn1, "shmupAlwaysOn1")
+	docToValue(addonOptions.shmupAlwaysOn2, "shmupAlwaysOn2")
+	docToValue(addonOptions.shmupAlwaysOn3, "shmupAlwaysOn3")
+	docToValue(addonOptions.shmupAlwaysOn4, "shmupAlwaysOn4")
+	docToPin(addonOptions.pinShmupBtn1, "pinShmupBtn1")
+	docToPin(addonOptions.pinShmupBtn2, "pinShmupBtn2")
+	docToPin(addonOptions.pinShmupBtn3, "pinShmupBtn3")
+	docToPin(addonOptions.pinShmupBtn4, "pinShmupBtn4")
+	docToValue(addonOptions.shmupBtnMask1, "shmupBtnMask1")
+	docToValue(addonOptions.shmupBtnMask2, "shmupBtnMask2")
+	docToValue(addonOptions.shmupBtnMask3, "shmupBtnMask3")
+	docToValue(addonOptions.shmupBtnMask4, "shmupBtnMask4")
+	docToPin(addonOptions.pinShmupDial, "pinShmupDial")
+	docToValue(addonOptions.sliderSOCDModeOne, "sliderSOCDModeOne")
+	docToValue(addonOptions.sliderSOCDModeTwo, "sliderSOCDModeTwo")
+	docToValue(addonOptions.sliderSOCDModeDefault, "sliderSOCDModeDefault")
+	docToValue(addonOptions.AnalogInputEnabled, "AnalogInputEnabled")
+	docToValue(addonOptions.BoardLedAddonEnabled, "BoardLedAddonEnabled")
+	docToValue(addonOptions.BuzzerSpeakerAddonEnabled, "BuzzerSpeakerAddonEnabled")
+	docToValue(addonOptions.BootselButtonAddonEnabled, "BootselButtonAddonEnabled")
+	docToValue(addonOptions.DualDirectionalInputEnabled, "DualDirectionalInputEnabled")
+	docToValue(addonOptions.ExtraButtonAddonEnabled, "ExtraButtonAddonEnabled")
+	docToValue(addonOptions.I2CAnalog1219InputEnabled, "I2CAnalog1219InputEnabled")
+	docToValue(addonOptions.JSliderInputEnabled, "JSliderInputEnabled")
+	docToValue(addonOptions.SliderSOCDInputEnabled, "SliderSOCDInputEnabled")
+	docToValue(addonOptions.PlayerNumAddonEnabled, "PlayerNumAddonEnabled")
+	docToValue(addonOptions.PS4ModeAddonEnabled, "PS4ModeAddonEnabled")
+	docToValue(addonOptions.ReverseInputEnabled, "ReverseInputEnabled")
+	docToValue(addonOptions.TurboInputEnabled, "TurboInputEnabled")
 
 	Storage::getInstance().setAddonOptions(addonOptions);
 


### PR DESCRIPTION
For any change, big or small, the addons config page sends all of the data to the board, which is inefficient and also caused a recent bug. This PR aims to send only what's updated and the firmware also accounts for fields which have been omitted.

Web-config repo has also been updated for this (https://github.com/OpenStickCommunity/WebConfigurator/pull/55).

Please review and merge, thanks!