### PR TITLE
Exclude fields from JSON config export

### DIFF
--- a/lib/nanopb/generator/nanopb_generator.py
+++ b/lib/nanopb/generator/nanopb_generator.py
@@ -561,6 +561,7 @@ class Field(ProtoElement):
         self.callback_datatype = field_options.callback_datatype
         self.math_include_required = False
         self.sort_by_tag = field_options.sort_by_tag
+        self.disallow_export = False
         
         if field_options.type == nanopb_pb2.FT_INLINE:
             # Before nanopb-0.3.8, fixed length bytes arrays were specified
@@ -581,6 +582,9 @@ class Field(ProtoElement):
 
         if field_options.HasField("max_count"):
             self.max_count = field_options.max_count
+
+        if field_options.HasField("disallow_export"):
+            self.disallow_export = field_options.disallow_export
 
         if desc.HasField('default_value'):
             self.default = desc.default_value
@@ -870,7 +874,7 @@ class Field(ProtoElement):
 
     def fieldlist(self):
         '''Return the FIELDLIST macro entry for this field.
-        Format is: X(a, ATYPE, HTYPE, LTYPE, field_name, tag)
+        Format is: X(a, ATYPE, HTYPE, LTYPE, field_name, tag, disallow_export)
         '''
         name = Globals.naming_style.var_name(self.name)
 
@@ -889,13 +893,14 @@ class Field(ProtoElement):
                 Globals.naming_style.var_name(self.name),
                 Globals.naming_style.var_name(self.name))
 
