### PR TITLE
Fix compile error with some GCC versions

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1310,7 +1310,7 @@ DataAndStatusCode setConfig()
 
 	// Store config struct on the heap to avoid stack overflow
 	std::unique_ptr<Config> config(new Config);
-	*config.get() = Config_init_default;
+	*config.get() = Config Config_init_default;
 	if (ConfigUtils::fromJSON(*config.get(), http_post_payload, http_post_payload_len))
 	{
 		Storage::getInstance().getConfig() = *config.get();


### PR DESCRIPTION
This PR fixes the compile error discovered by @chiyu521. This only happens with some versions of GCC, I am not sure which ones. However, the fix should work with all reasonably recent versions of GCC.