### PR TITLE
Fix Hotkey when Touchpad and Share are switched in PS4 Mode

### DIFF
--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -125,7 +125,11 @@ void Gamepad::setup()
 	uint16_t maskA2 = options.inputMode == INPUT_MODE_PS4
 	               && options.switchTpShareForDs4 ? GAMEPAD_MASK_S1 : GAMEPAD_MASK_A2;
 	mapButtonA2  = new GamepadButtonMapping(pinMappings.pinButtonA2, maskA2);
-
+	
+	if(options.inputMode == INPUT_MODE_PS4 && options.switchTpShareForDs4)
+	{
+		f1Mask = (GAMEPAD_MASK_A2 | GAMEPAD_MASK_S2);
+	}
 	gamepadMappings = new GamepadButtonMapping *[GAMEPAD_DIGITAL_INPUT_COUNT]
 	{
 		mapDpadUp,   mapDpadDown, mapDpadLeft, mapDpadRight,


### PR DESCRIPTION
When the Touchpad and Share buttons are switched in PS4 Mode, Hotkey F1 will be the Touchpad and Start button will not be the Option and Start button.