### PR TITLE
Reduce memory usage

### DIFF
--- a/headers/helper.h
+++ b/headers/helper.h
@@ -13,25 +13,6 @@
 // GP2040-CE Version (32 character limit)
 #define GP2040VERSION "v0.7.2"
 
-const std::string BUTTON_LABEL_UP = "Up";
-const std::string BUTTON_LABEL_DOWN = "Down";
-const std::string BUTTON_LABEL_LEFT = "Left";
-const std::string BUTTON_LABEL_RIGHT = "Right";
-const std::string BUTTON_LABEL_B1 = "B1";
-const std::string BUTTON_LABEL_B2 = "B2";
-const std::string BUTTON_LABEL_B3 = "B3";
-const std::string BUTTON_LABEL_B4 = "B4";
-const std::string BUTTON_LABEL_L1 = "L1";
-const std::string BUTTON_LABEL_R1 = "R1";
-const std::string BUTTON_LABEL_L2 = "L2";
-const std::string BUTTON_LABEL_R2 = "R2";
-const std::string BUTTON_LABEL_S1 = "S1";
-const std::string BUTTON_LABEL_S2 = "S2";
-const std::string BUTTON_LABEL_L3 = "L3";
-const std::string BUTTON_LABEL_R3 = "R3";
-const std::string BUTTON_LABEL_A1 = "A1";
-const std::string BUTTON_LABEL_A2 = "A2";
-
 #define PLED_REPORT_SIZE 32
 
 #ifndef PLED1_PIN

--- a/headers/themes.h
+++ b/headers/themes.h
@@ -15,279 +15,276 @@
 
 using namespace std;
 