-        return '%s(%s, %-9s %-9s %-9s %-16s %3d)' % (self.macro_x_param,
+        return '%s(%s, %-9s %-9s %-9s %-32s %3s %d)' % (self.macro_x_param,
                                                      self.macro_a_param,
                                                      self.allocation + ',',
                                                      self.rules + ',',
                                                      self.pbtype + ',',
                                                      name + ',',
-                                                     self.tag)
+                                                     str(self.tag) + ',',
+                                                     1 if self.disallow_export else 0)
 
     def data_size(self, dependencies):
         '''Return estimated size of this field in the C struct.

--- a/lib/nanopb/generator/proto/nanopb.proto
+++ b/lib/nanopb/generator/proto/nanopb.proto
@@ -153,6 +153,10 @@ message NanoPBOptions {
   // will be a a static field.
   // Fields with dynamic length are converted to either a pointer or a callback.
   optional FieldType fallback_type = 29 [default = FT_CALLBACK]; 
+
+  // GP2040-CE extension
+  // Marks a field to be excluded when performing export operations (i.e. converting to JSON)
+  optional bool disallow_export = 30 [default = false];
 }
 
 // Extensions to protoc 'Descriptor' type in order to define options

--- a/lib/nanopb/pb.h
+++ b/lib/nanopb/pb.h
@@ -520,42 +520,42 @@ struct pb_extension_s {
     }; \
     msgname ## _FIELDLIST(PB_GEN_FIELD_INFO_ASSERT_ ## width, structname)
 
-#define PB_GEN_FIELD_COUNT(structname, atype, htype, ltype, fieldname, tag) +1
-#define PB_GEN_REQ_FIELD_COUNT(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_COUNT(structname, atype, htype, ltype, fieldname, tag, disallow_export) +1
+#define PB_GEN_REQ_FIELD_COUNT(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     + (PB_HTYPE_ ## htype == PB_HTYPE_REQUIRED)
-#define PB_GEN_LARGEST_TAG(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_LARGEST_TAG(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     * 0 + tag
 
 /* X-macro for generating the entries in struct_field_info[] array. */
-#define PB_GEN_FIELD_INFO_1(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_1(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_1(tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_DATA_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_SIZE_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_ARRAY_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname))
 
-#define PB_GEN_FIELD_INFO_2(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_2(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_2(tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_DATA_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_SIZE_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_ARRAY_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname))
 
-#define PB_GEN_FIELD_INFO_4(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_4(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_4(tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_DATA_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_SIZE_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_ARRAY_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname))
 
-#define PB_GEN_FIELD_INFO_8(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_8(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_8(tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_DATA_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_SIZE_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_ARRAY_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname))
 
-#define PB_GEN_FIELD_INFO_AUTO(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_AUTO(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_AUTO2(PB_FIELDINFO_WIDTH_AUTO(_PB_ATYPE_ ## atype, _PB_HTYPE_ ## htype, _PB_LTYPE_ ## ltype), \
                    tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
@@ -572,35 +572,35 @@ struct pb_extension_s {
 /* X-macro for generating asserts that entries fit in struct_field_info[] array.
  * The structure of macros here must match the structure above in PB_GEN_FIELD_INFO_x(),
  * but it is not easily reused because of how macro substitutions work. */
-#define PB_GEN_FIELD_INFO_ASSERT_1(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_ASSERT_1(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_ASSERT_1(tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_DATA_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_SIZE_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_ARRAY_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname))
 
-#define PB_GEN_FIELD_INFO_ASSERT_2(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_ASSERT_2(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_ASSERT_2(tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_DATA_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_SIZE_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_ARRAY_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname))
 
-#define PB_GEN_FIELD_INFO_ASSERT_4(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_ASSERT_4(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_ASSERT_4(tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_DATA_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_SIZE_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_ARRAY_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname))
 
-#define PB_GEN_FIELD_INFO_ASSERT_8(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_ASSERT_8(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_ASSERT_8(tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_DATA_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_SIZE_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
                    PB_ARRAY_SIZE_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname))
 
-#define PB_GEN_FIELD_INFO_ASSERT_AUTO(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_FIELD_INFO_ASSERT_AUTO(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_FIELDINFO_ASSERT_AUTO2(PB_FIELDINFO_WIDTH_AUTO(_PB_ATYPE_ ## atype, _PB_HTYPE_ ## htype, _PB_LTYPE_ ## ltype), \
                    tag, PB_ATYPE_ ## atype | PB_HTYPE_ ## htype | PB_LTYPE_MAP_ ## ltype, \
                    PB_DATA_OFFSET_ ## atype(_PB_HTYPE_ ## htype, structname, fieldname), \
@@ -691,7 +691,7 @@ struct pb_extension_s {
 #define PB_ONEOF_NAME_MEMBER(unionname,membername,fullname) membername
 #define PB_ONEOF_NAME_FULL(unionname,membername,fullname) fullname
 
-#define PB_GEN_SUBMSG_INFO(structname, atype, htype, ltype, fieldname, tag) \
+#define PB_GEN_SUBMSG_INFO(structname, atype, htype, ltype, fieldname, tag, disallow_export) \
     PB_SUBMSG_INFO_ ## htype(_PB_LTYPE_ ## ltype, structname, fieldname)
 
 #define PB_SUBMSG_INFO_REQUIRED(ltype, structname, fieldname) PB_SI ## ltype(structname ## _ ## fieldname ## _MSGTYPE)

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -110,26 +110,26 @@ message PinMappings
 message DisplayOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 i2cBlock = 2;
 	optional int32 i2cSDAPin = 3;
 	optional int32 i2cSCLPin = 4;
 	optional int32 i2cAddress = 5;
 	optional int32 i2cSpeed = 6;
-
+	
 	optional ButtonLayout buttonLayout = 7;
 	optional ButtonLayoutRight buttonLayoutRight = 8;
 	optional ButtonLayoutCustomOptions buttonLayoutCustomOptions = 9;
-
+	
 	optional SplashMode splashMode = 10;
 	optional SplashChoice splashChoice = 11;
 	optional int32 splashDuration = 12;
 	optional bytes splashImage = 13 [(nanopb).max_size = 1024];
-
+	
 	optional int32 size = 14;
 	optional int32 flip = 15;
 	optional bool invert = 16;
-
+	
 	optional int32 displaySaverTimeout = 17;
 }
 
@@ -160,7 +160,7 @@ message LEDOptions
 	optional int32 indexR3 = 22;
 	optional int32 indexA1 = 23;
 	optional int32 indexA2 = 24;
-
+	
 	optional PLEDType pledType = 25;
 	optional int32 pledPin1 = 26;
 	optional int32 pledPin2 = 27;
@@ -179,7 +179,7 @@ message AnimationOptions_Proto
 	optional int32 chaseCycleTime = 5;
 	optional int32 rainbowCycleTime = 6;
 	optional uint32 themeIndex = 7;
-
+	
 	optional bool hasCustomTheme = 8;
 	optional uint32 customThemeUp = 9;
 	optional uint32 customThemeDown = 10;
@@ -234,7 +234,7 @@ message OnBoardLedOptions
 message AnalogOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 analogAdcPinX = 2;
 	optional int32 analogAdcPinY = 3;
 }
@@ -242,12 +242,12 @@ message AnalogOptions
 message TurboOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 buttonPin = 2;
 	optional int32 ledPin = 3;
 	optional uint32 shotCount = 4;
 	optional int32 shmupDialPin = 5;
-
+	
 	optional bool shmupModeEnabled = 6;
 	optional uint32 shmupAlwaysOn1 = 7;
 	optional uint32 shmupAlwaysOn2 = 8;
@@ -267,7 +267,7 @@ message TurboOptions
 message SliderOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 pinLS = 2;
 	optional int32 pinRS = 3;
 }
@@ -275,10 +275,10 @@ message SliderOptions
 message SOCDSliderOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 pinOne = 2;
 	optional int32 pinTwo = 3;
-
+	
 	optional SOCDMode modeDefault = 4;
 	optional SOCDMode modeOne = 5;
 	optional SOCDMode modeTwo = 6;
@@ -287,10 +287,10 @@ message SOCDSliderOptions
 message ReverseOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 buttonPin = 2;
 	optional int32 ledPin = 3;
-
+	
 	optional uint32 actionUp = 4;
 	optional uint32 actionDown = 5;
 	optional uint32 actionLeft = 6;
@@ -300,7 +300,7 @@ message ReverseOptions
 message AnalogADS1219Options
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 i2cBlock = 2;
 	optional int32 i2cSDAPin = 3;
 	optional int32 i2cSCLPin = 4;
@@ -311,7 +311,7 @@ message AnalogADS1219Options
 message DualDirectionalOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 upPin = 2;
 	optional int32 downPin = 3;
 	optional int32 leftPin = 4;
@@ -324,7 +324,7 @@ message DualDirectionalOptions
 message BuzzerOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 pin = 2;
 	optional uint32 volume = 3;
 }
@@ -332,7 +332,7 @@ message BuzzerOptions
 message ExtraButtonOptions
 {
 	optional bool enabled = 1;
-
+	
 	optional int32 pin = 2;
 	optional uint32 buttonMap = 3;
 }
@@ -389,7 +389,7 @@ message AddonOptions
 	optional BuzzerOptions buzzerOptions = 9;
 	optional ExtraButtonOptions extraButtonOptions = 10;
 	optional PlayerNumberOptions playerNumberOptions = 11;
-	optional PS4Options ps4Options = 12;
+	optional PS4Options ps4Options = 12 [(nanopb).disallow_export = true];
 	optional WiiOptions wiiOptions = 13;
 	optional SOCDSliderOptions socdSliderOptions = 14;
 	optional SNESOptions snesOptions = 15;
@@ -398,7 +398,7 @@ message AddonOptions
 message Config
 {
 	optional string boardVersion = 1 [(nanopb).max_length = 31];
-
+	
 	optional GamepadOptions gamepadOptions = 2;
 	optional HotkeyOptions hotkeyOptions = 3;
 	optional PinMappings pinMappings = 4;

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -620,12 +620,15 @@ static void __attribute__((noinline)) appendAsString(std::string& str, uint32_t 
 #define TO_JSON_POINTER(htype, ltype, fieldname, submessageType) static_assert(false, "not supported");
 #define TO_JSON_CALLBACK(htype, ltype, fieldname, submessageType) static_assert(false, "not supported");
 
-#define TO_JSON_FIELD(parenttype, atype, htype, ltype, fieldname, tag) \
-    if (!firstField) str.append(",\n"); \
-    firstField = false; \
-    writeIndentation(str, indentLevel); \
-    str.append("\"" #fieldname "\": "); \
-    PREPROCESSOR_JOIN(TO_JSON_, atype)(htype, ltype, fieldname, parenttype ## _ ## fieldname ## _MSGTYPE)
+#define TO_JSON_FIELD(parenttype, atype, htype, ltype, fieldname, tag, disallow_export) \
+    if (!disallow_export) \
+    { \
+        if (!firstField) str.append(",\n"); \
+        firstField = false; \
+        writeIndentation(str, indentLevel); \
+        str.append("\"" #fieldname "\": "); \
+        PREPROCESSOR_JOIN(TO_JSON_, atype)(htype, ltype, fieldname, parenttype ## _ ## fieldname ## _MSGTYPE) \
+    }
 
 #define GEN_TO_JSON_FUNCTION_DECL(structtype) static void toJSON ## structtype(std::string& str, const structtype& s, int indentLevel);
 
@@ -948,7 +951,7 @@ bool fromJsonBytes(JsonObjectConst jsonObject, const char* fieldname, uint8_t* b
 #define FROM_JSON_POINTER(htype, ltype, fieldname, submessageType) static_assert(false, "not supported");
 #define FROM_JSON_CALLBACK(htype, ltype, fieldname, submessageType) static_assert(false, "not supported");
 
-#define FROM_JSON_FIELD(parenttype, atype, htype, ltype, fieldname, tag) \
+#define FROM_JSON_FIELD(parenttype, atype, htype, ltype, fieldname, tag, disallow_export) \
     PREPROCESSOR_JOIN(FROM_JSON_, atype)(htype, ltype, fieldname, parenttype ## _ ## fieldname)
 
 #define GEN_FROM_JSON_FUNCTION_DECL(structtype) static bool fromJSON ## structtype(JsonObjectConst jsonObject, structtype& configStruct);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1269,6 +1269,7 @@ static const std::pair<const char*, HandlerFuncPtr> handlerFuncs[] =
 	{ "/api/getFirmwareVersion", getFirmwareVersion },
 	{ "/api/getMemoryReport", getMemoryReport },
 	{ "/api/getUsedPins", getUsedPins },
+	{ "/api/getConfig", getConfig },
 #if !defined(NDEBUG)
 	{ "/api/echo", echo },
 #endif


### PR DESCRIPTION
I extended NanoPb to allow Protobuf fields to be flagged with `(nanopb).disallow_export`. Fields with this flag will now be excluded when converting the config to JSON.

I have also reenabled the `/api/getConfig` endpoint.