### PR TITLE
only trigger a hotkey action once per press

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -4,6 +4,7 @@
 #include "BoardConfig.h"
 #include <string.h>
 
+#include "enums.pb.h"
 #include "gamepad/GamepadDebouncer.h"
 #include "gamepad/GamepadState.h"
 #include "gamepad/descriptors/HIDDescriptors.h"
@@ -66,7 +67,7 @@ public:
 	void save();
 	void debounce();
 	
-	GamepadHotkey hotkey();
+	void hotkey();
 
 	/**
 	 * @brief Flag to indicate analog trigger support.
@@ -168,6 +169,7 @@ private:
 	void releaseAllKeys(void);
 	void pressKey(uint8_t code);
 	uint8_t getModifier(uint8_t code);
+	void processHotkeyIfNewAction(GamepadHotkey action);
 
 	GamepadOptions& options;
 
@@ -179,6 +181,8 @@ private:
 	HotkeyEntry hotkeyF2Down;
 	HotkeyEntry hotkeyF2Left;
 	HotkeyEntry hotkeyF2Right;
+
+	GamepadHotkey lastAction = HOTKEY_NONE;
 };
 
 #endif

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -266,11 +266,10 @@ void Gamepad::save()
 	Storage::getInstance().save();
 }
 
-GamepadHotkey Gamepad::hotkey()
+void Gamepad::hotkey()
 {
-	if (options.lockHotkeys) return HOTKEY_NONE;
+	if (options.lockHotkeys) return;
 
-	static GamepadHotkey lastAction = HOTKEY_NONE;
 	GamepadHotkey action = HOTKEY_NONE;
 	if (pressedF1())
 	{
@@ -291,33 +290,42 @@ GamepadHotkey Gamepad::hotkey()
 			state.dpad = 0;
 			state.buttons &= ~(f2Mask);
 		}
+	} else {
+		// no hotkey pressed, set reset last action so we can process the next press
+		lastAction = HOTKEY_NONE;
 	}
+	processHotkeyIfNewAction(action);
+}
 
-	switch (action) {
-		case HOTKEY_NONE              : return action;
-		case HOTKEY_DPAD_DIGITAL      : options.dpadMode = DPAD_MODE_DIGITAL; break;
-		case HOTKEY_DPAD_LEFT_ANALOG  : options.dpadMode = DPAD_MODE_LEFT_ANALOG; break;
-		case HOTKEY_DPAD_RIGHT_ANALOG : options.dpadMode = DPAD_MODE_RIGHT_ANALOG; break;
-		case HOTKEY_HOME_BUTTON       : state.buttons |= GAMEPAD_MASK_A1; break; // Press the Home button
-		case HOTKEY_CAPTURE_BUTTON    :
-			break;
-		case HOTKEY_SOCD_UP_PRIORITY  : options.socdMode = SOCD_MODE_UP_PRIORITY; break;
-		case HOTKEY_SOCD_NEUTRAL      : options.socdMode = SOCD_MODE_NEUTRAL; break;
-		case HOTKEY_SOCD_LAST_INPUT   : options.socdMode = SOCD_MODE_SECOND_INPUT_PRIORITY; break;
-		case HOTKEY_SOCD_FIRST_INPUT  : options.socdMode = SOCD_MODE_FIRST_INPUT_PRIORITY; break;
-		case HOTKEY_SOCD_BYPASS       : options.socdMode = SOCD_MODE_BYPASS; break;
-		case HOTKEY_INVERT_X_AXIS     : break;
-		case HOTKEY_INVERT_Y_AXIS     :
-			if (lastAction != HOTKEY_INVERT_Y_AXIS)
-				options.invertYAxis = !options.invertYAxis;
-			break;
-	}
+/**
+ * @brief Take a hotkey action if it hasn't already been taken, modifying state/options appropriately.
+ */
+void Gamepad::processHotkeyIfNewAction(GamepadHotkey action)
+{
+	if (action != lastAction) {
+		switch (action) {
+			case HOTKEY_NONE              : return;
+			case HOTKEY_DPAD_DIGITAL      : options.dpadMode = DPAD_MODE_DIGITAL; break;
+			case HOTKEY_DPAD_LEFT_ANALOG  : options.dpadMode = DPAD_MODE_LEFT_ANALOG; break;
+			case HOTKEY_DPAD_RIGHT_ANALOG : options.dpadMode = DPAD_MODE_RIGHT_ANALOG; break;
+			case HOTKEY_HOME_BUTTON       : state.buttons |= GAMEPAD_MASK_A1; break; // Press the Home button
+			case HOTKEY_CAPTURE_BUTTON    :
+				break;
+			case HOTKEY_SOCD_UP_PRIORITY  : options.socdMode = SOCD_MODE_UP_PRIORITY; break;
+			case HOTKEY_SOCD_NEUTRAL      : options.socdMode = SOCD_MODE_NEUTRAL; break;
+			case HOTKEY_SOCD_LAST_INPUT   : options.socdMode = SOCD_MODE_SECOND_INPUT_PRIORITY; break;
+			case HOTKEY_SOCD_FIRST_INPUT  : options.socdMode = SOCD_MODE_FIRST_INPUT_PRIORITY; break;
+			case HOTKEY_SOCD_BYPASS       : options.socdMode = SOCD_MODE_BYPASS; break;
+			case HOTKEY_INVERT_X_AXIS     : break;
+			case HOTKEY_INVERT_Y_AXIS     :
+				if (lastAction != HOTKEY_INVERT_Y_AXIS)
+					options.invertYAxis = !options.invertYAxis;
+				break;
+		}
 
-	GamepadHotkey hotkey = action;
-	if (hotkey != GamepadHotkey::HOTKEY_NONE)
+		lastAction = action;
 		save();
-
-	return hotkey;
+	}
 }
 
 


### PR DESCRIPTION
working on 4-way joystick mode toggling in another branch, it was random whether or not I "landed" on set or unset. I identified this as the hotkey code not properly tracking lastAction.

before this change, while a hotkey was held, the action would be applied every time hotkey() was called, e.g. every millisecond, because lastAction was always NONE. this was only checked on the Y-axis toggle, but is now checked on all hotkey actions, as it also allows us from calling save() unnecessarily.

following this change I no longer experience the ambiguity on where I "land" for hotkeys that toggle a setting