### PR TITLE
Initial support for LKP (my capacitive slider controller module)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ src/addons/keyboard_host.cpp
 src/addons/i2canalog1219.cpp
 src/addons/jslider.cpp
 src/addons/i2cdisplay.cpp
+src/addons/i2clkp.cpp
 src/addons/neopicoleds.cpp
 src/addons/playernum.cpp
 src/addons/playerleds.cpp

--- a/headers/addons/i2clkp.h
+++ b/headers/addons/i2clkp.h
@@ -1,0 +1,102 @@
+#ifndef _I2CLKP_H
+#define _I2CLKP_H
+
+#include <hardware/i2c.h>
+
+#include "gpaddon.h"
+#include "GamepadEnums.h"
+
+#define I2CLKPName "I2CLKP"
+
+#ifndef LKP_ENABLED
+#define LKP_ENABLED 0
+#endif
+
+#ifndef LKP_I2C_BLOCK
+#define LKP_I2C_BLOCK i2c0
+#endif
+
+#ifndef LKP_INTERRUPT_PIN
+#define LKP_INTERRUPT_PIN -1
+#endif
+
+#ifndef LKP_ADDR
+#define LKP_ADDR 0x08
+#endif
+
+#ifndef LKP_SDA_PIN
+#define LKP_SDA_PIN -1
+#endif
+
+#ifndef LKP_SCL_PIN
+#define LKP_SCL_PIN -1
+#endif
+
+#ifndef LKP_SPEED
+#define LKP_SPEED 400000
+#endif
+
+class I2CLKPInput : public GPAddon {
+	public:
+	I2CLKPInput():
+		i2c(nullptr), addr(0), keys{0}, versionCheckStart(0),
+		probeFailed(false), connected(false) {}
+	virtual bool available();
+	virtual void setup();
+	virtual void preprocess() {}
+	virtual void process();
+	virtual std::string name() { return I2CLKPName; }
+
+	private:
+	/**
+	 * @brief Clear the interrupt.
+	 * @return Whether the operation was successful or not.
+	 */
+	bool cli();
+	/**
+	 * @brief Initiate the device probing.
+	 * Check device presence and query the version of the attached device.
+	 * @return Whether the operation was successful or not.
+	 */
+	bool probe();
+	/**
+	 * @brief Read an 8-bit register value from a device that uses 16-bit big-endian addressing.
+	 * @param u16Register Address of the register.
+	 * @return The content of that register.
+	 */
+	int readReg(uint16_t u16Register);
+	/**
+	 * @brief Read an array of 8-bit registers from a device that uses 16-bit big-endian addressing.
+	 * @param u16Register Address of the register.
+	 * @param dest Destination buffer.
+	 * @param len Size of the destination buffer and number of registers to read.
+	 * @return Whether the option was successful or not.
+	 */
+	bool readReg(uint16_t u16Register, uint8_t* dest, size_t len);
+	/**
+	 * @brief Write an 8-bit register value to a device that uses 16-bit big-endian addressing.
+	 * @param u16Register Address of the register.
+	 * @param newval New value to write to the register.
+	 * @return Whether the option was successful or not.
+	 */
+	bool writeReg(uint16_t u16Register, uint8_t newval);
+	// Bulk writing is not really used so not implemented as a convenient method
+
+  /** I2C instance. */
+	i2c_inst_t *i2c;
+	/** Cached device address. */
+	int addr;
+	/** Cached interrrupt pin number. */
+	uint interruptPin;
+	/** Most recent sensor state. */
+	uint8_t keys[4];
+
+  /** Version check start time. Used to detect timeouts. */
+	uint32_t versionCheckStart;
+	/** True if the probing failed last time. */
+	bool probeFailed;
+	/** True if device is connected. */
+	bool connected;
+};
+
+#endif // _I2CLKP_H

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -111,26 +111,26 @@ message PinMappings
 message DisplayOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 i2cBlock = 2;
 	optional int32 i2cSDAPin = 3;
 	optional int32 i2cSCLPin = 4;
 	optional int32 i2cAddress = 5;
 	optional int32 i2cSpeed = 6;
-	
+
 	optional ButtonLayout buttonLayout = 7;
 	optional ButtonLayoutRight buttonLayoutRight = 8;
 	optional ButtonLayoutCustomOptions buttonLayoutCustomOptions = 9;
-	
+
 	optional SplashMode splashMode = 10;
 	optional SplashChoice splashChoice = 11;
 	optional int32 splashDuration = 12;
 	optional bytes splashImage = 13 [(nanopb).max_size = 1024];
-	
+
 	optional int32 size = 14;
 	optional int32 flip = 15;
 	optional bool invert = 16;
-	
+
 	optional int32 displaySaverTimeout = 17;
 }
 
@@ -142,7 +142,7 @@ message LEDOptions
 	optional uint32 ledsPerButton = 4;
 	optional uint32 brightnessMaximum = 5;
 	optional uint32 brightnessSteps = 6;
-	
+
 	optional int32 indexUp = 7;
 	optional int32 indexDown = 8;
 	optional int32 indexLeft = 9;
@@ -161,7 +161,7 @@ message LEDOptions
 	optional int32 indexR3 = 22;
 	optional int32 indexA1 = 23;
 	optional int32 indexA2 = 24;
