### PR TITLE
Escape release notes headers from showing up

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -32,6 +32,12 @@
 	<script src="//cdn.jsdelivr.net/npm/prismjs@1.x/components/prism-ini.min.js"></script>
 
 	<script>
+		const renderer = {
+			heading(text, level) {
+				return `<h3>${text}</h3>`;
+			}
+		};
+
 		window.$docsify = {
 			name: 'GP2040-CE',
 			repo: 'https://github.com/OpenStickCommunity/GP2040-CE',
@@ -231,8 +237,9 @@
 						<div v-html="body"></div>
 					`,
 					data() {
+						marked.use({ renderer })
 						return {
-							body: marked.parse(this.$root.releaseNotes ? "## Release Notes\r\n" + this.$root.releaseNotes : ""),
+							body: marked.parse(this.$root.releaseNotes ? "---\r\n## Release Notes\r\n" + this.$root.releaseNotes : ""),
 						}
 					},
 				},


### PR DESCRIPTION
Release notes from the Github releases API were causing the notes sections to be displayed in sidebar, which may be unwanted and are causing layout inconsistencies.

In the following image, the sub-sections are not part of the `Installation` page.

![image](https://user-images.githubusercontent.com/77402236/236999706-f75b9f4d-46a0-4f34-8f7e-51ea5ca257cc.png)