-static map<uint32_t, RGB> themeStaticRainbow({
-	{ GAMEPAD_MASK_DL, ColorRed },
-	{ GAMEPAD_MASK_DD, ColorOrange },
-	{ GAMEPAD_MASK_DR, ColorYellow },
-	{ GAMEPAD_MASK_DU, ColorOrange },
-	{ GAMEPAD_MASK_B3, ColorGreen },
-	{ GAMEPAD_MASK_B1, ColorGreen },
-	{ GAMEPAD_MASK_B4, ColorAqua },
-	{ GAMEPAD_MASK_B2, ColorAqua },
-	{ GAMEPAD_MASK_R1, ColorBlue },
-	{ GAMEPAD_MASK_R2, ColorBlue },
-	{ GAMEPAD_MASK_L1, ColorMagenta },
-	{ GAMEPAD_MASK_L2, ColorMagenta },
-});
-
-static map<uint32_t, RGB> themeGuiltyGearTypeA({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorPink },
-	{ GAMEPAD_MASK_B3, ColorBlue },
-	{ GAMEPAD_MASK_B4, ColorGreen },
-	{ GAMEPAD_MASK_R1, ColorRed },
-	{ GAMEPAD_MASK_R2, ColorOrange },
-});
-
-static map<uint32_t, RGB> themeGuiltyGearTypeB({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorPink },
-	{ GAMEPAD_MASK_B4, ColorBlue },
-	{ GAMEPAD_MASK_R1, ColorGreen },
-	{ GAMEPAD_MASK_R2, ColorOrange },
-});
-
-static map<uint32_t, RGB> themeGuiltyGearTypeC({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorOrange },
-	{ GAMEPAD_MASK_B3, ColorPink },
-	{ GAMEPAD_MASK_B4, ColorBlue },
-	{ GAMEPAD_MASK_R1, ColorGreen },
-	{ GAMEPAD_MASK_R2, ColorRed },
-});
-
-static map<uint32_t, RGB> themeGuiltyGearTypeD({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B3, ColorPink },
-	{ GAMEPAD_MASK_B1, ColorBlue },
-	{ GAMEPAD_MASK_B4, ColorGreen },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_R1, ColorOrange },
-});
-
-static map<uint32_t, RGB> themeGuiltyGearTypeE({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B3, ColorPink },
-	{ GAMEPAD_MASK_B1, ColorGreen },
-	{ GAMEPAD_MASK_B4, ColorBlue },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_R1, ColorOrange },
-});
-
-static map<uint32_t, RGB> themeNeoGeo({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B3, ColorRed },
-	{ GAMEPAD_MASK_B4, ColorYellow },
-	{ GAMEPAD_MASK_R1, ColorGreen },
-	{ GAMEPAD_MASK_L1, ColorBlue },
-});
-
-static map<uint32_t, RGB> themeNeoGeoCurved({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorYellow },
-	{ GAMEPAD_MASK_B4, ColorGreen },
-	{ GAMEPAD_MASK_R1, ColorBlue },
-});
-
-static map<uint32_t, RGB> themeNeoGeoModern({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B3, ColorRed },
-	{ GAMEPAD_MASK_B1, ColorYellow },
-	{ GAMEPAD_MASK_B4, ColorGreen },
-	{ GAMEPAD_MASK_B2, ColorBlue },
-});
-
-static map<uint32_t, RGB> themeSixButtonFighter({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B3, ColorBlue },
-	{ GAMEPAD_MASK_B1, ColorBlue },
-	{ GAMEPAD_MASK_B4, ColorYellow },
-	{ GAMEPAD_MASK_B2, ColorYellow },
-	{ GAMEPAD_MASK_R1, ColorRed },
-	{ GAMEPAD_MASK_R2, ColorRed },
-});
-
-static map<uint32_t, RGB> themeSixButtonFighterPlus({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B3, ColorBlue },
-	{ GAMEPAD_MASK_B1, ColorBlue },
-	{ GAMEPAD_MASK_B4, ColorYellow },
-	{ GAMEPAD_MASK_B2, ColorYellow },
-	{ GAMEPAD_MASK_R1, ColorRed },
-	{ GAMEPAD_MASK_R2, ColorRed },
-	{ GAMEPAD_MASK_L1, ColorGreen },
-	{ GAMEPAD_MASK_L2, ColorGreen },
-});
-
-static map<uint32_t, RGB> themeStreetFighter2({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B3, ColorRed },
-	{ GAMEPAD_MASK_B1, ColorRed },
-	{ GAMEPAD_MASK_B4, ColorWhite },
-	{ GAMEPAD_MASK_B2, ColorWhite },
-	{ GAMEPAD_MASK_R1, ColorBlue },
-	{ GAMEPAD_MASK_R2, ColorBlue },
-	{ GAMEPAD_MASK_L1, ColorBlack },
-	{ GAMEPAD_MASK_L2, ColorBlack },
-});
-
-static map<uint32_t, RGB> themeTekken({
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_B3, ColorYellow },
-	{ GAMEPAD_MASK_B1, ColorAqua },
-	{ GAMEPAD_MASK_B4, ColorGreen },
-	{ GAMEPAD_MASK_B2, ColorPink },
-	{ GAMEPAD_MASK_R1, ColorRed },
-});
-
-static map<uint32_t, RGB> themePlayStation({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorBlue },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorMagenta },
-	{ GAMEPAD_MASK_B4, ColorGreen },
-	{ GAMEPAD_MASK_R1, ColorBlack },
-	{ GAMEPAD_MASK_R2, ColorBlack },
-	{ GAMEPAD_MASK_L1, ColorBlack },
-	{ GAMEPAD_MASK_L2, ColorBlack },
-});
-
-static map<uint32_t, RGB> themePlayStationAll({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorBlue },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorMagenta },
-	{ GAMEPAD_MASK_B4, ColorGreen },
-	{ GAMEPAD_MASK_R1, ColorWhite },
-	{ GAMEPAD_MASK_R2, ColorWhite },
-	{ GAMEPAD_MASK_L1, ColorWhite },
-	{ GAMEPAD_MASK_L2, ColorWhite },
-});
-
-static map<uint32_t, RGB> themeSuperFamicom({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorYellow },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorGreen },
-	{ GAMEPAD_MASK_B4, ColorBlue },
-	{ GAMEPAD_MASK_R1, ColorBlack },
-	{ GAMEPAD_MASK_R2, ColorBlack },
-	{ GAMEPAD_MASK_L1, ColorBlack },
-	{ GAMEPAD_MASK_L2, ColorBlack },
-});
-
-static map<uint32_t, RGB> themeSuperFamicomAll({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorYellow },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorGreen },
-	{ GAMEPAD_MASK_B4, ColorBlue },
-	{ GAMEPAD_MASK_R1, ColorWhite },
-	{ GAMEPAD_MASK_R2, ColorWhite },
-	{ GAMEPAD_MASK_L1, ColorWhite },
-	{ GAMEPAD_MASK_L2, ColorWhite },
-});
-
-static map<uint32_t, RGB> themeXbox({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorGreen },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorBlue },
-	{ GAMEPAD_MASK_B4, ColorYellow },
-	{ GAMEPAD_MASK_R1, ColorBlack },
-	{ GAMEPAD_MASK_R2, ColorBlack },
-	{ GAMEPAD_MASK_L1, ColorBlack },
-	{ GAMEPAD_MASK_L2, ColorBlack },
-});
-
-static map<uint32_t, RGB> themeXboxAll({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorGreen },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorBlue },
-	{ GAMEPAD_MASK_B4, ColorYellow },
-	{ GAMEPAD_MASK_R1, ColorWhite },
-	{ GAMEPAD_MASK_R2, ColorWhite },
-	{ GAMEPAD_MASK_L1, ColorWhite },
-	{ GAMEPAD_MASK_L2, ColorWhite },
-});
-
-static map<uint32_t, RGB> themeFightboard({
-	{ GAMEPAD_MASK_DU, ColorWhite },
-	{ GAMEPAD_MASK_DD, ColorWhite },
-	{ GAMEPAD_MASK_DL, ColorWhite },
-	{ GAMEPAD_MASK_DR, ColorWhite },
-	{ GAMEPAD_MASK_B1, ColorGreen },
-	{ GAMEPAD_MASK_B2, ColorRed },
-	{ GAMEPAD_MASK_B3, ColorBlue },
-	{ GAMEPAD_MASK_B4, ColorYellow },
-	{ GAMEPAD_MASK_R1, ColorPurple },
-	{ GAMEPAD_MASK_R2, ColorAqua },
-	{ GAMEPAD_MASK_L1, ColorOrange },
-	{ GAMEPAD_MASK_L2, ColorPink },
-});
-
-static map<uint32_t, RGB> customTheme;
-static map<uint32_t, RGB> customThemePressed;
-
 void addStaticThemes(const LEDOptions& options, const AnimationOptions& animationOptions)
 {
+	map<uint32_t, RGB> themeStaticRainbow({
+		{ GAMEPAD_MASK_DL, ColorRed },
+		{ GAMEPAD_MASK_DD, ColorOrange },
+		{ GAMEPAD_MASK_DR, ColorYellow },
+		{ GAMEPAD_MASK_DU, ColorOrange },
+		{ GAMEPAD_MASK_B3, ColorGreen },
+		{ GAMEPAD_MASK_B1, ColorGreen },
+		{ GAMEPAD_MASK_B4, ColorAqua },
+		{ GAMEPAD_MASK_B2, ColorAqua },
+		{ GAMEPAD_MASK_R1, ColorBlue },
+		{ GAMEPAD_MASK_R2, ColorBlue },
+		{ GAMEPAD_MASK_L1, ColorMagenta },
+		{ GAMEPAD_MASK_L2, ColorMagenta },
+	});
+
+	const map<uint32_t, RGB> themeGuiltyGearTypeA({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorPink },
+		{ GAMEPAD_MASK_B3, ColorBlue },
+		{ GAMEPAD_MASK_B4, ColorGreen },
+		{ GAMEPAD_MASK_R1, ColorRed },
+		{ GAMEPAD_MASK_R2, ColorOrange },
+	});
+
+	const map<uint32_t, RGB> themeGuiltyGearTypeB({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorPink },
+		{ GAMEPAD_MASK_B4, ColorBlue },
+		{ GAMEPAD_MASK_R1, ColorGreen },
+		{ GAMEPAD_MASK_R2, ColorOrange },
+	});
+
+	const map<uint32_t, RGB> themeGuiltyGearTypeC({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorOrange },
+		{ GAMEPAD_MASK_B3, ColorPink },
+		{ GAMEPAD_MASK_B4, ColorBlue },
+		{ GAMEPAD_MASK_R1, ColorGreen },
+		{ GAMEPAD_MASK_R2, ColorRed },
+	});
+
+	const map<uint32_t, RGB> themeGuiltyGearTypeD({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B3, ColorPink },
+		{ GAMEPAD_MASK_B1, ColorBlue },
+		{ GAMEPAD_MASK_B4, ColorGreen },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_R1, ColorOrange },
+	});
+
+	const map<uint32_t, RGB> themeGuiltyGearTypeE({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B3, ColorPink },
+		{ GAMEPAD_MASK_B1, ColorGreen },
+		{ GAMEPAD_MASK_B4, ColorBlue },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_R1, ColorOrange },
+	});
+
+	const map<uint32_t, RGB> themeNeoGeo({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B3, ColorRed },
+		{ GAMEPAD_MASK_B4, ColorYellow },
+		{ GAMEPAD_MASK_R1, ColorGreen },
+		{ GAMEPAD_MASK_L1, ColorBlue },
+	});
+
+	const map<uint32_t, RGB> themeNeoGeoCurved({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorYellow },
+		{ GAMEPAD_MASK_B4, ColorGreen },
+		{ GAMEPAD_MASK_R1, ColorBlue },
+	});
+
+	const map<uint32_t, RGB> themeNeoGeoModern({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B3, ColorRed },
+		{ GAMEPAD_MASK_B1, ColorYellow },
+		{ GAMEPAD_MASK_B4, ColorGreen },
+		{ GAMEPAD_MASK_B2, ColorBlue },
+	});
+
+	const map<uint32_t, RGB> themeSixButtonFighter({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B3, ColorBlue },
+		{ GAMEPAD_MASK_B1, ColorBlue },
+		{ GAMEPAD_MASK_B4, ColorYellow },
+		{ GAMEPAD_MASK_B2, ColorYellow },
+		{ GAMEPAD_MASK_R1, ColorRed },
+		{ GAMEPAD_MASK_R2, ColorRed },
+	});
+
+	const map<uint32_t, RGB> themeSixButtonFighterPlus({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B3, ColorBlue },
+		{ GAMEPAD_MASK_B1, ColorBlue },
+		{ GAMEPAD_MASK_B4, ColorYellow },
+		{ GAMEPAD_MASK_B2, ColorYellow },
+		{ GAMEPAD_MASK_R1, ColorRed },
+		{ GAMEPAD_MASK_R2, ColorRed },
+		{ GAMEPAD_MASK_L1, ColorGreen },
+		{ GAMEPAD_MASK_L2, ColorGreen },
+	});
+
+	const map<uint32_t, RGB> themeStreetFighter2({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B3, ColorRed },
+		{ GAMEPAD_MASK_B1, ColorRed },
+		{ GAMEPAD_MASK_B4, ColorWhite },
+		{ GAMEPAD_MASK_B2, ColorWhite },
+		{ GAMEPAD_MASK_R1, ColorBlue },
+		{ GAMEPAD_MASK_R2, ColorBlue },
+		{ GAMEPAD_MASK_L1, ColorBlack },
+		{ GAMEPAD_MASK_L2, ColorBlack },
+	});
+
+	const map<uint32_t, RGB> themeTekken({
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_B3, ColorYellow },
+		{ GAMEPAD_MASK_B1, ColorAqua },
+		{ GAMEPAD_MASK_B4, ColorGreen },
+		{ GAMEPAD_MASK_B2, ColorPink },
+		{ GAMEPAD_MASK_R1, ColorRed },
+	});
+
+	const map<uint32_t, RGB> themePlayStation({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorBlue },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorMagenta },
+		{ GAMEPAD_MASK_B4, ColorGreen },
+		{ GAMEPAD_MASK_R1, ColorBlack },
+		{ GAMEPAD_MASK_R2, ColorBlack },
+		{ GAMEPAD_MASK_L1, ColorBlack },
+		{ GAMEPAD_MASK_L2, ColorBlack },
+	});
+
+	const map<uint32_t, RGB> themePlayStationAll({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorBlue },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorMagenta },
+		{ GAMEPAD_MASK_B4, ColorGreen },
+		{ GAMEPAD_MASK_R1, ColorWhite },
+		{ GAMEPAD_MASK_R2, ColorWhite },
+		{ GAMEPAD_MASK_L1, ColorWhite },
+		{ GAMEPAD_MASK_L2, ColorWhite },
+	});
+
+	const map<uint32_t, RGB> themeSuperFamicom({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorYellow },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorGreen },
+		{ GAMEPAD_MASK_B4, ColorBlue },
+		{ GAMEPAD_MASK_R1, ColorBlack },
+		{ GAMEPAD_MASK_R2, ColorBlack },
+		{ GAMEPAD_MASK_L1, ColorBlack },
+		{ GAMEPAD_MASK_L2, ColorBlack },
+	});
+
+	const map<uint32_t, RGB> themeSuperFamicomAll({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorYellow },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorGreen },
+		{ GAMEPAD_MASK_B4, ColorBlue },
+		{ GAMEPAD_MASK_R1, ColorWhite },
+		{ GAMEPAD_MASK_R2, ColorWhite },
+		{ GAMEPAD_MASK_L1, ColorWhite },
+		{ GAMEPAD_MASK_L2, ColorWhite },
+	});
+
+	const map<uint32_t, RGB> themeXbox({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorGreen },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorBlue },
+		{ GAMEPAD_MASK_B4, ColorYellow },
+		{ GAMEPAD_MASK_R1, ColorBlack },
+		{ GAMEPAD_MASK_R2, ColorBlack },
+		{ GAMEPAD_MASK_L1, ColorBlack },
+		{ GAMEPAD_MASK_L2, ColorBlack },
+	});
+
+	const map<uint32_t, RGB> themeXboxAll({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorGreen },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorBlue },
+		{ GAMEPAD_MASK_B4, ColorYellow },
+		{ GAMEPAD_MASK_R1, ColorWhite },
+		{ GAMEPAD_MASK_R2, ColorWhite },
+		{ GAMEPAD_MASK_L1, ColorWhite },
+		{ GAMEPAD_MASK_L2, ColorWhite },
+	});
+
+	const map<uint32_t, RGB> themeFightboard({
+		{ GAMEPAD_MASK_DU, ColorWhite },
+		{ GAMEPAD_MASK_DD, ColorWhite },
+		{ GAMEPAD_MASK_DL, ColorWhite },
+		{ GAMEPAD_MASK_DR, ColorWhite },
+		{ GAMEPAD_MASK_B1, ColorGreen },
+		{ GAMEPAD_MASK_B2, ColorRed },
+		{ GAMEPAD_MASK_B3, ColorBlue },
+		{ GAMEPAD_MASK_B4, ColorYellow },
+		{ GAMEPAD_MASK_R1, ColorPurple },
+		{ GAMEPAD_MASK_R2, ColorAqua },
+		{ GAMEPAD_MASK_L1, ColorOrange },
+		{ GAMEPAD_MASK_L2, ColorPink },
+	});
+
 	// Rainbow theme on a Stickless layout should use green for up button
 	themeStaticRainbow[GAMEPAD_MASK_DU] = (options.ledLayout == BUTTON_LAYOUT_STICKLESS) ? ColorGreen : ColorOrange;
 
