### PR TITLE
Fix incorrect HID report ID

### DIFF
--- a/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
@@ -70,7 +70,7 @@ void send_report(void *report, uint16_t report_size)
 				break;
 
 			default:
-				sent = send_hid_report(0x02, report, report_size);
+				sent = send_hid_report(0, report, report_size);
 				break;
 		}
 


### PR DESCRIPTION
Sorry about the error. This test code crept in somehow.
All other HID devices, tested and working.