### PR TITLE
Removing used pins logic in analog pins

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -367,11 +367,12 @@ void addUsedPinsArray(DynamicJsonDocument& doc)
 	// addPinIfValid(boardOptions.i2cSDAPin);
 	// addPinIfValid(boardOptions.i2cSCLPin);
 
-	const AnalogOptions& analogOptions = Storage::getInstance().getAddonOptions().analogOptions;
-	addPinIfValid(analogOptions.analogAdc1PinX);
-	addPinIfValid(analogOptions.analogAdc1PinY);
-	addPinIfValid(analogOptions.analogAdc2PinX);
-	addPinIfValid(analogOptions.analogAdc2PinY);
+	// TODO: Used Pins logic does not work in add-ons, fix this
+	// const AnalogOptions& analogOptions = Storage::getInstance().getAddonOptions().analogOptions;
+	// addPinIfValid(analogOptions.analogAdc1PinX);
+	// addPinIfValid(analogOptions.analogAdc1PinY);
+	// addPinIfValid(analogOptions.analogAdc2PinX);
+	// addPinIfValid(analogOptions.analogAdc2PinY);
 
 	// TODO: Exclude non-button pins from validation for now, fix this when validation reworked
 	// addPinIfValid(addonOptions.buzzerPin);


### PR DESCRIPTION
Removing used pins in webconfig.cpp as it breaks our add-on pin logic. This will need to be reworked