### PR TITLE
Disable Wii extension addon by default

### DIFF
--- a/headers/addons/wiiext.h
+++ b/headers/addons/wiiext.h
@@ -14,7 +14,7 @@
 #define WiiExtensionName "WiiExtension"
 
 #ifndef WII_EXTENSION_ENABLED
-#define WII_EXTENSION_ENABLED 1
+#define WII_EXTENSION_ENABLED 0
 #endif
 
 #ifndef WII_EXTENSION_I2C_ADDR
@@ -22,11 +22,11 @@
 #endif
 
 #ifndef WII_EXTENSION_I2C_SDA_PIN
-#define WII_EXTENSION_I2C_SDA_PIN 16
+#define WII_EXTENSION_I2C_SDA_PIN -1
 #endif
 
 #ifndef WII_EXTENSION_I2C_SCL_PIN
-#define WII_EXTENSION_I2C_SCL_PIN 17
+#define WII_EXTENSION_I2C_SCL_PIN -1
 #endif
 
 #ifndef WII_EXTENSION_I2C_BLOCK


### PR DESCRIPTION
The Wii extension addon inadvertently enables the addon and maps pins by default, causing validation issues in the web config and confusion for the user. This PR disables the extension by default and unsets the default pin mappings.