-	
+
 	optional PLEDType pledType = 25;
 	optional int32 pledPin1 = 26;
 	optional int32 pledPin2 = 27;
@@ -180,7 +180,7 @@ message AnimationOptions_Proto
 	optional int32 chaseCycleTime = 5;
 	optional int32 rainbowCycleTime = 6;
 	optional uint32 themeIndex = 7;
-	
+
 	optional bool hasCustomTheme = 8;
 	optional uint32 customThemeUp = 9;
 	optional uint32 customThemeDown = 10;
@@ -235,7 +235,7 @@ message OnBoardLedOptions
 message AnalogOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 analogAdcPinX = 2;
 	optional int32 analogAdcPinY = 3;
 	optional bool forced_circularity = 4;
@@ -245,12 +245,12 @@ message AnalogOptions
 message TurboOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 buttonPin = 2;
 	optional int32 ledPin = 3;
 	optional uint32 shotCount = 4;
 	optional int32 shmupDialPin = 5;
-	
+
 	optional bool shmupModeEnabled = 6;
 	optional uint32 shmupAlwaysOn1 = 7;
 	optional uint32 shmupAlwaysOn2 = 8;
@@ -270,7 +270,7 @@ message TurboOptions
 message SliderOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 pinLS = 2;
 	optional int32 pinRS = 3;
 }
@@ -278,10 +278,10 @@ message SliderOptions
 message SOCDSliderOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 pinOne = 2;
 	optional int32 pinTwo = 3;
-	
+
 	optional SOCDMode modeDefault = 4;
 	optional SOCDMode modeOne = 5;
 	optional SOCDMode modeTwo = 6;
@@ -290,10 +290,10 @@ message SOCDSliderOptions
 message ReverseOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 buttonPin = 2;
 	optional int32 ledPin = 3;
-	
+
 	optional uint32 actionUp = 4;
 	optional uint32 actionDown = 5;
 	optional uint32 actionLeft = 6;
@@ -303,7 +303,7 @@ message ReverseOptions
 message AnalogADS1219Options
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 i2cBlock = 2;
 	optional int32 i2cSDAPin = 3;
 	optional int32 i2cSCLPin = 4;
@@ -314,12 +314,12 @@ message AnalogADS1219Options
 message DualDirectionalOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 upPin = 2;
 	optional int32 downPin = 3;
 	optional int32 leftPin = 4;
 	optional int32 rightPin = 5;
-	
+
 	optional DpadMode dpadMode = 6;
 	optional uint32 combineMode = 7;
 	optional bool fourWayMode = 8;
@@ -328,7 +328,7 @@ message DualDirectionalOptions
 message BuzzerOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 pin = 2;
 	optional uint32 volume = 3;
 }
@@ -336,7 +336,7 @@ message BuzzerOptions
 message ExtraButtonOptions
 {
 	optional bool enabled = 1;
-	
+
 	optional int32 pin = 2;
 	optional uint32 buttonMap = 3;
 }
@@ -397,6 +397,17 @@ message FocusModeOptions
 	optional bool buttonLockEnabled = 6;
 }
 
