### PR TITLE
Add 5V Power Pin option in Keyboard Host addon

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -294,6 +294,7 @@
 // Keyboard Host Addon defaults
 #define KEYBOARD_HOST_ENABLED 0
 #define KEYBOARD_HOST_PIN_DPLUS -1
+#define KEYBOARD_HOST_PIN_5V -1
 
 // For details on this, see: https://gp2040-ce.info/#/development?id=i2c-display-splash
 #define DEFAULT_SPLASH \

--- a/headers/addons/keyboard_host.h
+++ b/headers/addons/keyboard_host.h
@@ -12,6 +12,10 @@
 #define KEYBOARD_HOST_PIN_DPLUS -1
 #endif
 
+#ifndef KEYBOARD_HOST_PIN_5V
+#define KEYBOARD_HOST_PIN_5V -1
+#endif
+
 // KeyboardHost Module Name
 #define KeyboardHostName "KeyboardHost"
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -418,6 +418,7 @@ message KeyboardHostOptions
 	optional bool enabled = 1;
 	optional int32 pinDplus = 2;
 	optional KeyboardMapping mapping = 3;
+	optional int32 pin5V = 4;
 }
 
 message FocusModeOptions

--- a/src/addons/keyboard_host.cpp
+++ b/src/addons/keyboard_host.cpp
@@ -27,7 +27,9 @@ static KeyboardButtonMapping _keyboard_host_mapButtonA2  = KeyboardButtonMapping
 
 bool KeyboardHostAddon::available() {
   const KeyboardHostOptions& keyboardHostOptions = Storage::getInstance().getAddonOptions().keyboardHostOptions;
-	return keyboardHostOptions.enabled && isValidPin(keyboardHostOptions.pinDplus);
+	return keyboardHostOptions.enabled &&
+         isValidPin(keyboardHostOptions.pinDplus) &&
+         (keyboardHostOptions.pin5V == -1 || isValidPin(keyboardHostOptions.pin5V));
 }
 
 void KeyboardHostAddon::setup() {
@@ -37,6 +39,14 @@ void KeyboardHostAddon::setup() {
 	// board_init();
   // board_init() should be doing what the two lines below are doing but doesn't work
   // needs tinyusb_board library linked
+
+  if (keyboardHostOptions.pin5V != -1) {
+    const int32_t pin5V = keyboardHostOptions.pin5V;
+	  gpio_init(pin5V);
+	  gpio_set_dir(pin5V, GPIO_OUT);
+	  gpio_pull_up(pin5V);
+  }
+
 	pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
   pio_cfg.pin_dp = keyboardHostOptions.pinDplus;
   tuh_configure(1, TUH_CFGID_RPI_PIO_USB_CONFIGURATION, &pio_cfg);

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -447,6 +447,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     // keyboardMapping
     INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions, enabled, KEYBOARD_HOST_ENABLED);
     INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions, pinDplus, KEYBOARD_HOST_PIN_DPLUS);
+    INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions, pin5V, KEYBOARD_HOST_PIN_5V);
     INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions.mapping, keyDpadUp, KEY_DPAD_UP);
     INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions.mapping, keyDpadDown, KEY_DPAD_DOWN);
     INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions.mapping, keyDpadRight, KEY_DPAD_RIGHT);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1041,6 +1041,7 @@ std::string setAddonOptions()
 	KeyboardHostOptions& keyboardHostOptions = Storage::getInstance().getAddonOptions().keyboardHostOptions;
 	docToValue(keyboardHostOptions.enabled, doc, "KeyboardHostAddonEnabled");
 	docToPin(keyboardHostOptions.pinDplus, doc, "keyboardHostPinDplus");
+	docToPin(keyboardHostOptions.pin5V, doc, "keyboardHostPin5V");
 	docToValue(keyboardHostOptions.mapping.keyDpadUp, doc, "keyboardHostMap", "Up");
 	docToValue(keyboardHostOptions.mapping.keyDpadDown, doc, "keyboardHostMap", "Down");
 	docToValue(keyboardHostOptions.mapping.keyDpadLeft, doc, "keyboardHostMap", "Left");
@@ -1273,6 +1274,7 @@ std::string getAddonOptions()
 	const KeyboardHostOptions& keyboardHostOptions = Storage::getInstance().getAddonOptions().keyboardHostOptions;
 	writeDoc(doc, "KeyboardHostAddonEnabled", keyboardHostOptions.enabled);
 	writeDoc(doc, "keyboardHostPinDplus", keyboardHostOptions.pinDplus);
