### PR TITLE
Ability to switch between action/direction button profiles

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -62,6 +62,7 @@ public:
 	Gamepad(int debounceMS = 5);
 
 	void setup();
+	void teardown_and_reinit(const uint32_t profileNum);
 	void process();
 	void read();
 	void save();

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -44,8 +44,11 @@ public:
 	LEDOptions& getLedOptions() { return config.ledOptions; }
 	AddonOptions& getAddonOptions() { return config.addonOptions; }
 	AnimationOptions_Proto& getAnimationOptions() { return config.animationOptions; }
+	ProfileOptions& getProfileOptions() { return config.profileOptions; }
 
 	bool save();
+
+	PinMappings& getProfilePinMappings();
 
 	// Perform saves that were enqueued from core1
 	void performEnqueuedSaves();
@@ -65,6 +68,9 @@ public:
 	void ClearFeatureData();
 	uint8_t * GetFeatureData();
 
+	void setProfile(const uint32_t);		// profile support for multiple mappings
+	void setFunctionalPinMappings(const uint32_t);
+
 	void ResetSettings(); 				// EEPROM Reset Feature
 
 private:
@@ -79,6 +85,7 @@ private:
 	critical_section_t animationOptionsCs;
 	uint32_t animationOptionsCrc = 0;
 	AnimationOptions animationOptionsToSave = {};
+	PinMappings* functionalPinMappings = nullptr;
 };
 
 #endif

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -13,6 +13,7 @@ message GamepadOptions
 	optional bool switchTpShareForDs4 = 6;
 	optional bool lockHotkeys = 7;
 	optional bool fourWayMode = 8;
+	optional uint32 profileNumber = 9;
 }
 
 message KeyboardMapping
@@ -113,6 +114,29 @@ message PinMappings
 	optional int32 pinButtonA1 = 17;
 	optional int32 pinButtonA2 = 18;
 	optional int32 pinButtonFn = 19;
+}
+
+
+message AlternativePinMappings
+{
+	optional int32 pinButtonB1 = 1;
+	optional int32 pinButtonB2 = 2;
+	optional int32 pinButtonB3 = 3;
+	optional int32 pinButtonB4 = 4;
+	optional int32 pinButtonL1 = 5;
+	optional int32 pinButtonR1 = 6;
+	optional int32 pinButtonL2 = 7;
+	optional int32 pinButtonR2 = 8;
+	optional int32 pinDpadUp = 9;
+	optional int32 pinDpadDown = 10;
+	optional int32 pinDpadLeft = 11;
+	optional int32 pinDpadRight = 12;
+}
+
+
+message ProfileOptions
+{
+	repeated AlternativePinMappings alternativePinMappings = 1 [(nanopb).max_count = 3];
 }
 
 message DisplayOptions
@@ -465,4 +489,5 @@ message Config
 	optional AnimationOptions_Proto animationOptions = 8;
 	optional AddonOptions addonOptions = 9;
 	optional ForcedSetupOptions forcedSetupOptions = 10;
+	optional ProfileOptions profileOptions = 11;
 }

--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -136,6 +136,10 @@ enum GamepadHotkey
     HOTKEY_SOCD_BYPASS           = 12;
     HOTKEY_TOGGLE_4_WAY_MODE     = 13;
     HOTKEY_TOGGLE_DDI_4_WAY_MODE = 14;
+    HOTKEY_LOAD_PROFILE_1        = 15;
+    HOTKEY_LOAD_PROFILE_2        = 16;
+    HOTKEY_LOAD_PROFILE_3        = 17;
+    HOTKEY_LOAD_PROFILE_4        = 18;
 }
 
 // This has to be kept in sync with LEDFormat in NeoPico.hpp

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -97,6 +97,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.gamepadOptions, switchTpShareForDs4, false);
     INIT_UNSET_PROPERTY(config.gamepadOptions, lockHotkeys, DEFAULT_LOCK_HOTKEYS);
     INIT_UNSET_PROPERTY(config.gamepadOptions, fourWayMode, false);
+    INIT_UNSET_PROPERTY(config.gamepadOptions, profileNumber, 1);
 
     // hotkeyOptions
     HotkeyOptions& hotkeyOptions = config.hotkeyOptions;
@@ -226,6 +227,45 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.displayOptions, flip, DISPLAY_FLIP);
     INIT_UNSET_PROPERTY(config.displayOptions, invert, !!DISPLAY_INVERT);
     INIT_UNSET_PROPERTY(config.displayOptions, displaySaverTimeout, DISPLAY_SAVER_TIMEOUT);