+message LKPOptions
+{
+	optional bool enabled = 1;
+	optional int32 i2cBlock = 2;
+	optional int32 i2cAddress = 3;
+	optional int32 interruptPin = 4;
+	optional int32 i2cSDAPin = 5;
+	optional int32 i2cSCLPin = 6;
+	optional int32 i2cSpeed = 7;
+}
+
 message AddonOptions
 {
 	optional BootselButtonOptions bootselButtonOptions = 1;
@@ -416,12 +427,13 @@ message AddonOptions
 	optional SNESOptions snesOptions = 15;
 	optional FocusModeOptions focusModeOptions = 16;
 	optional KeyboardHostOptions keyboardHostOptions = 17;
+	optional LKPOptions lkpOptions = 18;
 }
 
 message Config
 {
 	optional string boardVersion = 1 [(nanopb).max_length = 31];
-	
+
 	optional GamepadOptions gamepadOptions = 2;
 	optional HotkeyOptions hotkeyOptions = 3;
 	optional PinMappings pinMappings = 4;

--- a/src/addons/i2clkp.cpp
+++ b/src/addons/i2clkp.cpp
@@ -1,0 +1,200 @@
+#include <pico/stdlib.h>
+#include <hardware/gpio.h>
+
+#include "addons/i2clkp.h"
+#include "storagemanager.h"
+#include "helper.h"
+#include "config.pb.h"
+
+#define LKP_PROTO_VER_MAJOR 1
+#define LKP_PROTO_VER_MINOR 0
+#define LKP_PROTO_VER_REV 0
+
+#define LKP_I2C_BREAK_US 100
+
+// RW registers
+#define LKP_REG_CTL 0x0000
+#define LKP_REG_CTL_SET 0x0001
+#define LKP_REG_CTL_CLEAR 0x0002
+#define LKP_REG_CTL_TOGGLE 0x0003
+
+#define LKP_REG_CTL_INTR_EN 0b00000010
+#define LKP_REG_CTL_INTR_TRIG 0b10000000
+
+// RO registers
+#define LKP_REG_VER 0x0100
+#define LKP_REG_VER_MAJOR LKP_REG_VER
+#define LKP_REG_VER_MINOR (LKP_REG_VER + 1)
+#define LKP_REG_VER_REV (LKP_REG_VER + 2)
+
+#define LKP_REG_KEYS 0x0104
+#define LKP_REG_KEY0 LKP_REG_KEYS
+#define LKP_REG_KEY1 (LKP_REG_KEYS + 1)
+#define LKP_REG_KEY2 (LKP_REG_KEYS + 2)
+#define LKP_REG_KEY3 (LKP_REG_KEYS + 3)
+
+#define LKP_REG_KEYS_ANALOG_BASE 0x0108
+#define LKP_REG_KEYS_ANALOG_SIZE 32
+
+static uint8_t reverse8(uint8_t bits) {
+	uint8_t rev = 0;
+	for (int _=0; _<8; _++) {
+		rev <<= 1;
+		rev |= bits & 1;
+		bits >>= 1;
+	}
+	return rev;
+}
+
+static inline void fillReg16(uint8_t* dest, uint16_t reg) {
+	dest[0] = reg >> 8;
+	dest[1] = reg & 0xff;
+}
+
+int I2CLKPInput::readReg(uint16_t u16Register) {
+  uint8_t u16RegisterBE[2];
+	uint8_t reg;
+
+	fillReg16(u16RegisterBE, u16Register);
+  auto rc = i2c_write_timeout_per_char_us(
+		this->i2c, this->addr, u16RegisterBE, sizeof(u16RegisterBE), true, LKP_I2C_BREAK_US
+	);
+  if (rc == sizeof(u16RegisterBE)) {
+  	rc = i2c_read_timeout_per_char_us(
+			this->i2c, this->addr, &reg, sizeof(reg), false, LKP_I2C_BREAK_US
+		);
+  }
+  return rc == sizeof(reg) ? reg : -1;
+}
+
+bool I2CLKPInput::readReg(uint16_t u16Register, uint8_t* dest, size_t len) {
+  uint8_t u16RegisterBE[2];
+
+	fillReg16(u16RegisterBE, u16Register);
+  auto rc = i2c_write_timeout_per_char_us(
+		this->i2c, this->addr, u16RegisterBE, sizeof(u16RegisterBE), true, LKP_I2C_BREAK_US
+	);
+  if (rc == sizeof(u16RegisterBE)) {
+  	rc = i2c_read_timeout_per_char_us(this->i2c, this->addr, dest, len, false, LKP_I2C_BREAK_US);
+  }
+  return rc == len;
+}
+
+bool I2CLKPInput::writeReg(uint16_t u16Register, uint8_t newval) {
+	uint8_t scratchPad[3];
+	fillReg16(scratchPad, u16Register);
+	scratchPad[2] = newval;
+  auto rc = i2c_write_timeout_per_char_us(
+		i2c, addr, scratchPad, sizeof(scratchPad), false, LKP_I2C_BREAK_US
+	);
+  return rc == sizeof(scratchPad);
+}
+
+bool I2CLKPInput::cli() {
+	auto result = this->writeReg(LKP_REG_CTL_CLEAR, LKP_REG_CTL_INTR_TRIG);
+
+	this->connected = result;
+	return result;
+}
+
+bool I2CLKPInput::probe() {
+	uint8_t ver[3];
+	auto result = false;
+
+	if (this->connected) {
+		return true;
+	}
+
+	do {
+		// Check timeout
+		if (this->probeFailed && (getMillis() - this->versionCheckStart) < 100) {
+			break;
+		}
+
+		this->versionCheckStart = getMillis();
+		this->probeFailed = false;
+
+		// Read version register
+		if (!this->readReg(LKP_REG_VER, ver, sizeof(ver))) {
+			this->probeFailed = true;
+			break;
+		}
+
+		// For major changes, reject when they are different.
+		// For minor changes, reject when we demand newer features that the device couldn't handle.
+		if (ver[0] != LKP_PROTO_VER_MAJOR || ver[1] < LKP_PROTO_VER_MINOR) {
+			this->probeFailed = true;
+			break;
+		}
+
+		// After version check passes, enable scan
+		if (!this->writeReg(LKP_REG_CTL, LKP_REG_CTL_INTR_EN)) {
+			this->probeFailed = true;
+			break;
+		}
+
+		result = true;
+	} while (false);
+
+	this->connected = result;
+	return result;
+}
+
+bool I2CLKPInput::available() {
+	const auto& options = Storage::getInstance().getAddonOptions().lkpOptions;
+	return options.enabled &&
+		isValidPin(options.interruptPin) &&
+		options.has_i2cAddress &&
+		options.has_i2cBlock &&
+		isValidPin(options.i2cSCLPin) &&
+		isValidPin(options.i2cSDAPin) &&
+		options.has_i2cSpeed;
+}
+
+void I2CLKPInput::setup() {
+	const auto& options = Storage::getInstance().getAddonOptions().lkpOptions;
+
+	// Setup addon parameters
+	this->addr = options.i2cAddress;
+	this->interruptPin = options.interruptPin;
+	this->i2c = options.i2cBlock == 0 ? i2c0 : i2c1;
+
+	// Setup INT pin
+	gpio_init(this->interruptPin);
+	gpio_set_dir(this->interruptPin, GPIO_IN);
+	gpio_pull_up(this->interruptPin);
+
+	// Ensure i2c block is initialized
+	// This should not be required once #293 (specifically the global serial block allocation part)
+	// is finished.
+	i2c_init(this->i2c, options.i2cSpeed);
+  gpio_set_function(options.i2cSDAPin, GPIO_FUNC_I2C);
+  gpio_set_function(options.i2cSCLPin, GPIO_FUNC_I2C);
+  gpio_pull_up(options.i2cSDAPin);
+  gpio_pull_up(options.i2cSCLPin);
+
+	// Start probing
+	this->probe();
+}
+
+void I2CLKPInput::process() {
+	// Check for connection and read the sensor states if changed.
+	if (!this->connected && !this->probe()) {
+		return;
+	}
+
+	if (!gpio_get(this->interruptPin)) {
+		this->connected = this->readReg(LKP_REG_KEY0, this->keys, sizeof(this->keys)) && this->cli();
+	}
+
+	// Emit hori stick push
+	// LKP uses left-to-right for consistency with the serial slider,
+	// while hori uses right-to-left so they need to be reversed.
+	auto* gamepad = Storage::getInstance().GetGamepad();
+	gamepad->state.lx = 0x8000 ^ (reverse8(this->keys[3]) << 8);
+	gamepad->state.ly = 0x8000 ^ (reverse8(this->keys[2]) << 8);
+	gamepad->state.rx = 0x8000 ^ (reverse8(this->keys[1]) << 8);
+	gamepad->state.ry = 0x8000 ^ (reverse8(this->keys[0]) << 8);
+
+	// TODO add more modes.
+}

--- a/src/addons/i2clkp.cpp
+++ b/src/addons/i2clkp.cpp
@@ -52,42 +52,42 @@ static inline void fillReg16(uint8_t* dest, uint16_t reg) {
 }
 
 int I2CLKPInput::readReg(uint16_t u16Register) {
-  uint8_t u16RegisterBE[2];
+	uint8_t u16RegisterBE[2];
 	uint8_t reg;
 
 	fillReg16(u16RegisterBE, u16Register);
-  auto rc = i2c_write_timeout_per_char_us(
+	auto rc = i2c_write_timeout_per_char_us(
 		this->i2c, this->addr, u16RegisterBE, sizeof(u16RegisterBE), true, LKP_I2C_BREAK_US
 	);
-  if (rc == sizeof(u16RegisterBE)) {
-  	rc = i2c_read_timeout_per_char_us(
+	if (rc == sizeof(u16RegisterBE)) {
+		rc = i2c_read_timeout_per_char_us(
 			this->i2c, this->addr, &reg, sizeof(reg), false, LKP_I2C_BREAK_US
 		);
-  }
-  return rc == sizeof(reg) ? reg : -1;
+	}
+	return rc == sizeof(reg) ? reg : -1;
 }
 
 bool I2CLKPInput::readReg(uint16_t u16Register, uint8_t* dest, size_t len) {
-  uint8_t u16RegisterBE[2];
+	uint8_t u16RegisterBE[2];
 
 	fillReg16(u16RegisterBE, u16Register);
-  auto rc = i2c_write_timeout_per_char_us(
+	auto rc = i2c_write_timeout_per_char_us(
 		this->i2c, this->addr, u16RegisterBE, sizeof(u16RegisterBE), true, LKP_I2C_BREAK_US
 	);
-  if (rc == sizeof(u16RegisterBE)) {
-  	rc = i2c_read_timeout_per_char_us(this->i2c, this->addr, dest, len, false, LKP_I2C_BREAK_US);
-  }
-  return rc == len;
+	if (rc == sizeof(u16RegisterBE)) {
+		rc = i2c_read_timeout_per_char_us(this->i2c, this->addr, dest, len, false, LKP_I2C_BREAK_US);
+	}
+	return rc == len;
 }
 
 bool I2CLKPInput::writeReg(uint16_t u16Register, uint8_t newval) {
 	uint8_t scratchPad[3];
 	fillReg16(scratchPad, u16Register);
 	scratchPad[2] = newval;
-  auto rc = i2c_write_timeout_per_char_us(
+	auto rc = i2c_write_timeout_per_char_us(
 		i2c, addr, scratchPad, sizeof(scratchPad), false, LKP_I2C_BREAK_US
 	);
-  return rc == sizeof(scratchPad);
+	return rc == sizeof(scratchPad);
 }
 
 bool I2CLKPInput::cli() {
@@ -141,8 +141,11 @@ bool I2CLKPInput::probe() {
 }
 
 bool I2CLKPInput::available() {
+	const DisplayOptions& displayOptions = Storage::getInstance().getDisplayOptions();
 	const auto& options = Storage::getInstance().getAddonOptions().lkpOptions;
-	return options.enabled &&
+
+	return (!displayOptions.enabled) &&
+		options.enabled &&
 		isValidPin(options.interruptPin) &&
 		options.has_i2cAddress &&
 		options.has_i2cBlock &&
@@ -168,10 +171,10 @@ void I2CLKPInput::setup() {
 	// This should not be required once #293 (specifically the global serial block allocation part)
 	// is finished.
 	i2c_init(this->i2c, options.i2cSpeed);
-  gpio_set_function(options.i2cSDAPin, GPIO_FUNC_I2C);
-  gpio_set_function(options.i2cSCLPin, GPIO_FUNC_I2C);
-  gpio_pull_up(options.i2cSDAPin);
-  gpio_pull_up(options.i2cSCLPin);
+	gpio_set_function(options.i2cSDAPin, GPIO_FUNC_I2C);
+	gpio_set_function(options.i2cSCLPin, GPIO_FUNC_I2C);
+	gpio_pull_up(options.i2cSDAPin);
+	gpio_pull_up(options.i2cSCLPin);
 
 	// Start probing
 	this->probe();

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -27,6 +27,7 @@
 #include "addons/turbo.h"
 #include "addons/wiiext.h"
 #include "addons/snes_input.h"
+#include "addons/i2clkp.h"
 
 #include "CRC32.h"
 #include "FlashPROM.h"
@@ -223,7 +224,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.ledOptions, pledPin2, PLED2_PIN);
     INIT_UNSET_PROPERTY(config.ledOptions, pledPin3, PLED3_PIN);
     INIT_UNSET_PROPERTY(config.ledOptions, pledPin4, PLED4_PIN);
-    INIT_UNSET_PROPERTY(config.ledOptions, pledColor, static_cast<uint32_t>(PLED_COLOR.r) << 16 | static_cast<uint32_t>(PLED_COLOR.g) << 8 | static_cast<uint32_t>(PLED_COLOR.b)); 
+    INIT_UNSET_PROPERTY(config.ledOptions, pledColor, static_cast<uint32_t>(PLED_COLOR.r) << 16 | static_cast<uint32_t>(PLED_COLOR.g) << 8 | static_cast<uint32_t>(PLED_COLOR.b));
 
     // animationOptions
     INIT_UNSET_PROPERTY(config.animationOptions, baseAnimationIndex, LEDS_BASE_ANIMATION_INDEX);
@@ -416,6 +417,15 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.addonOptions.focusModeOptions, oledLockEnabled, !!FOCUS_MODE_OLED_LOCK_ENABLED);
     INIT_UNSET_PROPERTY(config.addonOptions.focusModeOptions, rgbLockEnabled, !!FOCUS_MODE_RGB_LOCK_ENABLED);
     INIT_UNSET_PROPERTY(config.addonOptions.focusModeOptions, buttonLockEnabled, !!FOCUS_MODE_BUTTON_LOCK_ENABLED);
+
+		//addonOptions.lkpOptions
+		INIT_UNSET_PROPERTY(config.addonOptions.lkpOptions, enabled, !!LKP_ENABLED);
+		INIT_UNSET_PROPERTY(config.addonOptions.lkpOptions, i2cBlock, (LKP_I2C_BLOCK == i2c0) ? 0 : 1);
+		INIT_UNSET_PROPERTY(config.addonOptions.lkpOptions, i2cAddress, LKP_ADDR);
+		INIT_UNSET_PROPERTY(config.addonOptions.lkpOptions, interruptPin, LKP_INTERRUPT_PIN);
+		INIT_UNSET_PROPERTY(config.addonOptions.lkpOptions, i2cSDAPin, LKP_SDA_PIN);
+		INIT_UNSET_PROPERTY(config.addonOptions.lkpOptions, i2cSCLPin, LKP_SCL_PIN);
+		INIT_UNSET_PROPERTY(config.addonOptions.lkpOptions, i2cSpeed, LKP_SPEED);
 }
 
 // -----------------------------------------------------
@@ -524,7 +534,7 @@ static void setHasFlags(const pb_msgdesc_t* fields, void* s)
     {
         return;
     }
-    
+
     do
     {
         // Not implemented for extension fields
@@ -702,7 +712,7 @@ std::string ConfigUtils::toJSON(const Config& config)
 // From JSON
 // -----------------------------------------------------
 
-#define TEST_VALUE(name, value) if (v == value) return true; 
+#define TEST_VALUE(name, value) if (v == value) return true;
 
 #define GEN_IS_VALID_ENUM_VALUE_FUNCTION(enumtype) \
     static bool isValid ## enumtype(int v) \

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -459,7 +459,7 @@ std::string setSplashImage()
 std::string setGamepadOptions()
 {
 	DynamicJsonDocument doc = get_post_data();
-	
+
 	GamepadOptions& gamepadOptions = Storage::getInstance().getGamepadOptions();
 	readDoc(gamepadOptions.dpadMode, doc, "dpadMode");
 	readDoc(gamepadOptions.inputMode, doc, "inputMode");
@@ -795,7 +795,7 @@ std::string getPinMappings()
 std::string setKeyMappings()
 {
 	DynamicJsonDocument doc = get_post_data();
-	
+
 	KeyboardMapping& keyboardMapping = Storage::getInstance().getKeyboardMapping();
 
 	readDoc(keyboardMapping.keyDpadUp, doc, "Up");
@@ -911,8 +911,8 @@ std::string setAddonOptions()
 
 	ReverseOptions& reverseOptions = Storage::getInstance().getAddonOptions().reverseOptions;
 	docToValue(reverseOptions.enabled, doc, "ReverseInputEnabled");
-	docToPin(reverseOptions.buttonPin, doc, "reversePin");	
-	docToPin(reverseOptions.ledPin, doc, "reversePinLED");	
+	docToPin(reverseOptions.buttonPin, doc, "reversePin");
+	docToPin(reverseOptions.ledPin, doc, "reversePinLED");
 	docToValue(reverseOptions.actionUp, doc, "reverseActionUp");
 	docToValue(reverseOptions.actionDown, doc, "reverseActionDown");
 	docToValue(reverseOptions.actionLeft, doc, "reverseActionLeft");
@@ -988,6 +988,15 @@ std::string setAddonOptions()
 	docToValue(keyboardHostOptions.mapping.keyButtonR3, doc, "keyboardHostMap", "R3");
 	docToValue(keyboardHostOptions.mapping.keyButtonA1, doc, "keyboardHostMap", "A1");
 	docToValue(keyboardHostOptions.mapping.keyButtonA2, doc, "keyboardHostMap", "A2");
+
+	auto& lkpOptions = Storage::getInstance().getAddonOptions().lkpOptions;
+	docToValue(lkpOptions.enabled, doc, "I2CLKPAddonEnabled");
+	docToValue(lkpOptions.i2cBlock, doc, "lkpI2CBlock");
+	docToValue(lkpOptions.i2cAddress, doc, "lkpI2CAddress");
+	docToPin(lkpOptions.interruptPin, doc, "lkpInterruptPin");
+	docToPin(lkpOptions.i2cSDAPin, doc, "lkpI2CSDAPin");
+	docToPin(lkpOptions.i2cSCLPin, doc, "lkpI2CSCLPin");
+	docToValue(lkpOptions.i2cSpeed, doc, "lkpI2CSpeed");
 
 	Storage::getInstance().save();
 
@@ -1231,6 +1240,14 @@ std::string getAddonOptions()
 	writeDoc(doc, "focusModeRgbLockEnabled", focusModeOptions.rgbLockEnabled);
 	writeDoc(doc, "FocusModeAddonEnabled", focusModeOptions.enabled);
 
+	const auto& lkpOptions = Storage::getInstance().getAddonOptions().lkpOptions;
+	writeDoc(doc, "I2CLKPAddonEnabled", lkpOptions.enabled);
+	writeDoc(doc, "lkpI2CBlock", lkpOptions.i2cBlock);
+	writeDoc(doc, "lkpI2CAddress", lkpOptions.i2cAddress);
+	writeDoc(doc, "lkpInterruptPin", cleanPin(lkpOptions.interruptPin));
+	writeDoc(doc, "lkpI2CSDAPin", cleanPin(lkpOptions.i2cSDAPin));
+	writeDoc(doc, "lkpI2CSCLPin", cleanPin(lkpOptions.i2cSCLPin));
+	writeDoc(doc, "lkpI2CSpeed", lkpOptions.i2cSpeed);
 	return serialize_json(doc);
 }
 

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -22,6 +22,7 @@
 #include "addons/slider_socd.h"
 #include "addons/wiiext.h"
 #include "addons/snes_input.h"
+#include "addons/i2clkp.h"
 
 // Pico includes
 #include "pico/bootrom.h"
@@ -115,6 +116,7 @@ void GP2040::setup() {
 	addons.LoadAddon(new SNESpadInput(), CORE0_INPUT);
 	addons.LoadAddon(new PlayerNumAddon(), CORE0_USBREPORT);
 	addons.LoadAddon(new SliderSOCDInput(), CORE0_INPUT);
+	addons.LoadAddon(new I2CLKPInput(), CORE0_INPUT);
 }
 
 void GP2040::run() {

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -247,6 +247,12 @@ app.get("/api/getAddonsOptions", (req, res) => {
 		snesPadDataPin: -1,
 		keyboardHostPinDplus: 0,
 		keyboardHostMap: DEFAULT_KEYBOARD_MAPPING,
+		lkpI2CBlock: 0,
+		lkpI2CAddress: 0x08,
+		lkpInterruptPin: -1,
+		lkpI2CSDAPin: -1,
+		lkpI2CSCLPin: -1,
+		lkpI2CSpeed: 400000,
 		AnalogInputEnabled: 1,
 		BoardLedAddonEnabled: 1,
 		FocusModeAddonEnabled: 1,
@@ -264,6 +270,7 @@ app.get("/api/getAddonsOptions", (req, res) => {
 		TurboInputEnabled: 1,
 		WiiExtensionAddonEnabled: 1,
 		SNESpadAddonEnabled: 1,
+		I2CLKPAddonEnabled: 1,
 		usedPins: Object.values(picoController),
 	});
 });

--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -1898,14 +1898,7 @@ export default function AddonsConfigPage() {
 							id="I2CLKPAddonOptions"
 							hidden={!values.I2CLKPAddonEnabled}>
 							<Row>
-								<p>
-									<strong>
-										Currently the display driver will corrupt the data exchange between GP2040 and LKP
-										if both the display and LKP are on the same I2C block.
-										As a workaround, it is recommended to run LKP with display disabled or on a
-										different I2C block.
-									</strong>
-								</p>
+								<p>Note: If the Display is enabled at the same time, this Addon will be disabled.</p>
 							</Row>
 							<Row className="mb-3">
 								<FormSelect

--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -345,6 +345,14 @@ const schema = yup.object().shape({
 	wiiExtensionSCLPin:          yup.number().required().label('WiiExtension I2C SCL Pin').validatePinWhenValue('WiiExtensionAddonEnabled'),
 	wiiExtensionBlock:           yup.number().required().label('WiiExtension I2C Block').validateSelectionWhenValue('WiiExtensionAddonEnabled', I2C_BLOCKS),
 	wiiExtensionSpeed:           yup.number().label('WiiExtension I2C Speed').validateNumberWhenValue('WiiExtensionAddonEnabled'),
+
+	I2CLKPAddonEnabled:          yup.number().required().label('LKP Extension Enabled'),
+	lkpI2CBlock:                 yup.number().label('LKP I2C Block').validateSelectionWhenValue('I2CLKPAddonEnabled', I2C_BLOCKS),
+	lkpI2CAddress:               yup.number().label('LKP I2C Address').validateNumberWhenValue('I2CLKPAddonEnabled'),
+	lkpInterruptPin:             yup.number().label('LKP Interrupt Pin').validatePinWhenValue('I2CLKPAddonEnabled'),
+	lkpI2CSDAPin:                yup.number().label('LKP I2C SDA Pin').validatePinWhenValue('I2CLKPAddonEnabled'),
+	lkpI2CSCLPin:                yup.number().label('LKP I2C SCL Pin').validatePinWhenValue('I2CLKPAddonEnabled'),
+	lkpI2CSpeed:                 yup.number().label('LKP I2C Speed').validateNumberWhenValue('I2CLKPAddonEnabled'),
 });
 
 const defaultValues = {
@@ -407,6 +415,12 @@ const defaultValues = {
 	snesPadDataPin: -1,
 	keyboardHostPinDplus: -1,
 	keyboardHostMap: baseButtonMappings,
+	lkpI2CBlock: 0,
+	lkpI2CAddress: 0x08,
+	lkpInterruptPin: -1,
+	lkpI2CSDAPin: -1,
+	lkpI2CSCLPin: -1,
+	lkpI2CSpeed: 400000,
 	AnalogInputEnabled: 0,
 	BoardLedAddonEnabled: 0,
 	FocusModeAddonEnabled: 0,
@@ -424,6 +438,7 @@ const defaultValues = {
 	TurboInputEnabled: 0,
 	WiiExtensionAddonEnabled: 0,
 	SNESpadAddonEnabled: 0,
+	I2CLKPAddonEnabled: 0,
 };
 
 const FormContext = ({setStoredData}) => {
@@ -575,6 +590,18 @@ const sanitizeData = (values) => {
 			values.keyboardHostPinDplus = parseInt(values.keyboardHostPinDplus);
 		if (!!values.AnalogInputEnabled)
 			values.AnalogInputEnabled = parseInt(values.AnalogInputEnabled);
+		if (!!values.lkpI2CBlock)
+			values.lkpI2CBlock = parseInt(values.lkpI2CBlock);
+		if (!!values.lkpI2CAddress)
+			values.lkpI2CAddress = parseInt(values.lkpI2CAddress);
+		if (!!values.lkpInterruptPin)
+			values.lkpInterruptPin = parseInt(values.lkpInterruptPin);
+		if (!!values.lkpI2CSDAPin)
+			values.lkpI2CSDAPin = parseInt(values.lkpI2CSDAPin);
+		if (!!values.lkpI2CSCLPin)
+			values.lkpI2CSCLPin = parseInt(values.lkpI2CSCLPin);
+		if (!!values.lkpI2CSpeed)
+			values.lkpI2CSpeed = parseInt(values.lkpI2CSpeed);
 		if (!!values.BoardLedAddonEnabled)
 			values.BoardLedAddonEnabled = parseInt(values.BoardLedAddonEnabled);
 		if (!!values.BuzzerSpeakerAddonEnabled)
@@ -605,6 +632,8 @@ const sanitizeData = (values) => {
 			values.WiiExtensionAddonEnabled = parseInt(values.WiiExtensionAddonEnabled);
 		if (!!values.SNESpadAddonEnabled)
 			values.SNESpadAddonEnabled = parseInt(values.SNESpadAddonEnabled);
+		if (!!values.I2CLKPAddonEnabled)
+			values.I2CLKPAddonEnabled = parseInt(values.I2CLKPAddonEnabled);
 }
 
 function flattenObject(object) {
@@ -1733,7 +1762,7 @@ export default function AddonsConfigPage() {
 							checked={Boolean(values.SNESpadAddonEnabled)}
 							onChange={(e) => {handleCheckbox("SNESpadAddonEnabled", values); handleChange(e);}}
 						/>
-					</Section>	
+					</Section>
 					<Section title="Focus Mode Configuration">
 						<div
 							id="FocusModeAddonOptions"
@@ -1862,6 +1891,105 @@ export default function AddonsConfigPage() {
 							isInvalid={false}
 							checked={Boolean(values.KeyboardHostAddonEnabled)}
 							onChange={(e) => { handleCheckbox("KeyboardHostAddonEnabled", values); handleChange(e);}}
+						/>
+					</Section>
+					<Section title="LKP Capacitive Slider Extension Configuration">
+						<div
+							id="I2CLKPAddonOptions"
+							hidden={!values.I2CLKPAddonEnabled}>
+							<Row>
+								<p>
+									<strong>
+										Currently the display driver will corrupt the data exchange between GP2040 and LKP
+										if both the display and LKP are on the same I2C block.
+										As a workaround, it is recommended to run LKP with display disabled or on a
+										different I2C block.
+									</strong>
+								</p>
+							</Row>
+							<Row className="mb-3">
+								<FormSelect
+									label="I2C Block"
+									name="lkpI2CBlock"
+									className="form-select-sm"
+									groupClassName="col-sm-3 mb-3"
+									value={values.lkpI2CBlock}
+									error={errors.lkpI2CBlock}
+									isInvalid={errors.lkpI2CBlock}
+									onChange={handleChange}
+								>
+									{I2C_BLOCKS.map((o, i) => <option key={`lkpI2CBlock-option-${i}`} value={o.value}>{o.label}</option>)}
+								</FormSelect>
+								<FormControl
+									label="I2C Address"
+									name="lkpI2CAddress"
+									className="form-control-sm"
+									groupClassName="col-sm-3 mb-3"
+									value={values.lkpI2CAddress}
+									error={errors.lkpI2CAddress}
+									isInvalid={errors.lkpI2CAddress}
+									onChange={handleChange}
+									maxLength={4}
+								/>
+								<FormControl type="number"
+									label="Interrupt Pin"
+									name="lkpInterruptPin"
+									className="form-select-sm"
+									groupClassName="col-sm-3 mb-3"
+									value={values.lkpInterruptPin}
+									error={errors.lkpInterruptPin}
+									isInvalid={errors.lkpInterruptPin}
+									onChange={handleChange}
+									min={-1}
+									max={29}
+								/>
+							</Row>
+							<Row className="mb-3">
+							<FormControl type="number"
+									label="I2C SDA Pin"
+									name="lkpI2CSDAPin"
+									className="form-control-sm"
+									groupClassName="col-sm-3 mb-3"
+									value={values.lkpI2CSDAPin}
+									error={errors.lkpI2CSDAPin}
+									isInvalid={errors.lkpI2CSDAPin}
+									onChange={handleChange}
+									min={-1}
+									max={29}
+								/>
+								<FormControl type="number"
+									label="I2C SCL Pin"
+									name="lkpI2CSCLPin"
+									className="form-select-sm"
+									groupClassName="col-sm-3 mb-3"
+									value={values.lkpI2CSCLPin}
+									error={errors.lkpI2CSCLPin}
+									isInvalid={errors.lkpI2CSCLPin}
+									onChange={handleChange}
+									min={-1}
+									max={29}
+								/>
+								<FormControl
+									label="I2C Speed"
+									name="lkpI2CSpeed"
+									className="form-control-sm"
+									groupClassName="col-sm-3 mb-3"
+									value={values.lkpI2CSpeed}
+									error={errors.lkpI2CSpeed}
+									isInvalid={errors.lkpI2CSpeed}
+									onChange={handleChange}
+									min={100000}
+								/>
+							</Row>
+						</div>
+						<FormCheck
+							label="Enabled"
+							type="switch"
+							id="I2CLKPButton"
+							reverse
+							isInvalid={false}
+							checked={Boolean(values.I2CLKPAddonEnabled)}
+							onChange={(e) => {handleCheckbox("I2CLKPAddonEnabled", values); handleChange(e);}}
 						/>
 					</Section>
 					<div className="mt-3">


### PR DESCRIPTION
[LKP](https://github.com/Project-Alpaca/LKP) is a capacitive slider controller module inspired by certain elements in some arcade rhythm game controllers such as [that Miku game](https://commons.wikimedia.org/wiki/File:Hatsune_Miku_Project_DIVA_Arcade_Future_Tone_Version_A_20150327.jpg). It uses I2C interface with an interrupt pin to communicate with the host and provides digital ON/OFF reading of 32 individual capacitive touch sensors. This PR adds initial support for this module in GP2040.

Currently it is hardcoded to emulate the Hori analog stick protocol used in the official Project DIVA Future Tone/Mega Mix controller (documented [here](https://www.youtube.com/watch?v=dwpU5-l3zz8)) but I'm looking into adding other modes in the future, as well as hotkeys that switch between several modes at run-time. Possible interesting modes including emulating only analog stick left/right pushes (similar to what [Divaller](https://www.dj-dao.com/en/divaller) did) or binding touch sensors to key presses.

(~~Currently this is in draft because there is a regression on main branch that prevented addon settings from saving and I'm waiting for it to be fixed so I can test the rebased version.~~ ~~Fixed locally. Will test the changes here later. On my local development branch based on older code the PR seems to work fine.~~ Fully tested and ready.)