### PR TITLE
add a hotkey action to reboot the controller

### DIFF
--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -143,6 +143,7 @@ enum GamepadHotkey
     HOTKEY_L3_BUTTON             = 19;
     HOTKEY_R3_BUTTON             = 20;
     HOTKEY_TOUCHPAD_BUTTON       = 21;
+    HOTKEY_REBOOT_DEFAULT        = 22;
 }
 
 // This has to be kept in sync with LEDFormat in NeoPico.hpp

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -12,6 +12,7 @@
 #include "CRC32.h"
 
 #include "storagemanager.h"
+#include "system.h"
 
 // MUST BE DEFINED for mpgs
 uint32_t getMillis() {
@@ -326,6 +327,7 @@ void Gamepad::processHotkeyIfNewAction(GamepadHotkey action)
 		case HOTKEY_SOCD_LAST_INPUT   : options.socdMode = SOCD_MODE_SECOND_INPUT_PRIORITY; reqSave = true; break;
 		case HOTKEY_SOCD_FIRST_INPUT  : options.socdMode = SOCD_MODE_FIRST_INPUT_PRIORITY;  reqSave = true;break;
 		case HOTKEY_SOCD_BYPASS       : options.socdMode = SOCD_MODE_BYPASS; reqSave = true; break;
+		case HOTKEY_REBOOT_DEFAULT    : System::reboot(System::BootMode::DEFAULT); break;
 		case HOTKEY_CAPTURE_BUTTON    :
 			if (options.inputMode == INPUT_MODE_PS4 && options.switchTpShareForDs4) {
 				state.buttons |= GAMEPAD_MASK_A2;

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -51,6 +51,7 @@ export default {
 		'load-profile-2': 'Load Profile #2',
 		'load-profile-3': 'Load Profile #3',
 		'load-profile-4': 'Load Profile #4',
+		'reboot-default': 'Reboot GP2040-CE',
 	},
 	'forced-setup-mode-label': 'Forced Setup Mode',
 	'forced-setup-mode-options': {

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -56,6 +56,7 @@ const HOTKEY_ACTIONS = [
   { labelKey: 'hotkey-actions.l3-button', value: 19 },
 	{ labelKey: 'hotkey-actions.r3-button', value: 20 },
 	{ labelKey: 'hotkey-actions.touchpad-button', value: 21 },
+	{ labelKey: 'hotkey-actions.reboot-default', value: 22 },
 ];
 
 const FORCED_SETUP_MODES = [


### PR DESCRIPTION
Simple way to change modes, primary use case being you powered on your controller before remembering you need to switch modes, and want to switch to the proper mode without getting up or unplugging the cable or whatever --- just press your assigned hotkey while holding the normal input mode button and you'll reboot into that mode (because hey, why bother burning an unplug/plug count on your connector, if you don't have to).