### PR TITLE
/api/setConfig initializes config with defaults before saving

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1185,12 +1185,14 @@ DataAndStatusCode setConfig()
 
 	// Store config struct on the heap to avoid stack overflow
 	std::unique_ptr<Config> config(new Config);
+	*config.get() = Config_init_default;
 	if (ConfigUtils::fromJSON(*config.get(), http_post_payload, http_post_payload_len))
 	{
-	Storage::getInstance().getConfig() = *config.get();
+		Storage::getInstance().getConfig() = *config.get();
+		config.reset();
 		if (Storage::getInstance().save())
 		{
-	return DataAndStatusCode(getConfig(), HttpStatusCode::_200);
+			return DataAndStatusCode(getConfig(), HttpStatusCode::_200);
 		}
 		else
 		{


### PR DESCRIPTION
Previously `/api/setConfig` would not initialize the config before parsing the JSON. This could lead to Protobuf encoding errors or random data being written. With this PR the config is initialized to default values.