### PR TITLE
Refactor PS4 auth

### DIFF
--- a/headers/addons/ps4mode.h
+++ b/headers/addons/ps4mode.h
@@ -15,23 +15,14 @@
 
 class PS4ModeAddon : public GPAddon {
 public:
-    virtual bool available();
+	virtual bool available();
 	virtual void setup();       // TURBO Button Setup
-    virtual void preprocess() {}
+	virtual void preprocess() {}
 	virtual void process();     // TURBO Setting of buttons (Enable/Disable)
-    virtual std::string name() { return PS4ModeName; }
+	virtual std::string name() { return PS4ModeName; }
 private:
 	struct mbedtls_rsa_context rsa_context;
-    mbedtls_mpi_uint bytesN[64] = {};
-    mbedtls_mpi_uint bytesE[1] = {};
-    mbedtls_mpi_uint bytesD[64] = {};
-    mbedtls_mpi_uint bytesP[32] = {};
-    mbedtls_mpi_uint bytesQ[32] = {};
-    mbedtls_mpi_uint bytesDP[32] = {};
-    mbedtls_mpi_uint bytesDQ[32] = {};
-    mbedtls_mpi_uint bytesQP[32] = {};
-    mbedtls_mpi_uint bytesRN[64] = {};
-    uint8_t hashed_nonce[32] = {};
+	bool ready;
 };
 
 #endif  // PS4MODE_H_

--- a/src/addons/ps4mode.cpp
+++ b/src/addons/ps4mode.cpp
@@ -13,105 +13,101 @@
 #include "mbedtls/rsa.h"
 #include "mbedtls/sha256.h"
 
