### PR TITLE
Set the profile number in the config after switching

### DIFF
--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -143,7 +143,9 @@ PinMappings& Storage::getProfilePinMappings() {
 
 void Storage::setProfile(const uint32_t profileNum)
 {
+	if (profileNum < 1 || profileNum > 4) return;
 	setFunctionalPinMappings(profileNum);
+	this->config.gamepadOptions.profileNumber = profileNum;
 }
 
 void Storage::setFunctionalPinMappings(const uint32_t profileNum)


### PR DESCRIPTION
I apparently accidentally refactored this away, so adding it back