### PR TITLE
Stack optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,17 @@ FetchContent_MakeAvailable(ArduinoJson)
 pico_sdk_init()
 add_subdirectory(lib)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # Activate some compiler / linker options to aid us with diagnosing stack space issues in Debug builds
+  add_compile_options(-fstack-usage)
+  add_compile_definitions(PICO_USE_STACK_GUARDS=1)
+endif()
+
+# We want a larger stack of 4kb per core instead of the default 2kb
+add_compile_definitions(PICO_STACK_SIZE=0x1000)
+
+add_compile_options(-Wstack-usage=500)
+
 add_executable(${PROJECT_NAME}
 src/main.cpp
 src/gp2040.cpp
@@ -125,8 +136,6 @@ src/addons/slider_socd.cpp
 src/gamepad/GamepadDebouncer.cpp
 src/gamepad/GamepadDescriptors.cpp
 )
-
-add_compile_definitions(PICO_STACK_SIZE=0x1000)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME}_${CMAKE_PROJECT_VERSION}_${GP2040_BOARDCONFIG})
 

--- a/headers/configmanager.h
+++ b/headers/configmanager.h
@@ -19,7 +19,7 @@ public:
     void setBoardOptions(BoardOptions);
     void setPreviewBoardOptions(BoardOptions);
     void setLedOptions(LEDOptions);
-    void setSplashImage(SplashImage);
+    void setSplashImage(const SplashImage&);
 private:
     ConfigManager() {}
     void setupConfig(GPConfig*);

--- a/headers/configs/base64.h
+++ b/headers/configs/base64.h
@@ -70,7 +70,7 @@ class Base64 {
     return ret;
   }
 