+	writeDoc(doc, "keyboardHostPin5V", keyboardHostOptions.pin5V);
 	writeDoc(doc, "keyboardHostMap", "Up", keyboardHostOptions.mapping.keyDpadUp);
 	writeDoc(doc, "keyboardHostMap", "Down", keyboardHostOptions.mapping.keyDpadDown);
 	writeDoc(doc, "keyboardHostMap", "Left", keyboardHostOptions.mapping.keyDpadLeft);

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -103,7 +103,7 @@ void GP2040::setup() {
 	adc_init();
 
 	// Setup Add-ons
-  	//addons.LoadAddon(new KeyboardHostAddon(), CORE0_INPUT);
+  	addons.LoadAddon(new KeyboardHostAddon(), CORE0_INPUT);
 	addons.LoadAddon(new AnalogInput(), CORE0_INPUT);
 	addons.LoadAddon(new BootselButtonAddon(), CORE0_INPUT);
 	addons.LoadAddon(new DualDirectionalInput(), CORE0_INPUT);

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -313,6 +313,7 @@ app.get("/api/getAddonsOptions", (req, res) => {
 		snesPadLatchPin: -1,
 		snesPadDataPin: -1,
 		keyboardHostPinDplus: 0,
+		keyboardHostPin5V: -1,
 		keyboardHostMap: DEFAULT_KEYBOARD_MAPPING,
 		AnalogInputEnabled: 1,
 		BoardLedAddonEnabled: 1,

--- a/www/src/Locales/en/AddonsConfig.jsx
+++ b/www/src/Locales/en/AddonsConfig.jsx
@@ -114,7 +114,8 @@ export default {
 	'focus-mode-header-text': 'Focus Mode Configuration',
 	'focus-mode-pin-label': 'Focus Mode Pin',
 	'keyboard-host-header-text': 'Keyboard Host Configuration',
-	'keyboard-host-sub-header-text': 'Following set the data + and - pins. Only the + pin can be configured.',
+	'keyboard-host-sub-header-text': 'Following set the data +, - and 5V (optional) pins. Only the + and 5V pin can be configured.',
 	'keyboard-host-d-plus-label': 'D+',
 	'keyboard-host-d-minus-label': 'D-',
+	'keyboard-host-five-v-label': '5V Power (optional)',
 };

--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -301,6 +301,7 @@ const schema = yup.object().shape({
 
 	KeyboardHostAddonEnabled:    yup.number().required().label('Keyboard Host Add-On Enabled'),
 	keyboardHostPinDplus:        yup.number().label('Keyboard Host D+ Pin').validatePinWhenValue('KeyboardHostAddonEnabled'),
+	keyboardHostPin5V:           yup.number().label('Keyboard Host 5V Power Pin').validatePinWhenValue('KeyboardHostAddonEnabled'),
 
 	PlayerNumAddonEnabled:       yup.number().required().label('Player Number Add-On Enabled'),
 	playerNumber:                yup.number().label('Player Number').validateRangeWhenValue('PlayerNumAddonEnabled', 1, 4),
@@ -421,6 +422,7 @@ const defaultValues = {
 	snesPadLatchPin: -1,
 	snesPadDataPin: -1,
 	keyboardHostPinDplus: -1,
+	keyboardHostPin5V: -1,
 	keyboardHostMap: baseButtonMappings,
 	AnalogInputEnabled: 0,
 	BoardLedAddonEnabled: 0,
@@ -1936,7 +1938,6 @@ export default function AddonsConfigPage() {
 							onChange={(e) => { handleCheckbox("FocusModeAddonEnabled", values); handleChange(e);}}
 						/>
 					</Section>
-				{/*
 					<Section title={t('AddonsConfig:keyboard-host-header-text')}>
 						<div
 							id="KeyboardHostAddonOptions"
@@ -1962,6 +1963,18 @@ export default function AddonsConfigPage() {
 									groupClassName="col-sm-1 mb-3"
 									value={values.keyboardHostPinDplus === -1 ? -1 : values.keyboardHostPinDplus + 1}
 								/>
+								<FormControl type="number"
+									label={t('AddonsConfig:keyboard-host-five-v-label')}
+									name="keyboardHostPin5V"
+									className="form-select-sm"
+									groupClassName="col-sm-auto mb-3"
+									value={values.keyboardHostPin5V}
+									error={errors.keyboardHostPin5V}
+									isInvalid={errors.keyboardHostPin5V}
+									onChange={handleChange}
+									min={-1}
+									max={28}
+								/>
 							</Row>
 							<Row className="mb-3">
 								<p>{t('KeyboardMapping:sub-header-text')}</p>
@@ -1981,7 +1994,6 @@ export default function AddonsConfigPage() {
 							onChange={(e) => { handleCheckbox("KeyboardHostAddonEnabled", values); handleChange(e);}}
 						/>
 					</Section>
-									*/}
 					<div className="mt-3">
 						<Button type="submit" id="save">{t('Common:button-save-label')}</Button>
 						{saveMessage ? <span className="alert">{saveMessage}</span> : null}


### PR DESCRIPTION
This is meant to fix #389.
Thanks to @InfraredAces for figuring out this issue and for the amazing hardware built to test this!

I do not own proper hardware to test this one in a good way, so assistance is appreciated.
The newly added pin setting is optional and for those who know what they're doing.
Edit: The addon has been enabled for testing purpose. It can be disabled if there are difficulties in making the merge.

Please check and merge, thanks!