+
+    // alternate pin mappings
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinButtonB1, PIN_BUTTON_B1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinButtonB2, PIN_BUTTON_B2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinButtonB3, PIN_BUTTON_B3);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinButtonB4, PIN_BUTTON_B4);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinButtonL1, PIN_BUTTON_L1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinButtonR1, PIN_BUTTON_R1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinButtonL2, PIN_BUTTON_L2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinButtonR2, PIN_BUTTON_R2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinDpadUp, PIN_DPAD_UP);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinDpadDown, PIN_DPAD_DOWN);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinDpadLeft, PIN_DPAD_LEFT);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[0], pinDpadRight, PIN_DPAD_RIGHT);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinButtonB1, PIN_BUTTON_B1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinButtonB2, PIN_BUTTON_B2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinButtonB3, PIN_BUTTON_B3);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinButtonB4, PIN_BUTTON_B4);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinButtonL1, PIN_BUTTON_L1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinButtonR1, PIN_BUTTON_R1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinButtonL2, PIN_BUTTON_L2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinButtonR2, PIN_BUTTON_R2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinDpadUp, PIN_DPAD_UP);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinDpadDown, PIN_DPAD_DOWN);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinDpadLeft, PIN_DPAD_LEFT);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[1], pinDpadRight, PIN_DPAD_RIGHT);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinButtonB1, PIN_BUTTON_B1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinButtonB2, PIN_BUTTON_B2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinButtonB3, PIN_BUTTON_B3);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinButtonB4, PIN_BUTTON_B4);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinButtonL1, PIN_BUTTON_L1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinButtonR1, PIN_BUTTON_R1);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinButtonL2, PIN_BUTTON_L2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinButtonR2, PIN_BUTTON_R2);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinDpadUp, PIN_DPAD_UP);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinDpadDown, PIN_DPAD_DOWN);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinDpadLeft, PIN_DPAD_LEFT);
+    INIT_UNSET_PROPERTY(config.profileOptions.alternativePinMappings[2], pinDpadRight, PIN_DPAD_RIGHT);
+    config.profileOptions.alternativePinMappings_count = 3;
 
     // ledOptions
     INIT_UNSET_PROPERTY(config.ledOptions, dataPin, BOARD_LEDS_PIN);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1,4 +1,5 @@
 #include "configs/webconfig.h"
+#include "config.pb.h"
 #include "configs/base64.h"
 
 #include "storagemanager.h"
@@ -503,6 +504,60 @@ std::string setSplashImage()
 	return serialize_json(doc);
 }
 