-  static std::string Decode(const std::string& input, std::string& out) {
+  static bool Decode(const std::string& input, std::string& out) {
     static constexpr unsigned char kDecodingTable[] = {
       64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
       64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
@@ -91,7 +91,11 @@ class Base64 {
     };
 
     size_t in_len = input.size();
-    if (in_len % 4 != 0) return "Input data size is not a multiple of 4";
+    if (in_len % 4 != 0)
+    {
+      out.clear();
+      return false;
+    }
 
     size_t out_len = in_len / 4 * 3;
     if (input[in_len - 1] == '=') out_len--;
@@ -112,7 +116,7 @@ class Base64 {
       if (j < out_len) out[j++] = (triple >> 0 * 8) & 0xFF;
     }
 
-    return "";
+    return true;
   }
 
 };

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -231,7 +231,7 @@ public:
 	void setAddonOptions(AddonOptions); // Add-On Options
 	const AddonOptions& getAddonOptions() { return addonOptions; }
 
-	void setSplashImage(SplashImage);
+	void setSplashImage(const SplashImage&);
 	const SplashImage& getSplashImage() { return splashImage; }
 
 	void setLEDOptions(LEDOptions);		// LED Options

--- a/headers/themes.h
+++ b/headers/themes.h
@@ -284,7 +284,7 @@ static map<uint32_t, RGB> themeFightboard({
 static map<uint32_t, RGB> customTheme;
 static map<uint32_t, RGB> customThemePressed;
 
-void addStaticThemes(LEDOptions options, AnimationOptions animationOptions)
+void addStaticThemes(const LEDOptions& options, const AnimationOptions& animationOptions)
 {
 	// Rainbow theme on a Stickless layout should use green for up button
 	themeStaticRainbow[GAMEPAD_MASK_DU] = (options.ledLayout == BUTTON_LAYOUT_STICKLESS) ? ColorGreen : ColorOrange;

--- a/lib/AnimationStation/src/Effects/StaticTheme.cpp
+++ b/lib/AnimationStation/src/Effects/StaticTheme.cpp
@@ -32,14 +32,6 @@ void StaticTheme::Animate(RGB (&frame)[100]) {
   }
 }
 
-void StaticTheme::AddTheme(std::map<uint32_t, RGB> theme) {
-  themes.push_back(theme);
-}
-
-void StaticTheme::ClearThemes() {
-  themes.clear();
-}
-
 void StaticTheme::ParameterUp() {
   if (AnimationStation::options.themeIndex < StaticTheme::themes.size() - 1) {
     AnimationStation::options.themeIndex++;

--- a/lib/AnimationStation/src/Effects/StaticTheme.hpp
+++ b/lib/AnimationStation/src/Effects/StaticTheme.hpp
@@ -15,8 +15,8 @@ public:
   StaticTheme(PixelMatrix &matrix);
   ~StaticTheme() {};
 
-  static void AddTheme(std::map<uint32_t, RGB> theme);
-  static void ClearThemes();
+  static void AddTheme(const std::map<uint32_t, RGB>& theme) { themes.push_back(theme); }
+  static void ClearThemes() { themes.clear(); }
   void Animate(RGB (&frame)[100]);
   void ParameterUp();
   void ParameterDown();

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -60,6 +60,6 @@ void ConfigManager::setPreviewBoardOptions(BoardOptions boardOptions) {
 	Storage::getInstance().setPreviewBoardOptions(boardOptions);
 }
 
-void ConfigManager::setSplashImage(SplashImage image) {
+void ConfigManager::setSplashImage(const SplashImage& image) {
 	Storage::getInstance().setSplashImage(image);
 }

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -329,13 +329,14 @@ std::string getSplashImage()
 	return serialize_json(doc);
 }
 
-std::string setSplashImage() // Expects 16 chunked requests because
-{							 // it can't handle all the payload at once
+std::string setSplashImage()
+{
 	DynamicJsonDocument doc = get_post_data();
 	std::string decoded;
 	std::string base64String = doc["splashImage"];
 	Base64::Decode(base64String, decoded);
 	memcpy(splashImageTemp.data, decoded.data(), decoded.length());
+	splashImageTemp.checksum = CHECKSUM_MAGIC;
 	ConfigManager::getInstance().setSplashImage(splashImageTemp);
 
 	return serialize_json(doc);

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -230,15 +230,19 @@ void Storage::setDefaultSplashImage()
 	setSplashImage(splashImage);
 }
 
-void Storage::setSplashImage(SplashImage image)
+void Storage::setSplashImage(const SplashImage& image)
 {
 	if (memcmp(&splashImage, &image, sizeof(SplashImage)) != 0)
 	{
-		image.checksum = CHECKSUM_MAGIC; // set checksum to magic number
-		image.checksum = CRC32::calculate(&image);
-		EEPROM.set(SPLASH_IMAGE_STORAGE_INDEX, image);
-		EEPROM.commit();
 		memcpy(&splashImage, &image, sizeof(SplashImage));
+		splashImage.checksum = CHECKSUM_MAGIC; // set checksum to magic number
+		splashImage.checksum = CRC32::calculate(&splashImage);
+
+		EEPROM.set(SPLASH_IMAGE_STORAGE_INDEX, splashImage);
+		EEPROM.commit();
+
+		// Reset, so that the memcmp gives the correct result on the next call to this function
+		splashImage.checksum = CHECKSUM_MAGIC;
 	}
 }
 

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -13,7 +13,6 @@
 #include "hardware/watchdog.h"
 #include "Animation.hpp"
 #include "CRC32.h"
-#include <sstream>
 
 #include "addons/analog.h"
 #include "addons/board_led.h"


### PR DESCRIPTION
I have optimized the stack usage of a lot of functions, as we were having issues with stack overflows recently.

These are the functions I have optimized:
| Function | Stack usage before | Stack usage after |
|---|--:|--:|
|`fp_open_custom()` | 528 | 48 |
|`setCustomTheme()` | 1680 | 424 |
|`getCustomTheme()` | 1696 | 376 |
|`setDisplayOptions()` | 1288 | 272 |
|`getDisplayOptions()` | 1272 | 128 |
|`setLedOptions()` | 1856 | 248 |
|`getLedOptions()` | 1048 | 80 |
|`setAddonOptions()` | 1600 | 240 |
|`getAddonOptions()` | 1104 | 176 |
|`getGamepadOptions()` | 704 | 208 |
|`setGamepadOptions()` | 760 | 128 |
|`setSplashImage()` | 1184 | 168 |
|`setPS4Options()` | 896 | 128 |
|`setPinMappings()` | 616 | 328 |
|`addStaticThemes()` | 864 | 384 |
| `Storage::setDefaultSplashImage()` | 1032 | 16 |
| `ConfigManager::setSplashImage()` | 1032 |8 |

This should give us a lot more stack space headroom especially in webconfig mode.

Also, I have enabled `PICO_USE_STACK_GUARDS` in Debug builds to make it easier to find and diagnose stack overflows.