### PR TITLE
Document default pin mappings in the built binary

### DIFF
--- a/headers/build_info.h
+++ b/headers/build_info.h
@@ -1,0 +1,82 @@
+/* generate build information (such as stuff auto-included in the .uf2) */
+#include "pico/binary_info.h"
+#include "pico/binary_info/code.h"
+
+#include "BoardConfig.h"
+
+// generate binary information for picotool info, etc.
+#if(PIN_DPAD_UP >= 1)
+bi_decl(bi_1pin_with_name(PIN_DPAD_UP, "Up"));
+#endif
+
+#if(PIN_DPAD_DOWN >= 1)
+bi_decl(bi_1pin_with_name(PIN_DPAD_DOWN, "Down"));
+#endif
+
+#if(PIN_DPAD_LEFT >= 1)
+bi_decl(bi_1pin_with_name(PIN_DPAD_LEFT, "Left"));
+#endif
+
+#if(PIN_DPAD_RIGHT >= 1)
+bi_decl(bi_1pin_with_name(PIN_DPAD_RIGHT, "Right"));
+#endif
+
+#if(PIN_BUTTON_B1 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_B1, "B1"));
+#endif
+
+#if(PIN_BUTTON_B2 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_B2, "B2"));
+#endif
+
+#if(PIN_BUTTON_B3 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_B3, "B3"));
+#endif
+
+#if(PIN_BUTTON_B4 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_B4, "B4"));
+#endif
+
+#if(PIN_BUTTON_L1 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_L1, "L1"));
+#endif
+
+#if(PIN_BUTTON_R1 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_R1, "R1"));
+#endif
+
+#if(PIN_BUTTON_L2 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_L2, "L2"));
+#endif
+
+#if(PIN_BUTTON_R2 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_R2, "R2"));
+#endif
+
+#if(PIN_BUTTON_S1 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_S1, "S1"));
+#endif
+
+#if(PIN_BUTTON_S2 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_S2, "S2"));
+#endif
+
+#if(PIN_BUTTON_L3 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_L3, "L3"));
+#endif
+
+#if(PIN_BUTTON_R3 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_R3, "R3"));
+#endif
+
+#if(PIN_BUTTON_A1 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_A1, "A1"));
+#endif
+
+#if(PIN_BUTTON_A2 >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_A2, "A2"));
+#endif
+
+#if(PIN_BUTTON_FN >= 1)
+bi_decl(bi_1pin_with_name(PIN_BUTTON_FN, "Fn"));
+#endif

--- a/headers/build_info.h
+++ b/headers/build_info.h
@@ -5,78 +5,78 @@
 #include "BoardConfig.h"
 
 // generate binary information for picotool info, etc.
-#if(PIN_DPAD_UP >= 1)
+#if(PIN_DPAD_UP >= 0)
 bi_decl(bi_1pin_with_name(PIN_DPAD_UP, "Up"));
 #endif
 
-#if(PIN_DPAD_DOWN >= 1)
+#if(PIN_DPAD_DOWN >= 0)
 bi_decl(bi_1pin_with_name(PIN_DPAD_DOWN, "Down"));
 #endif
 
-#if(PIN_DPAD_LEFT >= 1)
+#if(PIN_DPAD_LEFT >= 0)
 bi_decl(bi_1pin_with_name(PIN_DPAD_LEFT, "Left"));
 #endif
 
-#if(PIN_DPAD_RIGHT >= 1)
+#if(PIN_DPAD_RIGHT >= 0)
 bi_decl(bi_1pin_with_name(PIN_DPAD_RIGHT, "Right"));
 #endif
 
-#if(PIN_BUTTON_B1 >= 1)
+#if(PIN_BUTTON_B1 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_B1, "B1"));
 #endif
 
-#if(PIN_BUTTON_B2 >= 1)
+#if(PIN_BUTTON_B2 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_B2, "B2"));
 #endif
 
-#if(PIN_BUTTON_B3 >= 1)
+#if(PIN_BUTTON_B3 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_B3, "B3"));
 #endif
 
-#if(PIN_BUTTON_B4 >= 1)
+#if(PIN_BUTTON_B4 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_B4, "B4"));
 #endif
 
-#if(PIN_BUTTON_L1 >= 1)
+#if(PIN_BUTTON_L1 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_L1, "L1"));
 #endif
 
-#if(PIN_BUTTON_R1 >= 1)
+#if(PIN_BUTTON_R1 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_R1, "R1"));
 #endif
 
-#if(PIN_BUTTON_L2 >= 1)
+#if(PIN_BUTTON_L2 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_L2, "L2"));
 #endif
 
-#if(PIN_BUTTON_R2 >= 1)
+#if(PIN_BUTTON_R2 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_R2, "R2"));
 #endif
 
-#if(PIN_BUTTON_S1 >= 1)
+#if(PIN_BUTTON_S1 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_S1, "S1"));
 #endif
 
-#if(PIN_BUTTON_S2 >= 1)
+#if(PIN_BUTTON_S2 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_S2, "S2"));
 #endif
 
-#if(PIN_BUTTON_L3 >= 1)
+#if(PIN_BUTTON_L3 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_L3, "L3"));
 #endif
 
-#if(PIN_BUTTON_R3 >= 1)
+#if(PIN_BUTTON_R3 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_R3, "R3"));
 #endif
 
-#if(PIN_BUTTON_A1 >= 1)
+#if(PIN_BUTTON_A1 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_A1, "A1"));
 #endif
 
-#if(PIN_BUTTON_A2 >= 1)
+#if(PIN_BUTTON_A2 >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_A2, "A2"));
 #endif
 
-#if(PIN_BUTTON_FN >= 1)
+#if(PIN_BUTTON_FN >= 0)
 bi_decl(bi_1pin_with_name(PIN_BUTTON_FN, "Fn"));
 #endif

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -4,6 +4,7 @@
 #include "system.h"
 #include "enums.pb.h"
 
+#include "build_info.h"
 #include "configmanager.h" // Global Managers
 #include "storagemanager.h"
 #include "addonmanager.h"


### PR DESCRIPTION
Note this can only document the defaults, since it's baked into the firmware binary and not dynamically generated at runtime. Demo:

```
bss@garnet ~/proj/GP2040-CE % picotool info -a
Program Information
 name:          GP2040-CE
 version:       0.7.2
 features:      double reset -> BOOTSEL
 binary start:  0x10000000
 binary end:    0x100b4e90

Fixed Pin Information
 5:   L2
 6:   R2
 7:   B2
 8:   B1
 9:   L1
 10:  R1
 11:  B4
 12:  B3
 13:  S2
 14:  A1
 15:  S1
 16:  Left
 17:  Right
 18:  Down
 19:  Up
 20:  A2
 21:  L3
 22:  R3

Build Information
 sdk version:       1.5.0
 pico_board:        pico
 boot2_name:        boot2_w25q080
 build date:        Jul 13 2023
 build attributes:  Release

Device Information
 flash size:   16384K
 ROM version:  3
```

I want to do more of this kind of thing, but for now this is a tiny quick win.