### PR TITLE
Add-Ons UI update

### DIFF
--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { Button, Form, Row, FormCheck } from "react-bootstrap";
+import { Button, Form, Row, FormCheck, Alert } from "react-bootstrap";
 import { Formik, useFormikContext } from "formik";
 import * as yup from "yup";
 import { Trans, useTranslation } from "react-i18next";
@@ -166,6 +166,10 @@ const verifyAndSavePS4 = async () => {
 		return btoa(String.fromCharCode.apply(null, arr));
 	}
 
+	// reset error before trying again
+	document.getElementById("ps4error").textContent = "";
+	document.getElementById("ps4alert").textContent = "";
+
 	try {
 		const [pem, signature, serialFileContent] = await Promise.all([
 			loadFile(PS4Key.files[0], true),
@@ -220,7 +224,7 @@ const verifyAndSavePS4 = async () => {
 			throw Error("ERROR: Failed to upload the key to the board");
 		}
 	} catch (e) {
-		document.getElementById("ps4alert").textContent =
+		document.getElementById("ps4error").textContent =
 			"ERROR: Could not verify required files: ${e}";
 	}
 };
@@ -2281,44 +2285,47 @@ export default function AddonsConfigPage() {
 						</Section>
 						<Section title={t("AddonsConfig:ps4-mode-header-text")}>
 							<div id="PS4ModeOptions" hidden={!values.PS4ModeAddonEnabled}>
-								<Row>
-									<Trans ns="AddonsConfig" i18nKey="ps4-mode-sub-header-text">
-										<h2>
-											!!!! DISCLAIMER: GP2040-CE WILL NEVER SUPPLY THESE FILES
-											!!!!
-										</h2>
-										<p>
-											Please upload the 3 required files and click the
-											&quot;Verify & Save&quot; button to use PS4 Mode.
-										</p>
-									</Trans>
-								</Row>
-								<Row className="mb-3">
-									<div className="col-sm-4 mb-3">
-										{t("AddonsConfig:ps4-mode-private-key-label")}:
-										<input type="file" id="ps4key-input" accept="*/*" />
+								<Trans ns="AddonsConfig" i18nKey="ps4-mode-sub-header-text">
+									<Alert variant="warning">
+										!!!! DISCLAIMER: GP2040-CE WILL NEVER SUPPLY THESE FILES
+										!!!!
+									</Alert>
+									<p>
+										Please upload the 3 required files and click the
+										&quot;Verify & Save&quot; button to use PS4 Mode.
+									</p>
+								</Trans>
+								<div className="mb-4 ps4-inputs">
+									<div className="ps4-file-input">
+										<label>
+											{t("AddonsConfig:ps4-mode-private-key-label")}:
+										</label>
+										<input type="file" id="ps4key-input" accept=".pem" />
 									</div>
-									<div className="col-sm-4 mb-3">
-										{t("AddonsConfig:ps4-mode-serial-number-label")}:
-										<input type="file" id="ps4serial-input" accept="*/*" />
+									<div className="ps4-file-input">
+										<label>
+											{t("AddonsConfig:ps4-mode-serial-number-label")}:
+										</label>
+										<input type="file" id="ps4serial-input" accept=".txt" />
 									</div>
-									<div className="col-sm-4 mb-3">
-										{t("AddonsConfig:ps4-mode-signature-label")}:
-										<input type="file" id="ps4signature-input" accept="*/*" />
+									<div className="ps4-file-input">
+										<label>{t("AddonsConfig:ps4-mode-signature-label")}:</label>
+										<input type="file" id="ps4signature-input" accept=".bin" />
 									</div>
-								</Row>
-								<Row className="mb-3">
+								</div>
+								<div className="mb-3">
 									<div className="col-sm-3 mb-3">
 										<Button type="button" onClick={verifyAndSavePS4}>
 											{t("Common:button-verify-save-label")}
 										</Button>
 									</div>
-								</Row>
-								<Row className="mb-3">
-									<div className="col-sm-3 mb-3">
-										<span id="ps4alert"></span>
+								</div>
+								<div className="mb-3">
+									<div className="col-sm-12 mb-3">
+										<Alert variant="success" id="ps4alert"></Alert>
+										<Alert variant="danger" id="ps4error"></Alert>
 									</div>
-								</Row>
+								</div>
 							</div>
 							<FormCheck
 								label={t("Common:switch-enabled")}

--- a/www/src/Pages/AddonsConfigPage.scss
+++ b/www/src/Pages/AddonsConfigPage.scss
@@ -10,3 +10,32 @@
 		grid-template-columns: repeat(2, 1fr);
 	}
 }
