### PR TITLE
Fixing PIO state machines 

### DIFF
--- a/src/addons/keyboard_host.cpp
+++ b/src/addons/keyboard_host.cpp
@@ -10,8 +10,6 @@ bool KeyboardHostAddon::available() {
 }
 
 void KeyboardHostAddon::setup() {
-  set_sys_clock_khz(120000, true); // Set Clock to 120MHz to avoid potential USB timing issues
-
   const KeyboardHostOptions& keyboardHostOptions = Storage::getInstance().getAddonOptions().keyboardHostOptions;
   const KeyboardMapping& keyboardMapping = keyboardHostOptions.mapping;
 

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -82,6 +82,9 @@ void GP2040::setup() {
 	addons.LoadAddon(new SliderSOCDInput(), CORE0_INPUT);
 	addons.LoadAddon(new TiltInput(), CORE0_INPUT);
 
+	// Initialize our USB manager
+	USBHostManager::getInstance().start();
+
 	const BootAction bootAction = getBootAction();
 
 	switch (bootAction) {

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -20,7 +20,6 @@
 #include "addons/i2canalog1219.h"
 #include "addons/jslider.h"
 #include "addons/playernum.h"
-#include "addons/pspassthrough.h"
 #include "addons/reverse.h"
 #include "addons/turbo.h"
 #include "addons/slider_socd.h"
@@ -66,7 +65,6 @@ void GP2040::setup() {
 
 	// Setup Add-ons
 	addons.LoadUSBAddon(new KeyboardHostAddon(), CORE0_INPUT);
-	addons.LoadUSBAddon(new PSPassthroughAddon(), CORE0_USBREPORT);
 	addons.LoadAddon(new AnalogInput(), CORE0_INPUT);
 	addons.LoadAddon(new BootselButtonAddon(), CORE0_INPUT);
 	addons.LoadAddon(new DualDirectionalInput(), CORE0_INPUT);
@@ -82,8 +80,6 @@ void GP2040::setup() {
 	addons.LoadAddon(new SliderSOCDInput(), CORE0_INPUT);
 	addons.LoadAddon(new TiltInput(), CORE0_INPUT);
 
-	// Initialize our USB manager
-	USBHostManager::getInstance().start();
 
 	const BootAction bootAction = getBootAction();
 

--- a/src/gp2040aux.cpp
+++ b/src/gp2040aux.cpp
@@ -29,8 +29,6 @@ void GP2040Aux::setup() {
 	addons.LoadAddon(new BoardLedAddon(), CORE1_LOOP);
 	addons.LoadAddon(new BuzzerSpeakerAddon(), CORE1_LOOP);
 	addons.LoadAddon(new PS4ModeAddon(), CORE1_LOOP);
-
-	USBHostManager::getInstance().start();
 }
 
 void GP2040Aux::run() {

--- a/src/gp2040aux.cpp
+++ b/src/gp2040aux.cpp
@@ -11,6 +11,7 @@
 #include "addons/i2cdisplay.h" // Add-Ons
 #include "addons/pleds.h"
 #include "addons/ps4mode.h"
+#include "addons/pspassthrough.h"
 #include "addons/neopicoleds.h"
 
 #include <iterator>
@@ -22,13 +23,17 @@ GP2040Aux::~GP2040Aux() {
 }
 
 void GP2040Aux::setup() {
-	// Setup Regular Add-ons
+	// Setup Add-ons
+	addons.LoadUSBAddon(new PSPassthroughAddon(), CORE1_LOOP);
 	addons.LoadAddon(new I2CDisplayAddon(), CORE1_LOOP);
 	addons.LoadAddon(new NeoPicoLEDAddon(), CORE1_LOOP);
 	addons.LoadAddon(new PlayerLEDAddon(), CORE1_LOOP);
 	addons.LoadAddon(new BoardLedAddon(), CORE1_LOOP);
 	addons.LoadAddon(new BuzzerSpeakerAddon(), CORE1_LOOP);
 	addons.LoadAddon(new PS4ModeAddon(), CORE1_LOOP);
+
+	// Initialize our USB manager
+	USBHostManager::getInstance().start();
 }
 
 void GP2040Aux::run() {

--- a/src/usbhostmanager.cpp
+++ b/src/usbhostmanager.cpp
@@ -10,12 +10,9 @@ void USBHostManager::setDataPin(uint8_t inPin) {
 
 void USBHostManager::start() {
     if ( !addons.empty() ) {
-    	// State Machine moved to PIO0:1 and PIO1:1,2 for NeoPico
         pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
         pio_cfg.pin_dp = dataPin;
-        pio_cfg.sm_eop = 2;
-        pio_cfg.sm_rx = 1;
-        pio_cfg.sm_tx = 1;
+        pio_cfg.sm_tx = 1; // NeoPico uses PIO0:0, move to state machine 1
         tuh_configure(1, TUH_CFGID_RPI_PIO_USB_CONFIGURATION, &pio_cfg);
         tuh_init(BOARD_TUH_RHPORT);
         sleep_us(10); // ensure we are ready

--- a/src/usbhostmanager.cpp
+++ b/src/usbhostmanager.cpp
@@ -10,8 +10,12 @@ void USBHostManager::setDataPin(uint8_t inPin) {
 
 void USBHostManager::start() {
     if ( !addons.empty() ) {
+    	// State Machine moved to PIO0:1 and PIO1:1,2 for NeoPico
         pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
         pio_cfg.pin_dp = dataPin;
+        pio_cfg.sm_eop = 2;
+        pio_cfg.sm_rx = 1;
+        pio_cfg.sm_tx = 1;
         tuh_configure(1, TUH_CFGID_RPI_PIO_USB_CONFIGURATION, &pio_cfg);
         tuh_init(BOARD_TUH_RHPORT);
         sleep_us(10); // ensure we are ready


### PR DESCRIPTION
This fixes our USB host manager start sync, and we can now run PIO state machines on both the PIO PICO USB configuration and the NeoPico PIO code samples.

The reason Core1 worked before is we had to init NeoPico BEFORE we did PIO USB.