### PR TITLE
include <cstdint> to get uint32_t

### DIFF
--- a/headers/configs/base64.h
+++ b/headers/configs/base64.h
@@ -25,6 +25,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <cstdint>
 #include <string>
 
 class Base64 {


### PR DESCRIPTION
I don't know why this wasn't complaining before, probably some nest of includes that is resolving differently now? ┐(ツ)┌

without this:
```
[ 89%] Building C object CMakeFiles/GP2040-CE.dir/home/bss/proj/pico/pico-sdk/src/rp2_common/pico_unique_id/unique_id.c.obj                                                                                                                                                    
In file included from /home/bss/proj/GP2040-CE/src/configs/webconfig.cpp:2:                                                                                                                                                                                                    
/home/bss/proj/GP2040-CE/headers/configs/base64.h: In static member function ‘static bool Base64::Decode(const char*, size_t, std::string&)’:                                                                                                                                  
/home/bss/proj/GP2040-CE/headers/configs/base64.h:114:7: error: ‘uint32_t’ was not declared in this scope                                                                                                                                                                      
  114 |       uint32_t a = dataPtr[i] == '=' ? 0 & i++ : kDecodingTable[static_cast<int>(dataPtr[i++])];                                                                                                                                                                       
      |       ^~~~~~~~                                                                                                                                                                                                                                                         
/home/bss/proj/GP2040-CE/headers/configs/base64.h:29:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?                                                                                                                             
   28 | #include <string>                                                                                                                                                                                                                                                      
  +++ |+#include <cstdint>                                                                                                                                                                                                                                                     
   29 |                                                                                                                                                                                                                                                                        
/home/bss/proj/GP2040-CE/headers/configs/base64.h:115:16: error: expected ‘;’ before ‘b’                                                                                                                                                                                       
  115 |       uint32_t b = dataPtr[i] == '=' ? 0 & i++ : kDecodingTable[static_cast<int>(dataPtr[i++])];                                                                                                                                                                       
      |                ^                                                                                                                                                                                                                                                       
/home/bss/proj/GP2040-CE/headers/configs/base64.h:116:16: error: expected ‘;’ before ‘c’                                                                                                                                                                                       
  116 |       uint32_t c = dataPtr[i] == '=' ? 0 & i++ : kDecodingTable[static_cast<int>(dataPtr[i++])];                                                                                                                                                                       
      |                ^                                                                                                                                                                                                                                                       
/home/bss/proj/GP2040-CE/headers/configs/base64.h:117:16: error: expected ‘;’ before ‘d’                                                                                                                                                                                       
  117 |       uint32_t d = dataPtr[i] == '=' ? 0 & i++ : kDecodingTable[static_cast<int>(dataPtr[i++])];                                                                                                                                                                       
      |                ^                                                                                                                                                                                                                                                       
/home/bss/proj/GP2040-CE/headers/configs/base64.h:119:16: error: expected ‘;’ before ‘triple’                                                                                                                                                                                  
  119 |       uint32_t triple = (a << 3 * 6) + (b << 2 * 6) + (c << 1 * 6) + (d << 0 * 6);                                                                                                                                                                                     
      |                ^~~~~~                                                                                                                                                                                                                                                  
/home/bss/proj/GP2040-CE/headers/configs/base64.h:121:36: error: ‘triple’ was not declared in this scope                                                                                                                                                                       
  121 |       if (j < out_len) out[j++] = (triple >> 2 * 8) & 0xFF;                                                                                                                                                                                                            
      |                                    ^~~~~~                                                                                                                                                                                                                              
/home/bss/proj/GP2040-CE/headers/configs/base64.h:122:36: error: ‘triple’ was not declared in this scope                                                                                                                                                                       
  122 |       if (j < out_len) out[j++] = (triple >> 1 * 8) & 0xFF;                                                                                                                                                                                                            
      |                                    ^~~~~~                                                                                                                                                                                                                              
/home/bss/proj/GP2040-CE/headers/configs/base64.h:123:36: error: ‘triple’ was not declared in this scope                                                                                                                                                                       
  123 |       if (j < out_len) out[j++] = (triple >> 0 * 8) & 0xFF;                                                                                                                                                                                                            
      |                                    ^~~~~~                                                                                                                                                                                                                              
make[2]: *** [CMakeFiles/GP2040-CE.dir/build.make:245: CMakeFiles/GP2040-CE.dir/src/configs/webconfig.cpp.obj] Error 1                                                                                                                                                         
make[2]: *** Waiting for unfinished jobs....                                                                                                                                                                                                                                   
make[1]: *** [CMakeFiles/Makefile2:1827: CMakeFiles/GP2040-CE.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
make: Leaving directory '/home/bss/proj/GP2040-CE/build'
```