@@ -320,6 +317,7 @@ void addStaticThemes(const LEDOptions& options, const AnimationOptions& animatio
 
 	if (animationOptions.hasCustomTheme)
 	{
+		map<uint32_t, RGB> customTheme;
 		customTheme[GAMEPAD_MASK_DU] = RGB(animationOptions.customThemeUp);
 		customTheme[GAMEPAD_MASK_DD] = RGB(animationOptions.customThemeDown);
 		customTheme[GAMEPAD_MASK_DL] = RGB(animationOptions.customThemeLeft);
@@ -340,6 +338,7 @@ void addStaticThemes(const LEDOptions& options, const AnimationOptions& animatio
 		customTheme[GAMEPAD_MASK_R3] = RGB(animationOptions.customThemeR3);
 		CustomTheme::SetCustomTheme(customTheme);
 
+		map<uint32_t, RGB> customThemePressed;
 		customThemePressed[GAMEPAD_MASK_DU] = RGB(animationOptions.customThemeUpPressed);
 		customThemePressed[GAMEPAD_MASK_DD] = RGB(animationOptions.customThemeDownPressed);
 		customThemePressed[GAMEPAD_MASK_DL] = RGB(animationOptions.customThemeLeftPressed);

--- a/lib/AnimationStation/src/Animation.hpp
+++ b/lib/AnimationStation/src/Animation.hpp
@@ -12,9 +12,9 @@
 struct RGB {
   RGB() : r(0), g(0), b(0) {}
 
-  RGB(uint8_t r, uint8_t g, uint8_t b) : r(r), g(g), b(b), w(0) {}
+  constexpr RGB(uint8_t r, uint8_t g, uint8_t b) : r(r), g(g), b(b), w(0) {}
 
-  RGB(uint8_t r, uint8_t g, uint8_t b, uint8_t w)
+  constexpr RGB(uint8_t r, uint8_t g, uint8_t b, uint8_t w)
     : r(r), g(g), b(b), w(w) { }
 
   RGB(uint32_t c)
@@ -78,25 +78,25 @@ struct RGB {
   }
 };
 
-static const RGB ColorBlack(0, 0, 0);
-static const RGB ColorWhite(255, 255, 255);
-static const RGB ColorRed(255, 0, 0);
-static const RGB ColorOrange(255, 128, 0);
-static const RGB ColorYellow(255, 255, 0);
-static const RGB ColorLimeGreen(128, 255, 0);
-static const RGB ColorGreen(0, 255, 0);
-static const RGB ColorSeafoam(0, 255, 128);
-static const RGB ColorAqua(0, 255, 255);
-static const RGB ColorSkyBlue(0, 128, 255);
-static const RGB ColorBlue(0, 0, 255);
-static const RGB ColorPurple(128, 0, 255);
-static const RGB ColorPink(255, 0, 255);
-static const RGB ColorMagenta(255, 0, 128);
+constexpr RGB ColorBlack(0, 0, 0);
+constexpr RGB ColorWhite(255, 255, 255);
+constexpr RGB ColorRed(255, 0, 0);
+constexpr RGB ColorOrange(255, 128, 0);
+constexpr RGB ColorYellow(255, 255, 0);
+constexpr RGB ColorLimeGreen(128, 255, 0);
+constexpr RGB ColorGreen(0, 255, 0);
+constexpr RGB ColorSeafoam(0, 255, 128);
+constexpr RGB ColorAqua(0, 255, 255);
+constexpr RGB ColorSkyBlue(0, 128, 255);
+constexpr RGB ColorBlue(0, 0, 255);
+constexpr RGB ColorPurple(128, 0, 255);
+constexpr RGB ColorPink(255, 0, 255);
+constexpr RGB ColorMagenta(255, 0, 128);
 
-static const std::vector<RGB> colors = {
+inline const std::vector<RGB> colors {
     ColorBlack,     ColorWhite,  ColorRed,     ColorOrange, ColorYellow,
     ColorLimeGreen, ColorGreen,  ColorSeafoam, ColorAqua,   ColorSkyBlue,
-    ColorBlue,      ColorPurple, ColorPink,    ColorMagenta};
+    ColorBlue,      ColorPurple, ColorPink,    ColorMagenta };
 
 class Animation {
 public:

--- a/lib/AnimationStation/src/Pixel.hpp
+++ b/lib/AnimationStation/src/Pixel.hpp
@@ -16,7 +16,7 @@ struct Pixel {
   std::vector<uint8_t> positions; // The actual LED indexes on the chain
 };
 
-const Pixel NO_PIXEL(-1);
+inline const Pixel NO_PIXEL(-1);
 
 struct PixelMatrix {
   PixelMatrix() { }

--- a/lib/FlashPROM/src/FlashPROM.h
+++ b/lib/FlashPROM/src/FlashPROM.h
@@ -28,6 +28,6 @@ class FlashPROM
 		static uint8_t writeCache[EEPROM_SIZE_BYTES];
 };
 
-static FlashPROM EEPROM;
+inline FlashPROM EEPROM;
 
 #endif

--- a/src/addons/neopicoleds.cpp
+++ b/src/addons/neopicoleds.cpp
@@ -16,6 +16,25 @@
 #include "enums.h"
 #include "helper.h"
 
+const std::string BUTTON_LABEL_UP = "Up";
+const std::string BUTTON_LABEL_DOWN = "Down";
+const std::string BUTTON_LABEL_LEFT = "Left";
+const std::string BUTTON_LABEL_RIGHT = "Right";
+const std::string BUTTON_LABEL_B1 = "B1";
+const std::string BUTTON_LABEL_B2 = "B2";
+const std::string BUTTON_LABEL_B3 = "B3";
+const std::string BUTTON_LABEL_B4 = "B4";
+const std::string BUTTON_LABEL_L1 = "L1";
+const std::string BUTTON_LABEL_R1 = "R1";
+const std::string BUTTON_LABEL_L2 = "L2";
+const std::string BUTTON_LABEL_R2 = "R2";
+const std::string BUTTON_LABEL_S1 = "S1";
+const std::string BUTTON_LABEL_S2 = "S2";
+const std::string BUTTON_LABEL_L3 = "L3";
+const std::string BUTTON_LABEL_R3 = "R3";
+const std::string BUTTON_LABEL_A1 = "A1";
+const std::string BUTTON_LABEL_A2 = "A2";
+
 static std::vector<uint8_t> EMPTY_VECTOR;
 
 uint32_t rgbPLEDValues[4];

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -34,8 +34,8 @@ using namespace std;
 
 extern struct fsdata_file file__index_html[];
 
-const static vector<string> spaPaths = { "/display-config", "/led-config", "/pin-mapping", "/keyboard-mapping", "/settings", "/reset-settings", "/add-ons", "/custom-theme" };
-const static vector<string> excludePaths = { "/css", "/images", "/js", "/static" };
+const static char* spaPaths[] = { "/display-config", "/led-config", "/pin-mapping", "/keyboard-mapping", "/settings", "/reset-settings", "/add-ons", "/custom-theme" };
+const static char* excludePaths[] = { "/css", "/images", "/js", "/static" };
 const static uint32_t rebootDelayMs = 500;
 static string http_post_uri;
 static char http_post_payload[LWIP_HTTPD_POST_MAX_PAYLOAD_LEN];
@@ -1300,13 +1300,13 @@ int fs_open_custom(struct fs_file *file, const char *name)
 	}
 
 	bool isExclude = false;
-	for (const auto &excludePath : excludePaths)
-		if (!excludePath.compare(name))
+	for (const char* excludePath : excludePaths)
+		if (strcmp(excludePath, name) == 0)
 			return 0;
 
-	for (const auto &spaPath : spaPaths)
+	for (const char* spaPath : spaPaths)
 	{
-		if (!spaPath.compare(name))
+		if (strcmp(spaPath, name) == 0)
 		{
 			file->data = (const char *)file__index_html[0].data;
 			file->len = file__index_html[0].len;


### PR DESCRIPTION
This PR reduces the memory usage (in webconfig mode) from 138 kb to 109 kb.

I achieved these improvement with the following changes:

*   Use `inline const` or `constexp` instead of `static const` in headers. The latter creates a new instance of the constant for each translation unit that includes the header, whereas the former creates a single instance for all translation units.
*   Converted global variables to local variables when possible
*   Converted constants with allocating types (i.e. `std::vector`, `std::string`) to non-allocating types (i.e. `C arrays`, `C strings`). The latter can be used directly from flash, whereas the former need to be copied to an allocated memory block first.