+#define NEW_CONFIG_MPI(name, buf, size) \
+	mbedtls_mpi_uint *bytes ## name = new mbedtls_mpi_uint[size / sizeof(mbedtls_mpi_uint)]; \
+	mbedtls_mpi name = { .s=1, .n=size / sizeof(mbedtls_mpi_uint), .p=bytes ## name }; \
+	memcpy(bytes ## name, buf, size);
+
+#define DELETE_CONFIG_MPI(name) delete bytes ## name;
+
 bool PS4ModeAddon::available() {
   const PS4Options& options = Storage::getInstance().getAddonOptions().ps4Options;
 	return options.enabled
-      && options.serial.size == sizeof(options.serial.bytes)
-      && options.signature.size == sizeof(options.signature.bytes)
-      && options.rsaN.size == sizeof(options.rsaN.bytes)
-      && options.rsaE.size == sizeof(options.rsaE.bytes)
-      && options.rsaD.size == sizeof(options.rsaD.bytes)
-      && options.rsaP.size == sizeof(options.rsaP.bytes)
-      && options.rsaQ.size == sizeof(options.rsaQ.bytes)
-      && options.rsaDP.size == sizeof(options.rsaDP.bytes)
-      && options.rsaDQ.size == sizeof(options.rsaDQ.bytes)
-      && options.rsaQP.size == sizeof(options.rsaQP.bytes)
-      && options.rsaRN.size == sizeof(options.rsaRN.bytes);
+		&& options.serial.size == sizeof(options.serial.bytes)
+		&& options.signature.size == sizeof(options.signature.bytes)
+		&& options.rsaN.size == sizeof(options.rsaN.bytes)
+		&& options.rsaE.size == sizeof(options.rsaE.bytes)
+		&& options.rsaP.size == sizeof(options.rsaP.bytes)
+		&& options.rsaQ.size == sizeof(options.rsaQ.bytes);
 }
 
 void PS4ModeAddon::setup() {
-    const PS4Options& options = Storage::getInstance().getAddonOptions().ps4Options;
+	const PS4Options& options = Storage::getInstance().getAddonOptions().ps4Options;
 
-    memcpy(bytesN, options.rsaN.bytes, options.rsaN.size);
-    memcpy(bytesE, options.rsaE.bytes, options.rsaE.size);
-    memcpy(bytesD, options.rsaD.bytes, options.rsaD.size);
-    memcpy(bytesP, options.rsaP.bytes, options.rsaP.size);
-    memcpy(bytesQ, options.rsaQ.bytes, options.rsaQ.size);
-    memcpy(bytesDP, options.rsaDP.bytes, options.rsaDP.size);
-    memcpy(bytesDQ, options.rsaDQ.bytes, options.rsaDQ.size);
-    memcpy(bytesQP, options.rsaQP.bytes, options.rsaQP.size);
-    memcpy(bytesRN, options.rsaRN.bytes, options.rsaRN.size);
+		ready = false;
 
-    rsa_context = {
-      .ver = 0,
-      .len = 256,
-      .N =  { .s=1, .n=64, .p=bytesN  },
-      .E =  { .s=1, .n=1,  .p=bytesE  },
-      .D =  { .s=1, .n=64, .p=bytesD  },
-      .P =  { .s=1, .n=32, .p=bytesP  },
-      .Q =  { .s=1, .n=32, .p=bytesQ  },
-      .DP = { .s=1, .n=32, .p=bytesDP },
-      .DQ = { .s=1, .n=32, .p=bytesDQ },
-      .QP = { .s=1, .n=32, .p=bytesQP },
-      .RN = { .s=1, .n=64, .p=bytesRN },
-      .RP = { .s=0, .n=0, .p=nullptr },
-      .RQ = { .s=0, .n=0, .p=nullptr },
-      .Vi = { .s=0, .n=0, .p=nullptr },
-      .Vf = { .s=0, .n=0, .p=nullptr },
-      .padding = MBEDTLS_RSA_PKCS_V21, .hash_id = MBEDTLS_MD_SHA256,
-    };
+		NEW_CONFIG_MPI(N, options.rsaN.bytes, options.rsaN.size)
+		NEW_CONFIG_MPI(E, options.rsaE.bytes, options.rsaE.size)
+		NEW_CONFIG_MPI(P, options.rsaP.bytes, options.rsaP.size)
+		NEW_CONFIG_MPI(Q, options.rsaQ.bytes, options.rsaQ.size)
+
+		mbedtls_rsa_init(&rsa_context, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
+		mbedtls_rsa_import(&rsa_context, &N, &P, &Q, nullptr, &E);
+		mbedtls_rsa_complete(&rsa_context);
+
+		DELETE_CONFIG_MPI(N)
+		DELETE_CONFIG_MPI(E)
+		DELETE_CONFIG_MPI(P)
+		DELETE_CONFIG_MPI(Q)
+
+		ready = true;
 }
 
 void PS4ModeAddon::process() {
-    const PS4Options& options = Storage::getInstance().getAddonOptions().ps4Options;
+	if (!ready) {
+		return;
+	}
 
-    int rss_error = 0;
+	const PS4Options& options = Storage::getInstance().getAddonOptions().ps4Options;
 
-    // Check to see if the PS4 Authentication needs work
-    if ( PS4Data::getInstance().ps4State == PS4State::nonce_ready ) {
+	int rss_error = 0;
 
-      // Generate some random for RNG
-      srand(getMillis());
-      auto rng = [](void*p_rng, unsigned char* p, size_t len) {
-          (void) p_rng;
-          p[0] = rand();
-          return 0;
-      };
+	// Check to see if the PS4 Authentication needs work
+	if ( PS4Data::getInstance().ps4State == PS4State::nonce_ready ) {
 
-      uint8_t nonce_signature[256];
-      uint8_t * nonce_buffer = PS4Data::getInstance().nonce_buffer;
-      uint8_t * ps4_auth_buffer = PS4Data::getInstance().ps4_auth_buffer;
+		// Generate some random for RNG
+		srand(getMillis());
+		auto rng = [](void*p_rng, unsigned char* p, size_t len) {
+			(void) p_rng;
+			p[0] = rand();
+			return 0;
+		};
 
-      // Sign the nonce now that we got it!
-      //
-      if ( mbedtls_sha256_ret(nonce_buffer, 256, hashed_nonce, 0) < 0 ) {
-        return;
-      }
+		uint8_t hashed_nonce[32];
+		uint8_t * nonce_buffer = PS4Data::getInstance().nonce_buffer;
+		uint8_t * ps4_auth_buffer = PS4Data::getInstance().ps4_auth_buffer;
 
-      rss_error = mbedtls_rsa_rsassa_pss_sign(&rsa_context, rng, nullptr,
-              MBEDTLS_RSA_PRIVATE, MBEDTLS_MD_SHA256,
-              32, hashed_nonce,
-              nonce_signature);
+		// Sign the nonce now that we got it!
+		//
+		if ( mbedtls_sha256_ret(nonce_buffer, 256, hashed_nonce, 0) < 0 ) {
+			return;
+		}
 
-      if ( rss_error < 0 ) {
-        return;
-      }
-      // copy the parts into our authentication buffer
-      int offset = 0;
-      memcpy(&ps4_auth_buffer[offset], nonce_signature, 256);
-      offset += 256;
-      memcpy(&ps4_auth_buffer[offset], options.serial.bytes, 16);
-      offset += 16;
-      mbedtls_mpi* mpi = static_cast<mbedtls_mpi*>(&rsa_context.N);
-      mbedtls_mpi_write_binary(mpi, &ps4_auth_buffer[offset], 256);
-      offset += 256;
-      mpi = static_cast<mbedtls_mpi*>(&rsa_context.E);
-      mbedtls_mpi_write_binary(mpi, &ps4_auth_buffer[offset], 256);
-      offset += 256;
-      memcpy(&ps4_auth_buffer[offset], options.signature.bytes, 256);
-      offset += 256;
-      memset(&ps4_auth_buffer[offset], 0, 24);
+		rss_error = mbedtls_rsa_rsassa_pss_sign(&rsa_context, rng, nullptr,
+				MBEDTLS_RSA_PRIVATE, MBEDTLS_MD_SHA256,
+				32, hashed_nonce,
+				&ps4_auth_buffer[0]);
 
-      PS4Data::getInstance().ps4State = PS4State::signed_nonce_ready; // signed and ready to party
-    }
+		if ( rss_error < 0 ) {
+			return;
+		}
+		// copy the parts into our authentication buffer
+		size_t offset = 256;
+		memcpy(&ps4_auth_buffer[offset], options.serial.bytes, 16);
+		offset += 16;
+		mbedtls_rsa_export_raw(
+			&rsa_context,
+			&ps4_auth_buffer[offset], 256,
+			nullptr, 0,
+			nullptr, 0,
+			nullptr, 0,
+			&ps4_auth_buffer[offset+256], 256
+		);
+		offset += 512;
+		memcpy(&ps4_auth_buffer[offset], options.signature.bytes, 256);
+		offset += 256;
+		memset(&ps4_auth_buffer[offset], 0, 24);
+
+		PS4Data::getInstance().ps4State = PS4State::signed_nonce_ready; // signed and ready to party
+	}
 }

--- a/src/addons/ps4mode.cpp
+++ b/src/addons/ps4mode.cpp
@@ -33,24 +33,25 @@ bool PS4ModeAddon::available() {
 
 void PS4ModeAddon::setup() {
 	const PS4Options& options = Storage::getInstance().getAddonOptions().ps4Options;
+	ready = false;
 
-		ready = false;
+	NEW_CONFIG_MPI(N, options.rsaN.bytes, options.rsaN.size)
+	NEW_CONFIG_MPI(E, options.rsaE.bytes, options.rsaE.size)
+	NEW_CONFIG_MPI(P, options.rsaP.bytes, options.rsaP.size)
+	NEW_CONFIG_MPI(Q, options.rsaQ.bytes, options.rsaQ.size)
 
-		NEW_CONFIG_MPI(N, options.rsaN.bytes, options.rsaN.size)
-		NEW_CONFIG_MPI(E, options.rsaE.bytes, options.rsaE.size)
-		NEW_CONFIG_MPI(P, options.rsaP.bytes, options.rsaP.size)
-		NEW_CONFIG_MPI(Q, options.rsaQ.bytes, options.rsaQ.size)
+	mbedtls_rsa_init(&rsa_context, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
 
-		mbedtls_rsa_init(&rsa_context, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
-		mbedtls_rsa_import(&rsa_context, &N, &P, &Q, nullptr, &E);
-		mbedtls_rsa_complete(&rsa_context);
-
-		DELETE_CONFIG_MPI(N)
-		DELETE_CONFIG_MPI(E)
-		DELETE_CONFIG_MPI(P)
-		DELETE_CONFIG_MPI(Q)
-
+	do {
+		if (mbedtls_rsa_import(&rsa_context, &N, &P, &Q, nullptr, &E) < 0) break;
+		if (mbedtls_rsa_complete(&rsa_context) < 0) break;
 		ready = true;
+	} while (false);
+
+	DELETE_CONFIG_MPI(N)
+	DELETE_CONFIG_MPI(E)
+	DELETE_CONFIG_MPI(P)
+	DELETE_CONFIG_MPI(Q)
 }
 
 void PS4ModeAddon::process() {

--- a/src/addons/ps4mode.cpp
+++ b/src/addons/ps4mode.cpp
@@ -42,11 +42,10 @@ void PS4ModeAddon::setup() {
 
 	mbedtls_rsa_init(&rsa_context, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_SHA256);
 
-	do {
-		if (mbedtls_rsa_import(&rsa_context, &N, &P, &Q, nullptr, &E) < 0) break;
-		if (mbedtls_rsa_complete(&rsa_context) < 0) break;
+	if (mbedtls_rsa_import(&rsa_context, &N, &P, &Q, nullptr, &E) == 0 &&
+			mbedtls_rsa_complete(&rsa_context) == 0) {
 		ready = true;
-	} while (false);
+	}
 
 	DELETE_CONFIG_MPI(N)
 	DELETE_CONFIG_MPI(E)

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -503,7 +503,7 @@ std::string setSplashImage()
 std::string setGamepadOptions()
 {
 	DynamicJsonDocument doc = get_post_data();
-	
+
 	GamepadOptions& gamepadOptions = Storage::getInstance().getGamepadOptions();
 	readDoc(gamepadOptions.dpadMode, doc, "dpadMode");
 	readDoc(gamepadOptions.inputMode, doc, "inputMode");
@@ -842,7 +842,7 @@ std::string getPinMappings()
 std::string setKeyMappings()
 {
 	DynamicJsonDocument doc = get_post_data();
-	
+
 	KeyboardMapping& keyboardMapping = Storage::getInstance().getKeyboardMapping();
 
 	readDoc(keyboardMapping.keyDpadUp, doc, "Up");
@@ -972,8 +972,8 @@ std::string setAddonOptions()
 
 	ReverseOptions& reverseOptions = Storage::getInstance().getAddonOptions().reverseOptions;
 	docToValue(reverseOptions.enabled, doc, "ReverseInputEnabled");
-	docToPin(reverseOptions.buttonPin, doc, "reversePin");	
-	docToPin(reverseOptions.ledPin, doc, "reversePinLED");	
+	docToPin(reverseOptions.buttonPin, doc, "reversePin");
+	docToPin(reverseOptions.ledPin, doc, "reversePinLED");
 	docToValue(reverseOptions.actionUp, doc, "reverseActionUp");
 	docToValue(reverseOptions.actionDown, doc, "reverseActionDown");
 	docToValue(reverseOptions.actionLeft, doc, "reverseActionLeft");
@@ -1091,12 +1091,6 @@ std::string setPS4Options()
 			ps4Options.rsaE.size = decoded.length();
 		}
 	}
-	if ( readEncoded("D") ) {
-		if ( Base64::Decode(encoded, decoded) && (decoded.length() == sizeof(ps4Options.rsaD.bytes)) ) {
-			memcpy(ps4Options.rsaD.bytes, decoded.data(), decoded.length());
-			ps4Options.rsaD.size = decoded.length();
-		}
-	}
 	if ( readEncoded("P") ) {
 		if ( Base64::Decode(encoded, decoded) && (decoded.length() == sizeof(ps4Options.rsaP.bytes)) ) {
 			memcpy(ps4Options.rsaP.bytes, decoded.data(), decoded.length());
@@ -1107,30 +1101,6 @@ std::string setPS4Options()
 		if ( Base64::Decode(encoded, decoded) && (decoded.length() == sizeof(ps4Options.rsaQ.bytes)) ) {
 			memcpy(ps4Options.rsaQ.bytes, decoded.data(), decoded.length());
 			ps4Options.rsaQ.size = decoded.length();
-		}
-	}
-	if ( readEncoded("DP") ) {
-		if ( Base64::Decode(encoded, decoded) && (decoded.length() == sizeof(ps4Options.rsaDP.bytes)) ) {
-			memcpy(ps4Options.rsaDP.bytes, decoded.data(), decoded.length());
-			ps4Options.rsaDP.size = decoded.length();
-		}
-	}
-	if ( readEncoded("DQ") ) {
-		if ( Base64::Decode(encoded, decoded) && (decoded.length() == sizeof(ps4Options.rsaDQ.bytes)) ) {
-			memcpy(ps4Options.rsaDQ.bytes, decoded.data(), decoded.length());
-			ps4Options.rsaDQ.size = decoded.length();
-		}
-	}
-	if ( readEncoded("QP") ) {
-		if ( Base64::Decode(encoded, decoded) && (decoded.length() == sizeof(ps4Options.rsaQP.bytes)) ) {
-			memcpy(ps4Options.rsaQP.bytes, decoded.data(), decoded.length());
-			ps4Options.rsaQP.size = decoded.length();
-		}
-	}
-	if ( readEncoded("RN") ) {
-		if ( Base64::Decode(encoded, decoded) && (decoded.length() == sizeof(ps4Options.rsaRN.bytes)) ) {
-			memcpy(ps4Options.rsaRN.bytes, decoded.data(), decoded.length());
-			ps4Options.rsaRN.size = decoded.length();
 		}
 	}
 	// Serial & Signature
@@ -1146,6 +1116,13 @@ std::string setPS4Options()
 			ps4Options.signature.size = decoded.length();
 		}
 	}
+
+	// Zap deprecated fields
+	if (ps4Options.rsaD.size != 0) ps4Options.rsaD.size = 0;
+	if (ps4Options.rsaDP.size != 0) ps4Options.rsaDP.size = 0;
+	if (ps4Options.rsaDQ.size != 0) ps4Options.rsaDQ.size = 0;
+	if (ps4Options.rsaQP.size != 0) ps4Options.rsaQP.size = 0;
+	if (ps4Options.rsaRN.size != 0) ps4Options.rsaRN.size = 0;
 
 	Storage::getInstance().save();
 

--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -13,8 +13,9 @@ import WebApi, { baseButtonMappings } from '../Services/WebApi';
 import JSEncrypt from 'jsencrypt';
 import CryptoJS from 'crypto-js';
 import * as bigintModArith from 'bigint-mod-arith';
-import get from 'lodash/get'
-import set from "lodash/set"
+import get from 'lodash/get';
+import set from "lodash/set";
+import isNil from 'lodash';
 
 const I2C_BLOCKS = [
 	{ label: 'i2c0', value: 0 },
@@ -104,152 +105,114 @@ const verifyAndSavePS4 = async () => {
 	let PS4Serial = document.getElementById("ps4serial-input");
 	let PS4Signature = document.getElementById("ps4signature-input");
 
-	let count = 0;
-	var pem;
-	var signature;
-	var serial;
-
-	const handlePEM = (e) => {
-		pem = keyReader.result;
-		count++;
-	};
-
-	const handleSignature = (e) => {
-		signature = sigReader.result;
-		count++;
-	};
-
-	const handleSerial = (e) => {
-		serial = serialReader.result;
-		count++;
-	};
-
-	let keyReader = new FileReader();
-	keyReader.onloadend = handlePEM;
-	keyReader.readAsText(PS4Key.files[0]);
-
-	let serialReader = new FileReader();
-	serialReader.onloadend = handleSerial;
-	serialReader.readAsText(PS4Serial.files[0]);
-
-	let sigReader = new FileReader();
-	sigReader.onloadend = handleSignature;
-	sigReader.readAsBinaryString(PS4Signature.files[0]);
-
-	async function checkRead () {
-		if ( count < 3 ) {
-			setTimeout(checkRead, 1000);
-		} else {
-			// Make sure our signature is 256 bytes
-			if ( signature.length !== 256 || serial.length !== 16) {
-				throw new Error("Signature or serial is invalid");
-			}
-			try {
-				serial = serial.padStart(32,'0'); // Add our padding
-
-				const key = new JSEncrypt();
-				key.setPrivateKey(pem);
-				const bytes = new Uint8Array(256);
-				for(let i = 0; i < 256; i++){
-					bytes[i] = Math.random();
-				}
-				const hashed = CryptoJS.SHA256(bytes);
-				const signNonce = key.sign(hashed, CryptoJS.SHA256, "sha256");
-
-				if (signNonce === false) {
-					throw new Error("Bad Private Key");
-				}
-
-				// Private key worked!
-
-				// Translate these to BigInteger
-				var N = BigInt(String(key.key.n));
-				var E = BigInt(String(key.key.e));
-				var D = BigInt(String(key.key.d));
-				var P = BigInt(String(key.key.p));
-				var Q = BigInt(String(key.key.q));
-				var DP = BigInt(String(key.key.dmp1));
-				var DQ = BigInt(String(key.key.dmq1));
-				var constantR = BigInt('2') ** BigInt(4096); 	// constant R
-				var QP = bigintModArith.modInv(Q,P); 						// qp = 1 / ( Q % P)
-				var RN = constantR % N; 						// rn = constant R mod N
-
-				function int2mbedmpi(num) {
-					var out = [];
-					var mask = BigInt('4294967295');
-					var zero = BigInt('0');
-					while(num !== zero) {
-						out.push((num & mask).toString(16).padStart(8, '0'));
-						num = num >> BigInt(32);
-					}
-					return out;
-				}
-
-				function hexToBytes(hex) {
-					let bytes = [];
-					for (let c = 0; c < hex.length; c += 2)
-						bytes.push(parseInt(hex.substr(c, 2), 16));
-					return bytes;
-				}
-
-				function mbedmpi2b64(mpi) {
-					var arr = new Uint8Array(mpi.length*4);
-					var cnt = 0;
-					for ( let i = 0; i < mpi.length; i++) {
-						let bytes = hexToBytes(mpi[i]);
-						for ( let j = 4; j > 0; j--) {
-							//arr[cnt] = bytes[j];
-							// TEST: re-order from LSB to MSB
-							arr[cnt] = bytes[j-1];
-							cnt++;
-						}
-					}
-
-					return btoa(String.fromCharCode.apply(null, arr));
-				}
-
-				const sendPS4Chunks = async (chunks) => {
-					for ( var i in chunks ) {
-						if (await WebApi.setPS4Options(chunks[i]) === false ) {
-							return false;
-						}
-					}
-					return true;
-				};
-
-
-				let serialBin = hexToBytes(serial);
-
-				let success = await sendPS4Chunks([{
-					N: mbedmpi2b64(int2mbedmpi(N)),
-					E: mbedmpi2b64(int2mbedmpi(E)),
-					D: mbedmpi2b64(int2mbedmpi(D))
-				}, {
-					P: mbedmpi2b64(int2mbedmpi(P)),
-					Q: mbedmpi2b64(int2mbedmpi(Q)),
-					DP: mbedmpi2b64(int2mbedmpi(DP)),
-					DQ: mbedmpi2b64(int2mbedmpi(DQ))
-				}, {
-					QP: mbedmpi2b64(int2mbedmpi(QP)),
-					RN: mbedmpi2b64(int2mbedmpi(RN)),
-					serial: btoa(String.fromCharCode(...new Uint8Array(serialBin)))
-				}, {
-					signature: btoa(signature)
-				}]);
-
-				if ( success ) {
-					document.getElementById("ps4alert").textContent = 'Verified and Saved PS4 Mode! Reboot to take effect';
-					document.getElementById("save").click();
+	const loadFile = (file, text) => {
+		return new Promise((resolve, reject) => {
+			const keyReader = new FileReader();
+			keyReader.onloadend = (e) => {
+				if (!isNil(keyReader.error)) {
+					reject(keyReader.error);
 				} else {
-					throw Error("PS4 Chunks Error");
+					resolve(keyReader.result);
 				}
+			};
+			if (text) {
+				keyReader.readAsText(file);
+			} else {
+				keyReader.readAsBinaryString(file);
+			}
+		});
+	};
 
-			} catch (e) {
-				document.getElementById("ps4alert").textContent = 'ERROR: Could not verify required files';
+	function int2mbedmpi(num) {
+		var out = [];
+		var mask = BigInt('4294967295');
+		var zero = BigInt('0');
+		while(num !== zero) {
+			out.push((num & mask).toString(16).padStart(8, '0'));
+			num = num >> BigInt(32);
+		}
+		return out;
+	}
+
+	function hexToBytes(hex) {
+		let bytes = [];
+		for (let c = 0; c < hex.length; c += 2)
+			bytes.push(parseInt(hex.substr(c, 2), 16));
+		return bytes;
+	}
+
+	function mbedmpi2b64(mpi) {
+		var arr = new Uint8Array(mpi.length*4);
+		var cnt = 0;
+		for ( let i = 0; i < mpi.length; i++) {
+			let bytes = hexToBytes(mpi[i]);
+			for ( let j = 4; j > 0; j--) {
+				//arr[cnt] = bytes[j];
+				// TEST: re-order from LSB to MSB
+				arr[cnt] = bytes[j-1];
+				cnt++;
 			}
 		}
-	};
-	setTimeout(checkRead, 1000);
+
+		return btoa(String.fromCharCode.apply(null, arr));
+	}
+
+	try {
+		const [pem, signature, serialFileContent] = await Promise.all([
+			loadFile(PS4Key.files[0], true),
+			loadFile(PS4Signature.files[0], false),
+			loadFile(PS4Serial.files[0], true),
+		]);
+
+		// Make sure our signature is 256 bytes
+		const serialNoPadding = serialFileContent.trimRight();
+		if ( signature.length !== 256 || serialNoPadding.length !== 16) {
+			throw new Error("Signature or serial is invalid");
+		}
+		const serial = serialNoPadding.padStart(32, '0'); // Add our padding
+
+		const key = new JSEncrypt();
+		key.setPrivateKey(pem);
+		const bytes = new Uint8Array(256);
+		for(let i = 0; i < 256; i++){
+			bytes[i] = Math.random() * 255;
+		}
+		const hashed = CryptoJS.SHA256(bytes);
+		const signNonce = key.sign(hashed, CryptoJS.SHA256, "sha256");
+
+		if (signNonce === false) {
+			throw new Error("Bad Private Key");
+		}
+
+		// Private key worked!
+
+		// Translate these to BigInteger
+		var N = BigInt(String(key.key.n));
+		var E = BigInt(String(key.key.e));
+		var P = BigInt(String(key.key.p));
+		var Q = BigInt(String(key.key.q));
+
+		let serialBin = hexToBytes(serial);
+
+		let success = await WebApi.setPS4Options({
+			N: mbedmpi2b64(int2mbedmpi(N)),
+			E: mbedmpi2b64(int2mbedmpi(E)),
+			P: mbedmpi2b64(int2mbedmpi(P)),
+			Q: mbedmpi2b64(int2mbedmpi(Q)),
+			serial: btoa(String.fromCharCode(...new Uint8Array(serialBin))),
+			signature: btoa(signature),
+		});
+
+		if ( success ) {
+			document.getElementById("ps4alert").textContent = 'Verified and Saved PS4 Mode! Reboot to take effect';
+			document.getElementById("save").click();
+		} else {
+			throw Error("ERROR: Failed to upload the key to the board");
+		}
+
+	} catch (e) {
+		document.getElementById("ps4alert").textContent = "ERROR: Could not verify required files: ${e}";
+	}
 };
 
 const SOCD_MODES = [


### PR DESCRIPTION
This is a smaller scale refactor than #374.

Notable changes:
- Frontend now uses Promise.all to load all required files.
- RSA key loading from config and identity exporting after signing are now done in mbedTLS API.
- Cut down redundant RSA factors in config storage. Now it only saves N, E, P and Q to the config and calculates the rest of the factors during setup(). This should save around 900 bytes of config storage.