### PR TITLE
add a BOOTSEL reboot hotkey to the "secret" hotkeys

### DIFF
--- a/headers/gp2040.h
+++ b/headers/gp2040.h
@@ -23,17 +23,18 @@ private:
     Gamepad snapshot;
     AddonManager addons;
 
-    struct WebConfigHotkey {
-        WebConfigHotkey();
+    struct RebootHotkeys {
+        RebootHotkeys();
         void process(Gamepad* gamepad, bool configMode);
 
         bool active;
 
         absolute_time_t noButtonsPressedTimeout;
         uint16_t webConfigHotkeyMask;
-        absolute_time_t webConfigHotkeyHoldTimeout;
+        uint16_t bootselHotkeyMask;
+        absolute_time_t rebootHotkeysHoldTimeout;
     };
-    WebConfigHotkey webConfigHotkey;
+    RebootHotkeys rebootHotkeys;
 
     enum class BootAction {
         NONE,


### PR DESCRIPTION
Simple enough. I wrote this because I usually want to bounce between gamepad and boot USB mode, and less so webconfig mode. I put it on S1 + B3 + B4 to match the behavior of the webconfig reboot.

Aside from adding the mask check, most of this is just renaming the struct to reflect that it has two hotkeys in it now.

This is ready to go, AFAIK, but I'm marking it as a draft because I don't think there's any reason to rush it for 0.7.3.