### PR TITLE
Fix PLED_TYPE overriding LEDOptions.pledType

### DIFF
--- a/headers/addons/pleds.h
+++ b/headers/addons/pleds.h
@@ -9,6 +9,7 @@
 #include "BoardConfig.h"
 #include <stdint.h>
 #include "AnimationStation.hpp"
+#include "storagemanager.h"
 #include "PlayerLEDs.h"
 #include "gpaddon.h"
 #include "helper.h"
@@ -36,7 +37,9 @@ public:
 	virtual void preprocess() {}
 	virtual void process();
 	virtual std::string name() { return PLEDName; }
-	PlayerLEDAddon() : type(PLED_TYPE) {}
+	PlayerLEDAddon() {
+		type = static_cast<PLEDType>(Storage::getInstance().getLEDOptions().pledType);
+	}
 	PlayerLEDAddon(PLEDType type) : type(type) {}
 
 protected:

--- a/src/addons/neopicoleds.cpp
+++ b/src/addons/neopicoleds.cpp
@@ -95,7 +95,7 @@ void NeoPicoLEDAddon::setup()
 		Storage::getInstance().setDefaultLEDOptions();
 	}
 
-	if ( PLED_TYPE == PLED_TYPE_RGB ) {
+	if ( ledOptions.pledType == PLED_TYPE_RGB ) {
 		neoPLEDs = new NeoPicoPlayerLEDs();
 	}
 
@@ -117,7 +117,7 @@ void NeoPicoLEDAddon::process()
 	Gamepad * gamepad = Storage::getInstance().GetProcessedGamepad();
 	uint8_t * featureData = Storage::getInstance().GetFeatureData();
 	AnimationHotkey action = animationHotkeys(gamepad);
-	if (PLED_TYPE == PLED_TYPE_RGB) {
+	if (ledOptions.pledType == PLED_TYPE_RGB) {
 		inputMode = gamepad->options.inputMode; // HACK
 		switch (gamepad->options.inputMode) {
 			case INPUT_MODE_XINPUT:
@@ -151,7 +151,7 @@ void NeoPicoLEDAddon::process()
 	as.ApplyBrightness(frame);
 
 	// Apply the player LEDs to our first 4 leds if we're in NEOPIXEL mode
-	if (PLED_TYPE == PLED_TYPE_RGB) {
+	if (ledOptions.pledType == PLED_TYPE_RGB) {
 		switch (inputMode) { // HACK
 			case INPUT_MODE_XINPUT:
 				auto pledPins = Storage::getInstance().getPLEDPins();
@@ -461,7 +461,7 @@ uint8_t NeoPicoLEDAddon::setupButtonPositions()
 	uint8_t buttonCount = 0;
 	for (auto const buttonPosition : buttonPositions)
 	{
-		if (buttonPosition.second != -1)
+		if (buttonPosition.second > -1)
 			buttonCount++;
 	}
 
@@ -475,7 +475,7 @@ void NeoPicoLEDAddon::configureLEDs()
 	vector<vector<Pixel>> pixels = createLEDLayout(ledOptions.ledLayout, ledOptions.ledsPerButton, buttonCount);
 	matrix.setup(pixels, ledOptions.ledsPerButton);
 	ledCount = matrix.getLedCount();
-	if (PLED_TYPE == PLED_TYPE_RGB && PLED_COUNT > 0)
+	if (ledOptions.pledType == PLED_TYPE_RGB && PLED_COUNT > 0)
 		ledCount += PLED_COUNT;
 
 	// Remove the old neopico (config can call this)

--- a/src/addons/playerleds.cpp
+++ b/src/addons/playerleds.cpp
@@ -78,12 +78,12 @@ PLEDAnimationState getXInputAnimationPWM(uint8_t *data)
 }
 
 bool PlayerLEDAddon::available() {
-	return PLED_TYPE != PLED_TYPE_NONE;
+	return Storage::getInstance().getLEDOptions().pledType != PLED_TYPE_NONE;
 }
 
 void PlayerLEDAddon::setup() {
-
-	switch (PLED_TYPE)
+	LEDOptions ledOptions = Storage::getInstance().getLEDOptions();
+	switch (ledOptions.pledType)
 	{
 		case PLED_TYPE_PWM:
 			pwmLEDs = new PWMPlayerLEDs();
@@ -100,10 +100,11 @@ void PlayerLEDAddon::setup() {
 void PlayerLEDAddon::process()
 {
 	Gamepad * gamepad = Storage::getInstance().GetProcessedGamepad();
+	LEDOptions ledOptions = Storage::getInstance().getLEDOptions();
 
 	// Player LEDs can be PWM or driven by NeoPixel
 	uint8_t * featureData = Storage::getInstance().GetFeatureData();
-	if (PLED_TYPE == PLED_TYPE_PWM) { // only process the feature queue if we're on PWM
+	if (ledOptions.pledType == PLED_TYPE_PWM) { // only process the feature queue if we're on PWM
 		if (pwmLEDs != nullptr)
 			pwmLEDs->display();
 


### PR DESCRIPTION
Missed this update when implementing the PLED configuration. Firmware was always using the PLED_TYPE instead of the configured option.