### PR TITLE
Setting to treat the dpad as a 4-way joystick

### DIFF
--- a/headers/gamepad/GamepadState.h
+++ b/headers/gamepad/GamepadState.h
@@ -146,6 +146,53 @@ inline uint16_t dpadToAnalogY(uint8_t dpad)
 }
 
 /**
+ * @brief DRY method used in filtering diagonals for 4-way mode, checks two adjacent directions
+ * and tracks how they toggle.
+ *
+ * @param dir_a Direction state A to track.
+ * @param dir_mask_a Dpad mask state A to check/deselect.
+ * @param dir_b Direction state B to track.
+ * @param dir_mask_b Dpad mask state B to check/deselect.
+ * @param state History for this diagonal (affects which cardinal to deselect).
+ * @return uint8_t The modified dpad
+ */
+inline uint8_t diagonal_check(uint8_t dpad, DpadDirection dir_a, uint16_t dir_mask_a, DpadDirection dir_b,
+		uint16_t dir_mask_b, DpadDirection* state) {
+	uint8_t newDpad = ~0;
+	if ((dpad & (dir_mask_a | dir_mask_b)) == (dir_mask_a | dir_mask_b)) {
+		newDpad = (*state == dir_a) ? ~dir_mask_a : ~dir_mask_b;
+	} else if ((dpad & (dir_mask_a | dir_mask_b)) == dir_mask_a) {
+		*state = dir_a;
+	} else if ((dpad & (dir_mask_a | dir_mask_b)) == dir_mask_b) {
+		*state = dir_b;
+	}
+	return newDpad;
+}
+
+/**
+ * @brief Filter diagonals out of the dpad, making the device work as a 4-way lever.
+ *
+ * The most recent cardinal direction wins.
+ *
+ * @param dpad The GameState.dpad value.
+ * @return uint8_t The new dpad value.
+ */
+inline uint8_t filterToFourWayMode(uint8_t dpad)
+{
+	static DpadDirection lastUL = DIRECTION_NONE;
+	static DpadDirection lastUR = DIRECTION_NONE;
+	static DpadDirection lastDR = DIRECTION_NONE;
+	static DpadDirection lastDL = DIRECTION_NONE;
+
+	dpad &= diagonal_check(dpad, DIRECTION_LEFT, GAMEPAD_MASK_LEFT, DIRECTION_UP, GAMEPAD_MASK_UP, &lastUL);
+	dpad &= diagonal_check(dpad, DIRECTION_UP, GAMEPAD_MASK_UP, DIRECTION_RIGHT, GAMEPAD_MASK_RIGHT, &lastUR);
+	dpad &= diagonal_check(dpad, DIRECTION_RIGHT, GAMEPAD_MASK_RIGHT, DIRECTION_DOWN, GAMEPAD_MASK_DOWN, &lastDR);
+	dpad &= diagonal_check(dpad, DIRECTION_DOWN, GAMEPAD_MASK_DOWN, DIRECTION_LEFT, GAMEPAD_MASK_LEFT, &lastDL);
+
+	return dpad;
+}
+
+/**
  * @brief Run SOCD cleaning against a D-pad value.
  *
  * @param mode The SOCD cleaning mode.

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -12,6 +12,7 @@ message GamepadOptions
 	optional bool invertYAxis = 5;
 	optional bool switchTpShareForDs4 = 6;
 	optional bool lockHotkeys = 7;
+	optional bool fourWayMode = 8;
 }
 
 message KeyboardMapping

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -320,6 +320,7 @@ message DualDirectionalOptions
 	
 	optional DpadMode dpadMode = 6;
 	optional uint32 combineMode = 7;
+	optional bool fourWayMode = 8;
 }
 
 message BuzzerOptions

--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -124,6 +124,7 @@ enum GamepadHotkey
     HOTKEY_INVERT_Y_AXIS        = 10;
     HOTKEY_SOCD_FIRST_INPUT     = 11;
     HOTKEY_SOCD_BYPASS          = 12;
+    HOTKEY_TOGGLE_4_WAY_MODE    = 13;
 }
 
 // This has to be kept in sync with LEDFormat in NeoPico.hpp

--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -111,20 +111,21 @@ enum GamepadHotkey
 {
     option (nanopb_enumopt).long_names = false;
 
-    HOTKEY_NONE                 = 0;
-    HOTKEY_DPAD_DIGITAL         = 1;
-    HOTKEY_DPAD_LEFT_ANALOG     = 2;
-    HOTKEY_DPAD_RIGHT_ANALOG    = 3;
-    HOTKEY_HOME_BUTTON          = 4;
-    HOTKEY_CAPTURE_BUTTON       = 5;
-    HOTKEY_SOCD_UP_PRIORITY     = 6;
-    HOTKEY_SOCD_NEUTRAL         = 7;
-    HOTKEY_SOCD_LAST_INPUT      = 8;
-    HOTKEY_INVERT_X_AXIS        = 9;
-    HOTKEY_INVERT_Y_AXIS        = 10;
-    HOTKEY_SOCD_FIRST_INPUT     = 11;
-    HOTKEY_SOCD_BYPASS          = 12;
-    HOTKEY_TOGGLE_4_WAY_MODE    = 13;
+    HOTKEY_NONE                  = 0;
+    HOTKEY_DPAD_DIGITAL          = 1;
+    HOTKEY_DPAD_LEFT_ANALOG      = 2;
+    HOTKEY_DPAD_RIGHT_ANALOG     = 3;
+    HOTKEY_HOME_BUTTON           = 4;
+    HOTKEY_CAPTURE_BUTTON        = 5;
+    HOTKEY_SOCD_UP_PRIORITY      = 6;
+    HOTKEY_SOCD_NEUTRAL          = 7;
+    HOTKEY_SOCD_LAST_INPUT       = 8;
+    HOTKEY_INVERT_X_AXIS         = 9;
+    HOTKEY_INVERT_Y_AXIS         = 10;
+    HOTKEY_SOCD_FIRST_INPUT      = 11;
+    HOTKEY_SOCD_BYPASS           = 12;
+    HOTKEY_TOGGLE_4_WAY_MODE     = 13;
+    HOTKEY_TOGGLE_DDI_4_WAY_MODE = 14;
 }
 
 // This has to be kept in sync with LEDFormat in NeoPico.hpp

--- a/src/addons/dualdirectional.cpp
+++ b/src/addons/dualdirectional.cpp
@@ -1,4 +1,5 @@
 #include "addons/dualdirectional.h"
+#include "GamepadOptions.h"
 #include "storagemanager.h"
 #include "helper.h"
 #include "config.pb.h"
@@ -126,6 +127,11 @@ void DualDirectionalInput::process()
     uint8_t dualOut = dualState;
     const SOCDMode socdMode = getSOCDMode(gamepad->getOptions());
 
+    // SOCD cleaning already happened, allows for control over which diagonal to take/filter
+    if (options.fourWayMode) {
+        dualOut = filterToFourWayMode(dualOut);
+    }
+
     // If we're in mixed mode
     if (combineMode == DUAL_COMBINE_MODE_MIXED) {
         uint8_t gamepadDpad = gpadToBinary(gamepad->getOptions().dpadMode, gamepad->state);
@@ -144,8 +150,6 @@ void DualDirectionalInput::process()
             OverrideGamepad(gamepad, gamepad->getOptions().dpadMode, dualOut | gamepad->state.dpad);
         }
     } else { // We are not mixed mode, don't change dual output
-        dualOut = dualState;
-
         if ( combineMode == DUAL_COMBINE_MODE_GAMEPAD ) {
             // Set Dual Directional Output
             OverrideGamepad(gamepad, dpadMode, dualOut);

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -91,6 +91,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.gamepadOptions, invertXAxis, false);
     INIT_UNSET_PROPERTY(config.gamepadOptions, switchTpShareForDs4, false);
     INIT_UNSET_PROPERTY(config.gamepadOptions, lockHotkeys, DEFAULT_LOCK_HOTKEYS);
+    INIT_UNSET_PROPERTY(config.gamepadOptions, fourWayMode, false);
 
     // hotkeyOptions
     HotkeyOptions& hotkeyOptions = config.hotkeyOptions;

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -340,6 +340,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.addonOptions.dualDirectionalOptions, rightPin, PIN_DUAL_DIRECTIONAL_RIGHT);
     INIT_UNSET_PROPERTY(config.addonOptions.dualDirectionalOptions, dpadMode, static_cast<DpadMode>(DUAL_DIRECTIONAL_STICK_MODE));
     INIT_UNSET_PROPERTY(config.addonOptions.dualDirectionalOptions, combineMode, DUAL_DIRECTIONAL_COMBINE_MODE);
+    INIT_UNSET_PROPERTY(config.addonOptions.dualDirectionalOptions, fourWayMode, false);
 
     // addonOptions.buzzerOptions
     INIT_UNSET_PROPERTY(config.addonOptions.buzzerOptions, enabled, !!BUZZER_ENABLED);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -456,6 +456,7 @@ std::string setGamepadOptions()
 	readDoc(gamepadOptions.socdMode, doc, "socdMode");
 	readDoc(gamepadOptions.switchTpShareForDs4, doc, "switchTpShareForDs4");
 	readDoc(gamepadOptions.lockHotkeys, doc, "lockHotkeys");
+	readDoc(gamepadOptions.fourWayMode, doc, "fourWayMode");
 
 	HotkeyOptions& hotkeyOptions = Storage::getInstance().getHotkeyOptions();
 	readDoc(hotkeyOptions.hotkeyF1Up.action, doc, "hotkeyF1", 0, "action");
@@ -486,6 +487,7 @@ std::string getGamepadOptions()
 	writeDoc(doc, "socdMode", gamepadOptions.socdMode);
 	writeDoc(doc, "switchTpShareForDs4", gamepadOptions.switchTpShareForDs4 ? 1 : 0);
 	writeDoc(doc, "lockHotkeys", gamepadOptions.lockHotkeys ? 1 : 0);
+	writeDoc(doc, "fourWayMode", gamepadOptions.fourWayMode ? 1 : 0);
 
 	HotkeyOptions& hotkeyOptions = Storage::getInstance().getHotkeyOptions();
 	writeDoc(doc, "hotkeyF1", 0, "action", hotkeyOptions.hotkeyF1Up.action);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -864,6 +864,7 @@ std::string setAddonOptions()
 	docToPin(dualDirectionalOptions.rightPin, doc, "dualDirRightPin");
 	docToValue(dualDirectionalOptions.dpadMode, doc, "dualDirDpadMode");
 	docToValue(dualDirectionalOptions.combineMode, doc, "dualDirCombineMode");
+	docToValue(dualDirectionalOptions.fourWayMode, doc, "dualDirFourWayMode");
 	docToValue(dualDirectionalOptions.enabled, doc, "DualDirectionalInputEnabled");
 
     ExtraButtonOptions& extraButtonOptions = Storage::getInstance().getAddonOptions().extraButtonOptions;
@@ -1073,6 +1074,7 @@ std::string getAddonOptions()
 	writeDoc(doc, "dualDirRightPin", cleanPin(dualDirectionalOptions.rightPin));
 	writeDoc(doc, "dualDirDpadMode", dualDirectionalOptions.dpadMode);
 	writeDoc(doc, "dualDirCombineMode", dualDirectionalOptions.combineMode);
+	writeDoc(doc, "dualDirFourWayMode", dualDirectionalOptions.fourWayMode);
 	writeDoc(doc, "DualDirectionalInputEnabled", dualDirectionalOptions.enabled);
 
     const ExtraButtonOptions& extraButtonOptions = Storage::getInstance().getAddonOptions().extraButtonOptions;

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -171,6 +171,11 @@ void Gamepad::process()
 
 	state.dpad = runSOCDCleaner(resolveSOCDMode(options), state.dpad);
 
+	// SOCD cleaning first, allows for control over which diagonal to take/filter
+	if (options.fourWayMode) {
+		state.dpad = filterToFourWayMode(state.dpad);
+	}
+
 	switch (options.dpadMode)
 	{
 		case DpadMode::DPAD_MODE_LEFT_ANALOG:

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -323,6 +323,12 @@ void Gamepad::processHotkeyIfNewAction(GamepadHotkey action)
 				if (lastAction != HOTKEY_TOGGLE_4_WAY_MODE)
 					options.fourWayMode = !options.fourWayMode;
 				break;
+			case HOTKEY_TOGGLE_DDI_4_WAY_MODE:
+				if (lastAction != HOTKEY_TOGGLE_DDI_4_WAY_MODE) {
+					DualDirectionalOptions& ddiOpt = Storage::getInstance().getAddonOptions().dualDirectionalOptions;
+					ddiOpt.fourWayMode = !ddiOpt.fourWayMode;
+				}
+				break;
 		}
 
 		lastAction = action;

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -5,6 +5,7 @@
 
 // GP2040 Libraries
 #include "gamepad.h"
+#include "enums.pb.h"
 #include "storagemanager.h"
 
 #include "FlashPROM.h"
@@ -317,6 +318,10 @@ void Gamepad::processHotkeyIfNewAction(GamepadHotkey action)
 			case HOTKEY_INVERT_Y_AXIS     :
 				if (lastAction != HOTKEY_INVERT_Y_AXIS)
 					options.invertYAxis = !options.invertYAxis;
+				break;
+			case HOTKEY_TOGGLE_4_WAY_MODE :
+				if (lastAction != HOTKEY_TOGGLE_4_WAY_MODE)
+					options.fourWayMode = !options.fourWayMode;
 				break;
 		}
 

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -91,6 +91,7 @@ app.get("/api/getGamepadOptions", (req, res) => {
 		switchTpShareForDs4: 0,
 		forcedSetupMode: 0,
 		lockHotkeys: 0,
+		fourWayMode: 0,
 		hotkeyF1: [
 			{ action: 1, mask: 1 << 0 },
 			{ action: 2, mask: 1 << 1 },
@@ -204,6 +205,7 @@ app.get("/api/getAddonsOptions", (req, res) => {
 		dualDirRightPin: -1,
 		dualDirDpadMode: 0,
 		dualDirCombineMode: 0,
+		dualDirFourWayMode: 0,
 		analogAdcPinX: -1,
 		analogAdcPinY: -1,
 		bootselButtonMap: 0,

--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -281,6 +281,7 @@ const schema = yup.object().shape({
 	dualDirRightPin:             yup.number().label('Dual Directional Right Pin').validatePinWhenValue('DualDirectionalInputEnabled'),
 	dualDirDpadMode:             yup.number().label('Dual Stick Mode').validateSelectionWhenValue('DualDirectionalInputEnabled', DUAL_STICK_MODES),
 	dualDirCombineMode:          yup.number().label('Dual Combination Mode').validateSelectionWhenValue('DualDirectionalInputEnabled', DUAL_COMBINE_MODES),
+	dualDirFourWayMode:          yup.number().label('Dual Directional 4-Way Joystick Mode').validateRangeWhenValue('DualDirectionalInputEnabled', 0, 1),
 
 	ExtraButtonAddonEnabled:     yup.number().required().label('Extra Button Add-On Enabled'),
 	extraButtonPin:              yup.number().label('Extra Button Pin').validatePinWhenValue('ExtraButtonAddonEnabled'),
@@ -355,6 +356,7 @@ const defaultValues = {
 	dualRightPin: -1,
 	dualDirDpadMode: 0,
 	dualDirCombineMode: 0,
+	dualDirFourWayMode: 0,
 	analogAdcPinX : -1,
  	analogAdcPinY : -1,
 	bootselButtonMap: 0,
@@ -474,6 +476,8 @@ const sanitizeData = (values) => {
 			values.dualRightPin = parseInt(values.dualRightPin);
 		if (!!values.dualDirMode)
 			values.dualDirMode = parseInt(values.dualDirMode);
+		if (!!values.dualDirFourWayMode)
+			values.dualDirFourWayMode = parseInt(values.dualDirFourWayMode);
 		if (!!values.analogAdcPinX)
 			values.analogAdcPinX = parseInt(values.analogAdcPinX);
 		if (!!values.analogAdcPinY)
@@ -1259,6 +1263,15 @@ export default function AddonsConfigPage() {
 							>
 								{DUAL_COMBINE_MODES.map((o, i) => <option key={`button-dualDirCombineMode-option-${i}`} value={o.value}>{o.label}</option>)}
 							</FormSelect>
+							<FormCheck
+								label="Dual Directional 4-Way Joystick Mode"
+								type="switch"
+								id="DualDirFourWayMode"
+								className="col-sm-3 ms-2"
+								isInvalid={false}
+								checked={Boolean(values.dualDirFourWayMode)}
+								onChange={(e) => {handleCheckbox("dualDirFourWayMode", values); handleChange(e);}}
+							/>
 						</Row>
 						</div>
 						<FormCheck

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -53,6 +53,7 @@ const HOTKEY_ACTIONS = [
 	{ label: 'Invert X Axis', value: 9 },
 	{ label: 'Invert Y Axis', value: 10 },
 	{ label: 'Toggle 4-Way Joystick Mode', value: 13 },
+	{ label: 'Toggle DDI 4-Way Joystick Mode', value: 14 },
 ];
 
 const FORCED_SETUP_MODES = [

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -76,6 +76,7 @@ const schema = yup.object().shape({
 	switchTpShareForDs4: yup.number().required().label('Switch Touchpad and Share'),
 	forcedSetupMode : yup.number().required().oneOf(FORCED_SETUP_MODES.map(o => o.value)).label('SOCD Cleaning Mode'),
 	lockHotkeys: yup.number().required().label('Lock Hotkeys'),
+	fourWayMode: yup.number().required().label('4-Way Joystick Mode'),
 });
 
 const FormContext = ({ setButtonLabels }) => {
@@ -103,6 +104,8 @@ const FormContext = ({ setButtonLabels }) => {
 			values.forcedSetupMode = parseInt(values.forcedSetupMode);
 		if (!!values.lockHotkeys)
 			values.lockHotkeys = parseInt(values.lockHotkeys);
+		if (!!values.fourWayMode)
+			values.fourWayMode = parseInt(values.fourWayMode);
 
 		setButtonLabels({ swapTpShareLabels: (values.switchTpShareForDs4 === 1) && (values.inputMode === 4) });
 
@@ -211,6 +214,14 @@ export default function SettingsPage() {
 								<Form.Control.Feedback type="invalid">{errors.forcedSetupMode}</Form.Control.Feedback>
 							</div>
 						</Form.Group>
+						<Form.Check
+							label="4-Way Joystick Mode"
+							type="switch"
+							id="fourWayMode"
+							isInvalid={false}
+							checked={Boolean(values.fourWayMode)}
+							onChange={(e) => { setFieldValue("fourWayMode", e.target.checked ? 1 : 0); }}
+						/>
 					</Section>
 					<Section title="Hotkey Settings">
 						<div id="Hotkeys"

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -52,6 +52,7 @@ const HOTKEY_ACTIONS = [
 	{ label: 'SOCD Cleaning Off', value: 12 },
 	{ label: 'Invert X Axis', value: 9 },
 	{ label: 'Invert Y Axis', value: 10 },
+	{ label: 'Toggle 4-Way Joystick Mode', value: 13 },
 ];
 
 const FORCED_SETUP_MODES = [


### PR DESCRIPTION
This masks off the oldest cardinal direction of a diagonal, allowing for fast switching to new cardinal directions on a lever, meant for arcade games which don't benefit from diagonals and would likely benefit from unambiguous, immediate direction change.