+
+.ps4-inputs {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+	gap: 8px;
+
+	.ps4-file-input {
+		border: $grey 1px solid;
+		padding: 8px;
+		border-radius: 4px;
+		box-sizing: border-box;
+		background-color: rgba(0, 0, 0, 0.034);
+
+		label {
+			font-weight: 600;
+			margin-bottom: 8px;
+		}
+
+		input[type="file"]::file-selector-button {
+			@include gp2040-btn-secondary;
+		}
+	}
+}
+
+#ps4error:empty,
+#ps4alert:empty {
+	display: none;
+}

--- a/www/src/Pages/AddonsConfigPage.scss
+++ b/www/src/Pages/AddonsConfigPage.scss
@@ -1,0 +1,12 @@
+@use "src/styles/util" as *;
+
+.add-ons-wrapper {
+	display: grid;
+	grid-template-columns: repeat(1, 1fr);
+	grid-template-rows: auto;
+	gap: 16px;
+
+	@include min-width-lg {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}

--- a/www/src/styles/_util.scss
+++ b/www/src/styles/_util.scss
@@ -1,0 +1,36 @@
+$md-breakpoint: 720px;
+$sm-breakpoint: 480px;
+$lg-breakpoint: 1080px;
+$xl-breakpoint: 1440px;
+
+// in case you want it for another size
+@mixin min-width($size) {
+	@media (min-width: $size) {
+		@content;
+	}
+}
+
+// ehh might as well use it
+@mixin min-width-sm {
+	@include min-width($sm-breakpoint) {
+		@content;
+	}
+}
+
+@mixin min-width-md {
+	@include min-width($md-breakpoint) {
+		@content;
+	}
+}
+
+@mixin min-width-lg {
+	@include min-width($lg-breakpoint) {
+		@content;
+	}
+}
+
+@mixin min-width-xl {
+	@include min-width($xl-breakpoint) {
+		@content;
+	}
+}

--- a/www/src/styles/_util.scss
+++ b/www/src/styles/_util.scss
@@ -2,6 +2,9 @@ $md-breakpoint: 720px;
 $sm-breakpoint: 480px;
 $lg-breakpoint: 1080px;
 $xl-breakpoint: 1440px;
+$magenta-primary: rgb(255, 0, 242);
+$black: rgb(37, 37, 37);
+$grey: #495057;
 
 // in case you want it for another size
 @mixin min-width($size) {
@@ -32,5 +35,41 @@ $xl-breakpoint: 1440px;
 @mixin min-width-xl {
 	@include min-width($xl-breakpoint) {
 		@content;
+	}
+}
+
+@mixin gp2040-btn-primary {
+	background-color: $magenta-primary;
+	border: $magenta-primary 1px solid;
+	border-radius: 4px;
+	box-sizing: border-box;
+	color: white;
+
+	&:hover {
+		background-color: darken($magenta-primary, 5);
+		cursor: pointer;
+	}
+
+	&:active {
+		background-color: darken($magenta-primary, 10);
+		cursor: pointer;
+	}
+}
+
+@mixin gp2040-btn-secondary {
+	background-color: $grey;
+	border: $grey 1px solid;
+	border-radius: 4px;
+	box-sizing: border-box;
+	color: white;
+
+	&:hover {
+		background-color: darken($grey, 5);
+		cursor: pointer;
+	}
+
+	&:active {
+		background-color: darken($grey, 10);
+		cursor: pointer;
 	}
 }


### PR DESCRIPTION
![image](https://github.com/OpenStickCommunity/GP2040-CE/assets/139376505/0264845c-333b-4b10-bfdb-6a8350ea46a6)

In this PR, I've done the following:

- Added a utility Sass file with a few breakpoint mixins to use for common screen sizes. Not accounting for mobile because I can't think of anyone using their web configurator on a phone, though I guess it is possible.
- Broke up the add-ons page into CSS grid-based columns, can change the number of columns per breakpoint for future updates. I felt it was too much on a larger screen, and I tend to keep my browser at 1080p.
- Updated the PS4 Mode module to be a little more... hip.

In my opinion, this page could use a full refresh. Side menu that has all add-on options that, when clicked, load only that add-on configuration to be changed. Add-ons broken up into individual components rather than having a massive file.