### PR TITLE
fix second analog pins soft lock

### DIFF
--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -690,7 +690,7 @@ export default function AddonsConfigPage() {
 									isInvalid={errors.analogAdc2PinX}
 									onChange={handleChange}
 								>
-									<AvailablePinOptions pins={availableAnalogPins}/>
+									<AvailablePinOptions pins={ANALOG_PINS}/>
 								</FormSelect>
 								<FormSelect
 									label={t('AddonsConfig:analog-adc-2-pin-y-label')}
@@ -702,7 +702,7 @@ export default function AddonsConfigPage() {
 									isInvalid={errors.analogAdc2PinY}
 									onChange={handleChange}
 								>
-									<AvailablePinOptions pins={availableAnalogPins}/>
+									<AvailablePinOptions pins={ANALOG_PINS}/>
 								</FormSelect>
 								<FormSelect
 									label={t('AddonsConfig:analog-adc-2-mode-label')}


### PR DESCRIPTION
Due to problems with the add-on page pin loading (issue 391), there is a soft lock if you update the second set of analog pins. They disappear from the drop down and you are unable to select any other option, you are then forced to do a board reset to regain control of the analog pins. This does not resolve the add-on page issue, but it does resolve the soft lock issue.