### PR TITLE
Correctly import isNil

### DIFF
--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -15,7 +15,7 @@ import CryptoJS from 'crypto-js';
 import * as bigintModArith from 'bigint-mod-arith';
 import get from 'lodash/get';
 import set from "lodash/set";
-import isNil from 'lodash';
+import isNil from 'lodash/isNil';
 
 const I2C_BLOCKS = [
 	{ label: 'i2c0', value: 0 },


### PR DESCRIPTION
The isNil was incorrectly imported, uploading **might** have given false positives or not worked at all prior to this change.
This also reduces the size of the bundle by about 80kb.
