### PR TITLE
Fix implementation of Dual Directional Input, Combination Mode None

### DIFF
--- a/src/addons/dualdirectional.cpp
+++ b/src/addons/dualdirectional.cpp
@@ -98,6 +98,11 @@ void DualDirectionalInput::preprocess()
             gamepadState = SOCDGamepadClean(gamepadState, socdMode == SOCD_MODE_SECOND_INPUT_PRIORITY) | dualState;
         }
     }
+    // None Mode (no combination, no overwrite)
+    else if ( combineMode == DUAL_COMBINE_MODE_NONE ) {
+        // just SOCD clean the dual inputs based on the desired mode
+        SOCDDualClean(gamepad->options.socdMode);
+    }
     // Gamepad Overwrite Mode
     else if ( combineMode == DUAL_COMBINE_MODE_GAMEPAD ) {
         if ( gamepadState != 0 && (gamepadState != dualState)) {

--- a/src/addons/dualdirectional.cpp
+++ b/src/addons/dualdirectional.cpp
@@ -121,6 +121,7 @@ void DualDirectionalInput::preprocess()
 
 void DualDirectionalInput::process()
 {
+    const AddonOptions& options = Storage::getInstance().getAddonOptions();
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
     uint8_t dualOut = dualState;
     const SOCDMode& socdMode = getSOCDMode(gamepad->options);
@@ -148,6 +149,17 @@ void DualDirectionalInput::process()
         if ( combineMode == DUAL_COMBINE_MODE_GAMEPAD ) {
             // Set Dual Directional Output
             OverrideGamepad(gamepad, dpadMode, dualOut);
+        }
+        else if (combineMode == DUAL_COMBINE_MODE_NONE) {
+            // Set the configured directional mode to the value of the dual output
+            // if configured dual mode is the same mode as the gamepad mode, they
+            // need to be SOCD cleaned first
+            // this also avoids accidentally masking gamepad inputs with the lack of dual inputs
+            if (gamepad->options.dpadMode == options.dualDirDpadMode) {
+                uint8_t gamepadDpad = gpadToBinary(gamepad->options.dpadMode, gamepad->state);
+                dualOut = SOCDGamepadClean(dualOut | gamepadDpad, gamepad->options.socdMode == SOCD_MODE_SECOND_INPUT_PRIORITY);
+            }
+            OverrideGamepad(gamepad, options.dualDirDpadMode, dualOut);
         }
     }
 }


### PR DESCRIPTION
This fixes/implements Combination Mode "None" behavior for the Dual Directional Input add-on. It allows for an essentially distinct set of directional inputs that acts independently (mostly) from the "normal" set of directional inputs. For example, if the normal D-Pad Mode is set to Left Stick, and Dual D-Pad Mode is set to D-Pad, you can register them as two separate axes/hats simultaneously. The DDI inputs are SOCD cleaned as per the board's setting, again independently from the normal input's readings.

To avoid one set of inputs masking the other, when normal and dual D-Pad are set to the *same* mode, as in both are for example in D-Pad mode, they are bitwise ORed together and SOCD cleaned in tandem. Without the bitwise OR, the DDI D-Pad would overwrite whatever was registered on the normal D-Pad, and without the SOCD cleaner, the resultant behavior would always be neutral SOCD cleaning. (The behavior is basically the same as Mixed mode, except it's only Mixed for when both inputs are on the same D-Pad Mode, rather than applying the mix to any D-Pad Mode.)

This might make sense best as follows (numbers in parenthesis are the order in which they're pressed for Last Input Wins mode):

## D-Pad Mode Left Stick, Dual D-Pad Mode D-Pad, SOCD Cleaner Last Input Wins, Combination Mode None

```
| Normal Directional Input | Dual Directional Input | Controller Reading |
--------------------------------------------------------------------------
| Left                     | Left                   | LS Left, DP Left   |
| Left                     | Up                     | LS Left, DP Up     |
| Up                       | Down                   | LS Up, DP Down     |
| Up (1), Down (2)         | Down                   | LS Down, DP Down   |
```
and so on.

A smarter person than me will probably come up with some bizarre tech you can do with two sets of inputs registering this way, maybe by pianoing stuff:

## D-Pad Mode D-Pad, Dual D-Pad Mode D-Pad, SOCD Cleaner Last Input Wins, Combination Mode None

```
| Normal Directional Input | Dual Directional Input | Controller Reading |
--------------------------------------------------------------------------
| Left                     | Left                   | DP Left            |
| Left                     | Up                     | DP Left, DP Up     |
| Left (1)                 | Right (2)              | DP Right           |
| Left (1), Right (3)      | Right (2)              | DP Right           |
| Left (1), Right (2)      | Left (3)               | DP Left            |
```
and so on.

Anyway, this accomplishes what I wanted, which was the ability to have two input types, a LS and DP simultaneously, while still having the option to have the D-Pad Mode selector choose a mode for one of those input types. I haven't done any in-game testing with this yet but it all registers as expected in a joystick tester (D-Input mode).