+std::string setProfileOptions()
+{
+	DynamicJsonDocument doc = get_post_data();
+
+	ProfileOptions& profileOptions = Storage::getInstance().getProfileOptions();
+	JsonObject options = doc.as<JsonObject>();
+	JsonArray alts = options["alternativePinMappings"];
+	int altsIndex = 0;
+	for (JsonObject alt : alts) {
+		profileOptions.alternativePinMappings[altsIndex].pinButtonB1 = alt["B1"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinButtonB2 = alt["B2"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinButtonB3 = alt["B3"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinButtonB4 = alt["B4"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinButtonL1 = alt["L1"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinButtonR1 = alt["R1"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinButtonL2 = alt["L2"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinButtonR2 = alt["R2"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinDpadUp = alt["Up"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinDpadDown = alt["Down"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinDpadLeft = alt["Left"].as<int>();
+		profileOptions.alternativePinMappings[altsIndex].pinDpadRight = alt["Right"].as<int>();
+		profileOptions.alternativePinMappings_count = ++altsIndex;
+		if (altsIndex > 2) break;
+	}
+
+	Storage::getInstance().save();
+	return serialize_json(doc);
+}
+
+std::string getProfileOptions()
+{
+	DynamicJsonDocument doc(LWIP_HTTPD_POST_MAX_PAYLOAD_LEN);
+
+	ProfileOptions& profileOptions = Storage::getInstance().getProfileOptions();
+	JsonArray alts = doc.createNestedArray("alternativePinMappings");
+	for (int i = 0; i < profileOptions.alternativePinMappings_count; i++) {
+		JsonObject altMappings = alts.createNestedObject();
+		altMappings["B1"] = profileOptions.alternativePinMappings[i].pinButtonB1;
+		altMappings["B2"] = profileOptions.alternativePinMappings[i].pinButtonB2;
+		altMappings["B3"] = profileOptions.alternativePinMappings[i].pinButtonB3;
+		altMappings["B4"] = profileOptions.alternativePinMappings[i].pinButtonB4;
+		altMappings["L1"] = profileOptions.alternativePinMappings[i].pinButtonL1;
+		altMappings["R1"] = profileOptions.alternativePinMappings[i].pinButtonR1;
+		altMappings["L2"] = profileOptions.alternativePinMappings[i].pinButtonL2;
+		altMappings["R2"] = profileOptions.alternativePinMappings[i].pinButtonR2;
+		altMappings["Up"] = profileOptions.alternativePinMappings[i].pinDpadUp;
+		altMappings["Down"] = profileOptions.alternativePinMappings[i].pinDpadDown;
+		altMappings["Left"] = profileOptions.alternativePinMappings[i].pinDpadLeft;
+		altMappings["Right"] = profileOptions.alternativePinMappings[i].pinDpadRight;
+	}
+
+	return serialize_json(doc);
+}
+
 std::string setGamepadOptions()
 {
 	DynamicJsonDocument doc = get_post_data();
@@ -514,6 +569,7 @@ std::string setGamepadOptions()
 	readDoc(gamepadOptions.switchTpShareForDs4, doc, "switchTpShareForDs4");
 	readDoc(gamepadOptions.lockHotkeys, doc, "lockHotkeys");
 	readDoc(gamepadOptions.fourWayMode, doc, "fourWayMode");
+	readDoc(gamepadOptions.profileNumber, doc, "profileNumber");
 
 	HotkeyOptions& hotkeyOptions = Storage::getInstance().getHotkeyOptions();
 	save_hotkey(&hotkeyOptions.hotkey01, doc, "hotkey01");
@@ -548,6 +604,7 @@ std::string getGamepadOptions()
 	writeDoc(doc, "switchTpShareForDs4", gamepadOptions.switchTpShareForDs4 ? 1 : 0);
 	writeDoc(doc, "lockHotkeys", gamepadOptions.lockHotkeys ? 1 : 0);
 	writeDoc(doc, "fourWayMode", gamepadOptions.fourWayMode ? 1 : 0);
+	writeDoc(doc, "profileNumber", gamepadOptions.profileNumber);
 
 	const PinMappings& pinMappings = Storage::getInstance().getPinMappings();
 	writeDoc(doc, "fnButtonPin", pinMappings.pinButtonFn);
@@ -1402,6 +1459,7 @@ static const std::pair<const char*, HandlerFuncPtr> handlerFuncs[] =
 	{ "/api/setCustomTheme", setCustomTheme },
 	{ "/api/getCustomTheme", getCustomTheme },
 	{ "/api/setPinMappings", setPinMappings },
+	{ "/api/setProfileOptions", setProfileOptions },
 	{ "/api/setKeyMappings", setKeyMappings },
 	{ "/api/setAddonsOptions", setAddonOptions },
 	{ "/api/setPS4Options", setPS4Options },
@@ -1411,6 +1469,7 @@ static const std::pair<const char*, HandlerFuncPtr> handlerFuncs[] =
 	{ "/api/getGamepadOptions", getGamepadOptions },
 	{ "/api/getLedOptions", getLedOptions },
 	{ "/api/getPinMappings", getPinMappings },
+	{ "/api/getProfileOptions", getProfileOptions },
 	{ "/api/getKeyMappings", getKeyMappings },
 	{ "/api/getAddonsOptions", getAddonOptions },
 	{ "/api/resetSettings", resetSettings },

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -9,6 +9,7 @@
 #include "AnimationStorage.hpp"
 #include "Effects/StaticColor.hpp"
 #include "FlashPROM.h"
+#include "config.pb.h"
 #include "hardware/watchdog.h"
 #include "Animation.hpp"
 #include "CRC32.h"
@@ -130,6 +131,39 @@ void Storage::ResetSettings()
 {
 	EEPROM.reset();
 	watchdog_reboot(0, SRAM_END, 2000);
+}
+
+PinMappings& Storage::getProfilePinMappings() {
+	if (functionalPinMappings == nullptr) {
+		functionalPinMappings = (PinMappings*)malloc(sizeof(PinMappings));
+		setFunctionalPinMappings(config.gamepadOptions.profileNumber);
+	}
+	return *functionalPinMappings;
+}
+
+void Storage::setProfile(const uint32_t profileNum)
+{
+	setFunctionalPinMappings(profileNum);
+}
+
+void Storage::setFunctionalPinMappings(const uint32_t profileNum)
+{
+	memcpy(functionalPinMappings, &config.pinMappings, sizeof(PinMappings));
+	if (profileNum < 2 || profileNum > 4) return;
+
+	AlternativePinMappings alts = this->config.profileOptions.alternativePinMappings[profileNum-2];
+	if (isValidPin(alts.pinButtonB1)) functionalPinMappings->pinButtonB1 = alts.pinButtonB1;
+	if (isValidPin(alts.pinButtonB2)) functionalPinMappings->pinButtonB2 = alts.pinButtonB2;
+	if (isValidPin(alts.pinButtonB3)) functionalPinMappings->pinButtonB3 = alts.pinButtonB3;
+	if (isValidPin(alts.pinButtonB4)) functionalPinMappings->pinButtonB4 = alts.pinButtonB4;
+	if (isValidPin(alts.pinButtonL1)) functionalPinMappings->pinButtonL1 = alts.pinButtonL1;
+	if (isValidPin(alts.pinButtonR1)) functionalPinMappings->pinButtonR1 = alts.pinButtonR1;
+	if (isValidPin(alts.pinButtonL2)) functionalPinMappings->pinButtonL2 = alts.pinButtonL2;
+	if (isValidPin(alts.pinButtonR2)) functionalPinMappings->pinButtonR2 = alts.pinButtonR2;
+	if (isValidPin(alts.pinDpadUp)) functionalPinMappings->pinDpadUp = alts.pinDpadUp;
+	if (isValidPin(alts.pinDpadDown)) functionalPinMappings->pinDpadDown = alts.pinDpadDown;
+	if (isValidPin(alts.pinDpadLeft)) functionalPinMappings->pinDpadLeft = alts.pinDpadLeft;
+	if (isValidPin(alts.pinDpadRight)) functionalPinMappings->pinDpadRight = alts.pinDpadRight;
 }
 
 void Storage::SetConfigMode(bool mode) { // hack for config mode

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -92,6 +92,7 @@ app.get("/api/getGamepadOptions", (req, res) => {
 		lockHotkeys: 0,
 		fourWayMode: 0,
 		fnButtonPin: -1,
+		profileNumber: 1,
 		hotkey01: {
 			auxMask: 32768,
 			buttonsMask: 66304,
@@ -225,6 +226,51 @@ app.get("/api/getPinMappings", (req, res) => {
 app.get("/api/getKeyMappings", (req, res) =>
 	res.send(mapValues(DEFAULT_KEYBOARD_MAPPING))
 );
+
+app.get("/api/getProfileOptions", (req, res) => {
+	return res.send({
+		alternativePinMappings: [{
+			B1: 10,
+			B2: 6,
+			B3: 11,
+			B4: 12,
+			L1: 13,
+			R1: 9,
+			L2: 7,
+			R2: 8,
+			Up: 2,
+			Down: 3,
+			Left: 5,
+			Right: 4
+		},{
+			B1: 10,
+			B2: 11,
+			B3: 12,
+			B4: 13,
+			L1: 6,
+			R1: 8,
+			L2: 7,
+			R2: 9,
+			Up: 3,
+			Down: 2,
+			Left: 4,
+			Right: 5
+		},{
+			B1: 6,
+			B2: 7,
+			B3: 8,
+			B4: 9,
+			L1: 10,
+			R1: 12,
+			L2: 11,
+			R2: 13,
+			Up: 3,
+			Down: 5,
+			Left: 4,
+			Right: 2
+		}]
+	});
+});
 
 app.get("/api/getAddonsOptions", (req, res) => {
 	return res.send({

--- a/www/src/App.jsx
+++ b/www/src/App.jsx
@@ -7,6 +7,7 @@ import Navigation from './Components/Navigation'
 
 import HomePage from './Pages/HomePage'
 import PinMappingPage from "./Pages/PinMapping";
+import ProfileSettingsPage from "./Pages/ProfileSettings";
 import KeyboardMappingPage from "./Pages/KeyboardMapping";
 import ResetSettingsPage from './Pages/ResetSettingsPage';
 import SettingsPage from './Pages/SettingsPage';
@@ -31,6 +32,7 @@ const App = () => {
 						<Route path="/settings" element={<SettingsPage />} />
 						<Route path="/pin-mapping" element={<PinMappingPage />} />
 						<Route path="/keyboard-mapping" element={<KeyboardMappingPage />} />
+						<Route path="/profile-settings" element={<ProfileSettingsPage />} />
 						<Route path="/reset-settings" element={<ResetSettingsPage />} />
 						<Route path="/led-config" element={<LEDConfigPage />} />
 						<Route path="/custom-theme" element={<CustomThemePage />} />

--- a/www/src/Components/Navigation.jsx
+++ b/www/src/Components/Navigation.jsx
@@ -51,6 +51,7 @@ const Navigation = (props) => {
 					<NavDropdown title={t('Navigation:config-label')}>
 						<NavDropdown.Item as={NavLink} exact="true" to="/pin-mapping">{t('Navigation:pin-mapping-label')}</NavDropdown.Item>
 						<NavDropdown.Item as={NavLink} exact="true" to="/keyboard-mapping">{t('Navigation:keyboard-mapping-label')}</NavDropdown.Item>
+						<NavDropdown.Item as={NavLink} exact="true" to="/profile-settings">{t('Navigation:profile-settings-label')}</NavDropdown.Item>
 						<NavDropdown.Item as={NavLink} exact="true" to="/led-config">{t('Navigation:led-config-label')}</NavDropdown.Item>
 						<NavDropdown.Item as={NavLink} exact="true" to="/custom-theme">{t('Navigation:custom-theme-label')}</NavDropdown.Item>
 						<NavDropdown.Item as={NavLink} exact="true" to="/display-config">{t('Navigation:display-config-label')}</NavDropdown.Item>

--- a/www/src/Locales/en/Index.jsx
+++ b/www/src/Locales/en/Index.jsx
@@ -5,6 +5,7 @@ import SettingsPage from './SettingsPage';
 import ResetSettings from './ResetSettings';
 import Components from './Components';
 import PinMapping from './PinMapping';
+import ProfileSettings from './ProfileSettings';
 import KeyboardMapping from './KeyboardMapping';
 import LedConfig from './LedConfig';
 import CustomTheme from './CustomTheme';
@@ -20,6 +21,7 @@ export default {
 	ResetSettings,
 	Components,
 	PinMapping,
+	ProfileSettings,
 	KeyboardMapping,
 	LedConfig,
 	CustomTheme,

--- a/www/src/Locales/en/Navigation.jsx
+++ b/www/src/Locales/en/Navigation.jsx
@@ -12,6 +12,7 @@ export default {
 	'led-config-label': 'LED Configuration',
 	'links-label': 'Links',
 	'pin-mapping-label': 'Pin Mapping',
+	"profile-settings-label": "Profile Settings",
 	'reboot-label': 'Reboot',
 	'reboot-modal-body': 'Select a mode to reboot to',
 	'reboot-modal-button-bootsel-label': 'USB (BOOTSEL)',

--- a/www/src/Locales/en/ProfileSettings.jsx
+++ b/www/src/Locales/en/ProfileSettings.jsx
@@ -1,0 +1,9 @@
+export default {
+	"header-text": "Profiles",
+	"profile-pins-desc": "This page allows three additional button mappings to be configured as profiles 2 through 4, which can be loaded via hotkey. (The first profile is the core configuration from the Pin Mapping page.) A physical layout of the pins:",
+	"profile-1": "Profile 1",
+	"profile-2": "Profile 2",
+	"profile-3": "Profile 3",
+	"profile-4": "Profile 4",
+	"profile-pins-warning": "Try to avoid changing the buttons/directions used for your switch profile hotkeys, or else it will get hard to understand what profile you are selecting!",
+}

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -24,6 +24,7 @@ export default {
 		'first-win': 'First Win',
 		'off': 'Off'
 	},
+	'profile-number-label': 'Profile Number',
 	'hotkey-settings-label': 'Hotkey Settings',
 	'hotkey-settings-sub-header': "The <1>Fn</1> slider provides a mappable Function button in the <3 exact='true' to='/pin-mapping'>Pin Mapping</3> page. By selecting the <1>Fn</1> slider option, the Function button must be held along with the selected hotkey settings.<5 />Additionally, select <1>None</1> from the dropdown to unassign any button.",
 	'hotkey-settings-warning': 'Function button is not mapped. The Fn slider will be disabled.',
@@ -43,6 +44,10 @@ export default {
 		'invert-y': 'Invert Y Axis',
 		'toggle-4way-joystick-mode': 'Toggle 4-Way Joystick Mode',
 		'toggle-ddi-4way-joystick-mode': 'Toggle DDI 4-Way Joystick Mode',
+		'load-profile-1': 'Load Profile #1',
+		'load-profile-2': 'Load Profile #2',
+		'load-profile-3': 'Load Profile #3',
+		'load-profile-4': 'Load Profile #4',
 	},
 	'forced-setup-mode-label': 'Forced Setup Mode',
 	'forced-setup-mode-options': {

--- a/www/src/Pages/ProfileSettings.jsx
+++ b/www/src/Pages/ProfileSettings.jsx
@@ -1,0 +1,199 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { NavLink } from "react-router-dom";
+import { Button, Form } from 'react-bootstrap';
+import { AppContext } from '../Contexts/AppContext';
+import Section from '../Components/Section';
+import WebApi, { baseProfileOptions, baseButtonMappings } from '../Services/WebApi';
+import boards from '../Data/Boards.json';
+import { BUTTONS } from '../Data/Buttons';
+import './PinMappings.scss';
+import { Trans, useTranslation } from 'react-i18next';
+
+const requiredButtons = ['S2'];
+const errorType = {
+	required: 'errors.required',
+	conflict: 'errors.conflict',
+	invalid: 'errors.invalid',
+	used: 'errors.used',
+};
+
+export default function ProfileOptionsPage() {
+	const { buttonLabels, setButtonLabels, usedPins, updateUsedPins } = useContext(AppContext);
+	const [validated, setValidated] = useState(false);
+	const [saveMessage, setSaveMessage] = useState('');
+	const [buttonMappings, setButtonMappings] = useState(baseButtonMappings);
+	const [profileOptions, setProfileOptions] = useState(baseProfileOptions);
+	const [selectedBoard] = useState(import.meta.env.VITE_GP2040_BOARD);
+	const { buttonLabelType } = buttonLabels;
+	const { setLoading } = useContext(AppContext);
+
+	const { t } = useTranslation('');
+
+	const translatedErrorType = Object.keys(errorType).reduce((a, k) => ({ ...a, [k]: t(`ProfileOptions:${errorType[k]}`) }), {});
+
+	useEffect(() => {
+		async function fetchData() {
+			setButtonMappings(await WebApi.getPinMappings(setLoading));
+			setProfileOptions(await WebApi.getProfileOptions(setLoading));
+			setButtonLabels({});
+		}
+
+		fetchData();
+	}, [setButtonMappings, setProfileOptions]);
+
+	const handlePinChange = (e, index, key) => {
+		const newProfileOptions = { ...profileOptions };
+		if (e.target.value)
+			newProfileOptions['alternativePinMappings'][index][key].pin = parseInt(e.target.value);
+		else
+			newProfileOptions['alternativePinMappings'][index][key].pin = '';
+
+		validateMappings(newProfileOptions);
+	};
+
+	const handleSubmit = async (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		let mappings = { ...profileOptions };
+		validateMappings(mappings);
+
+		if (Object.keys(mappings).filter(p => mappings[p].error).length > 0) {
+			setSaveMessage(t('Common:errors.validation-error'));
+			return;
+		}
+
+		const success = await WebApi.setProfileOptions(mappings);
+		if (success)
+			updateUsedPins();
+		setSaveMessage(success ? t('Common:saved-success-message') : t('Common:saved-error-message'));
+	};
+
+	const validateMappings = (mappings) => {
+		profileOptions['alternativePinMappings'].forEach((altMappings) => {
+			const buttons = Object.keys(altMappings);
+
+			// Create some mapped pin groups for easier error checking
+			const mappedPins = buttons
+				.filter(p => altMappings[p].pin > -1)
+				.reduce((a, p) => {
+					a.push(altMappings[p].pin);
+					return a;
+				}, []);
+			const mappedPinCounts = mappedPins.reduce((a, p) => ({ ...a, [p]: (a[p] || 0) + 1 }), {});
+			const uniquePins = mappedPins.filter((p, i, a) => a.indexOf(p) === i);
+			const conflictedPins = Object.keys(mappedPinCounts).filter(p => mappedPinCounts[p] > 1).map(parseInt);
+			const invalidPins = uniquePins.filter(p => boards[selectedBoard].invalidPins.indexOf(p) > -1);
+			const otherPins = usedPins.filter(p => uniquePins.indexOf(p) === -1);
+
+			for (let button of buttons) {
+				altMappings[button].error = '';
+
+				// Validate required button
+				if ((altMappings[button].pin < boards[selectedBoard].minPin || altMappings[button].pin > boards[selectedBoard].maxPin) && requiredButtons.filter(b => b === button).length)
+					altMappings[button].error = translatedErrorType.required;
+
+				// Identify conflicted pins
+				else if (conflictedPins.indexOf(altMappings[button].pin) > -1)
+					altMappings[button].error = translatedErrorType.conflict;
+
+				// Identify invalid pin assignments
+				else if (invalidPins.indexOf(altMappings[button].pin) > -1)
+					altMappings[button].error = translatedErrorType.invalid;
+
+				// Identify used pins
+				else if (otherPins.indexOf(altMappings[button].pin) > -1)
+					altMappings[button].error = translatedErrorType.used;
+			}
+		});
+
+		setProfileOptions(mappings);
+		setValidated(true);
+	};
+
+	const pinCell = (profile, button) => {
+		return <td>
+			<Form.Control
+				type="number"
+				className="pin-input form-control-sm"
+				value={profileOptions['alternativePinMappings'][profile][button].pin}
+				min={-1}
+				max={boards[selectedBoard].maxPin}
+				isInvalid={profileOptions['alternativePinMappings'][profile][button].error}
+				onChange={(e) => handlePinChange(e, profile, button)}
+			></Form.Control>
+			<Form.Control.Feedback type="invalid">
+				{renderError(profile, button)}
+			</Form.Control.Feedback>
+		</td>
+	}
+
+	const renderError = (index, button) => {
+		if (profileOptions['alternativePinMappings'][index][button].error === translatedErrorType.required) {
+			return <span key="required" className="error-message">{t('PinMapping:errors.required', {
+        button: BUTTONS[buttonLabelType][button]
+      })}</span>;
+		}
+		else if (profileOptions['alternativePinMappings'][index][button].error === translatedErrorType.conflict) {
+			const conflictedMappings = Object.keys(profileOptions['alternativePinMappings'][index])
+				.filter(b => b !== button)
+				.filter(b => profileOptions['alternativePinMappings'][index][b].pin === profileOptions['alternativePinMappings'][index][button].pin)
+				.map(b => BUTTONS[buttonLabelType][b]);
+
+			return <span key="conflict" className="error-message">{t('PinMapping:errors.conflict', {
+        pin: profileOptions['alternativePinMappings'][index][button].pin,
+        conflictedMappings: conflictedMappings.join(', '),
+      })}</span>;
+		}
+		else if (profileOptions['alternativePinMappings'][index][button].error === translatedErrorType.invalid) {
+			console.log(profileOptions['alternativePinMappings'][index][button].pin);
+			return <span key="invalid" className="error-message">{t('PinMapping:errors.invalid', {
+        pin: profileOptions['alternativePinMappings'][index][button].pin
+      })}</span>;
+		}
+		else if (profileOptions['alternativePinMappings'][index][button].error === translatedErrorType.used) {
+			return <span key="used" className="error-message">{t('PinMapping:errors.used', {
+        pin: profileOptions['alternativePinMappings'][index][button].pin
+      })}</span>;
+		}
+
+		return <></>;
+	};
+
+	return (
+		<Section title={t('ProfileSettings:header-text')}>
+			<p>{t('ProfileSettings:profile-pins-desc')}</p>
+			<pre>&nbsp;&nbsp;{String(buttonMappings['Up'].pin).padStart(2)}<br />
+		             {String(buttonMappings['Left'].pin).padStart(2)}&nbsp;&nbsp;{String(buttonMappings['Right'].pin).padStart(2)}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{String(buttonMappings['B3'].pin).padStart(2)} {String(buttonMappings['B4'].pin).padStart(2)} {String(buttonMappings['R1'].pin).padStart(2)} {String(buttonMappings['L1'].pin).padStart(2)}<br />
+			     &nbsp;&nbsp;{String(buttonMappings['Down'].pin).padStart(2)}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{String(buttonMappings['B1'].pin).padStart(2)} {String(buttonMappings['B2'].pin).padStart(2)} {String(buttonMappings['R2'].pin).padStart(2)} {String(buttonMappings['L2'].pin).padStart(2)}</pre>
+			<p><b>{t('ProfileSettings:profile-pins-warning')}</b></p>
+			<Form noValidate validated={validated} onSubmit={handleSubmit}>
+				<table className="table table-sm pin-mapping-table">
+					<thead>
+						<tr>
+							<th className="table-header-button-label">{BUTTONS[buttonLabelType].label}</th>
+							<th>{t('ProfileSettings:profile-1')}</th>
+							<th>{t('ProfileSettings:profile-2')}</th>
+							<th>{t('ProfileSettings:profile-3')}</th>
+							<th>{t('ProfileSettings:profile-4')}</th>
+						</tr>
+					</thead>
+					<tbody>
+						{console.log(Object.keys(profileOptions['alternativePinMappings'][0]))}
+						{Object.keys(profileOptions['alternativePinMappings'][0]).map((key) => (
+							<tr key={key}>
+								<td>{BUTTONS[buttonLabelType][key]}</td>
+								<td>{buttonMappings[key].pin}</td>
+								{pinCell(0, key)}
+								{pinCell(1, key)}
+								{pinCell(2, key)}
+							</tr>
+						))}
+					</tbody>
+				</table>
+				<Button type="submit">{t('Common:button-save-label')}</Button>
+				{saveMessage ? <span className="alert">{saveMessage}</span> : null}
+			</Form>
+		</Section>
+	);
+}

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -49,6 +49,10 @@ const HOTKEY_ACTIONS = [
 	{ labelKey: 'hotkey-actions.invert-y', value: 10 },
 	{ labelKey: 'hotkey-actions.toggle-4way-joystick-mode', value: 13 },
 	{ labelKey: 'hotkey-actions.toggle-ddi-4way-joystick-mode', value: 14 },
+	{ labelKey: 'hotkey-actions.load-profile-1', value: 15 },
+	{ labelKey: 'hotkey-actions.load-profile-2', value: 16 },
+	{ labelKey: 'hotkey-actions.load-profile-3', value: 17 },
+	{ labelKey: 'hotkey-actions.load-profile-4', value: 18 },
 ];
 
 const FORCED_SETUP_MODES = [
@@ -80,6 +84,7 @@ const schema = yup.object().shape({
 	forcedSetupMode : yup.number().required().oneOf(FORCED_SETUP_MODES.map(o => o.value)).label('SOCD Cleaning Mode'),
 	lockHotkeys: yup.number().required().label('Lock Hotkeys'),
 	fourWayMode: yup.number().required().label('4-Way Joystick Mode'),
+	profileNumber: yup.number().required().label('Profile Number'),
 });
 
 const FormContext = ({ setButtonLabels }) => {
@@ -110,6 +115,8 @@ const FormContext = ({ setButtonLabels }) => {
 			values.lockHotkeys = parseInt(values.lockHotkeys);
 		if (!!values.fourWayMode)
 			values.fourWayMode = parseInt(values.fourWayMode);
+		if (!!values.profileNumber)
+			values.profileNumber = parseInt(values.profileNumber);
 
 		setButtonLabels({ swapTpShareLabels: (values.switchTpShareForDs4 === 1) && (values.inputMode === 4) });
 
@@ -242,6 +249,20 @@ export default function SettingsPage() {
 							checked={Boolean(values.fourWayMode)}
 							onChange={(e) => { setFieldValue("fourWayMode", e.target.checked ? 1 : 0); }}
 						/>
+						<Form.Group className="row mb-3">
+							<Form.Label>{t('SettingsPage:profile-number-label')}</Form.Label>
+							<div className="col-sm-3">
+								<Form.Control
+									type="number"
+									className="row mb-3"
+									value={values.profileNumber}
+									min={1}
+									max={4}
+									isInvalid={false}
+									onChange={(e) => { setFieldValue("profileNumber", parseInt(e.target.value));}}
+								></Form.Control>
+							</div>
+						</Form.Group>
 					</Section>
 					<Section title={t('SettingsPage:hotkey-settings-label')}>
 						<div className="mb-3">

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -25,6 +25,49 @@ export const baseButtonMappings = {
 	Fn:    { pin: -1, key: 0, error: null },
 };
 
+export const baseProfileOptions = {
+	alternativePinMappings: [{
+		Up:    { pin: -1, key: 0, error: null },
+		Down:  { pin: -1, key: 0, error: null },
+		Left:  { pin: -1, key: 0, error: null },
+		Right: { pin: -1, key: 0, error: null },
+		B1:    { pin: -1, key: 0, error: null },
+		B2:    { pin: -1, key: 0, error: null },
+		B3:    { pin: -1, key: 0, error: null },
+		B4:    { pin: -1, key: 0, error: null },
+		L1:    { pin: -1, key: 0, error: null },
+		R1:    { pin: -1, key: 0, error: null },
+		L2:    { pin: -1, key: 0, error: null },
+		R2:    { pin: -1, key: 0, error: null },
+	},{
+		Up:    { pin: -1, key: 0, error: null },
+		Down:  { pin: -1, key: 0, error: null },
+		Left:  { pin: -1, key: 0, error: null },
+		Right: { pin: -1, key: 0, error: null },
+		B1:    { pin: -1, key: 0, error: null },
+		B2:    { pin: -1, key: 0, error: null },
+		B3:    { pin: -1, key: 0, error: null },
+		B4:    { pin: -1, key: 0, error: null },
+		L1:    { pin: -1, key: 0, error: null },
+		R1:    { pin: -1, key: 0, error: null },
+		L2:    { pin: -1, key: 0, error: null },
+		R2:    { pin: -1, key: 0, error: null },
+	},{
+		Up:    { pin: -1, key: 0, error: null },
+		Down:  { pin: -1, key: 0, error: null },
+		Left:  { pin: -1, key: 0, error: null },
+		Right: { pin: -1, key: 0, error: null },
+		B1:    { pin: -1, key: 0, error: null },
+		B2:    { pin: -1, key: 0, error: null },
+		B3:    { pin: -1, key: 0, error: null },
+		B4:    { pin: -1, key: 0, error: null },
+		L1:    { pin: -1, key: 0, error: null },
+		R1:    { pin: -1, key: 0, error: null },
+		L2:    { pin: -1, key: 0, error: null },
+		R2:    { pin: -1, key: 0, error: null },
+	}]
+};
+
 async function resetSettings() {
 	return axios.get(`${baseUrl}/api/resetSettings`)
 		.then((response) => response.data)
@@ -235,6 +278,46 @@ async function setPinMappings(mappings) {
 		});
 }
 
+async function getProfileOptions(setLoading) {
+	setLoading(true);
+
+	try {
+		const response = await axios.get(`${baseUrl}/api/getProfileOptions`);
+		let profileOptions = { ...baseProfileOptions };
+		response.data['alternativePinMappings'].forEach((altButtons, index) => {
+			for (let prop of Object.keys(altButtons))
+				profileOptions['alternativePinMappings'][index][prop].pin = parseInt(
+					response.data['alternativePinMappings'][index][prop]
+				);
+		});
+		setLoading(false);
+		return profileOptions;
+	} catch (error) {
+		console.error(error);
+		return false;
+	}
+}
+
+async function setProfileOptions(options) {
+	let data = {};
+	data['alternativePinMappings'] = [];
+	options['alternativePinMappings'].forEach((altButtons, index) => {
+		let altMapping = {};
+		Object.keys(options['alternativePinMappings'][index]).map((button, i) => altMapping[button] = altButtons[button].pin);
+		data['alternativePinMappings'].push(altMapping);
+	});
+
+	return axios.post(`${baseUrl}/api/setProfileOptions`, sanitizeRequest(data))
+		.then((response) => {
+			console.log(response.data);
+			return true;
+		})
+		.catch((err) => {
+			console.error(err);
+			return false;
+		});
+}
+
 async function getKeyMappings(setLoading) {
 	setLoading(true);
 
@@ -385,6 +468,8 @@ const WebApi = {
 	setCustomTheme,
 	getPinMappings,
 	setPinMappings,
+	getProfileOptions,
+	setProfileOptions,
 	getKeyMappings,
 	setKeyMappings,
 	getAddonsOptions,


### PR DESCRIPTION
Working:
* config section defines up to three three alternative action button slots
* hotkey actions to switch to them
* the actual application of profiles (2-4 overlay the total core mappings in the base settings, which is profile 1)
* config option to store selected profile
* exposing the alt mappings in the API
* web configurator profile setting page w/i18n
* actual board saves and intended behavior confirmed and checked with binary-tools
* above for directionals