### PR TITLE
Rename "PS4 Mode" addon

### DIFF
--- a/docs/ps4.md
+++ b/docs/ps4.md
@@ -20,7 +20,7 @@ The 8-minute timeout works like this:
 5. User unplugs their non-functional controller
 6. Go back to step 1 and repeat
 
-GP2040-CE allows you to upload the files required to authenticate your device via the [PS4 Mode addon](web-configurator?id=ps4-mode), which effectively removes this timeout issue. If you're using an OLED display, the input mode will change from `PS4` to `PS4:AS` to indicate your device has successfully authenticated with the PS4/PS5 console.
+GP2040-CE allows you to upload the files required to authenticate your device via the [PS4 File Authentication addon](web-configurator?id=ps4-mode), which effectively removes this timeout issue. If you're using an OLED display, the input mode will change from `PS4` to `PS4:AS` to indicate your device has successfully authenticated with the PS4/PS5 console.
 
 !> **The GP2040-CE project will not provide files or information related to authenticating your device beyond what the firmware has implemented. Please do not ask via any of our communication channels as this may result in a blacklist/ban.**
 

--- a/docs/web-configurator.md
+++ b/docs/web-configurator.md
@@ -274,9 +274,9 @@ Values are:
 * `SOCD Slider Mode Two` - The SOCD mode you would like to have enabled for the second slder position.
 * `Pin Two` - The GPIO pin used for second SOCD mode slider position.
 
-### PS4 Mode
+### PS4 File Authentication
 
-![GP2040 Configurator - PS4 Mode](assets/images/gpc-add-ons-ps4-mode.png)
+![GP2040 Configurator - PS4 File Authentication](assets/images/gpc-add-ons-ps4-mode.png)
 
 Please note that GP2040-CE will never provide these files!
 

--- a/www/src/Locales/en/AddonsConfig.jsx
+++ b/www/src/Locales/en/AddonsConfig.jsx
@@ -106,9 +106,9 @@ export default {
 	'socd-cleaning-mode-selection-slider-pin-one-label': 'Pin One',
 	'socd-cleaning-mode-selection-slider-mode-two-label': 'SOCD Slider Mode Two',
 	'socd-cleaning-mode-selection-slider-pin-two-label': 'Pin Two',
-	'ps4-mode-header-text': 'PS4 Mode',
+	'ps4-mode-header-text': 'PS4 File Authentication',
 	'ps4-mode-sub-header-text':
-		'<0>!!!! DISCLAIMER: GP2040-CE WILL NEVER SUPPLY THESE FILES !!!!</0> <1>Please upload the 3 required files and click the "Verify & Save" button to use PS4 Mode.</1>',
+		'<0>!!!! DISCLAIMER: GP2040-CE WILL NEVER SUPPLY THESE FILES !!!!</0> <1>Please upload the 3 required files and click the "Verify & Save" button to use PS4 File Authentication.</1>',
 	'ps4-mode-private-key-label': 'Private Key (PEM)',
 	'ps4-mode-serial-number-label': 'Serial Number (16 Bytes in Hex Ascii)',
 	'ps4-mode-signature-label': 'Signature (256 Bytes in Binary)',
@@ -133,7 +133,7 @@ export default {
 	'keyboard-host-d-plus-label': 'D+',
 	'keyboard-host-d-minus-label': 'D-',
 	'keyboard-host-five-v-label': '5V Power (optional)',
-	'pspassthrough-header-text': 'PS Passthrough',
+	'pspassthrough-header-text': 'PS Passthrough Authentication',
 	'pspassthrough-sub-header-text':
 		'Following set the data +, - and 5V (optional) pins. Only the + and 5V pin can be configured.',
 	'pspassthrough-d-plus-label': 'D+',

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -31,7 +31,7 @@ export default {
 	},
 	'profile-number-label': 'Profile Number',
 	'ps4-compatibility-label':
-		'For <strong>PS5 compatibility</strong>, use "Arcade Stick" and enable PS Passthrough add-on<br/>For <strong>PS4 support</strong>, use "Controller" and enable PS4 Mode add-on if you have the necessary files',
+		'For <strong>PS5 compatibility</strong>, use "Arcade Stick" and enable PS Passthrough add-on<br/>For <strong>PS4 support</strong>, use "Controller" and enable either "PS4 File Authentication" add-on if you have the necessary files, or use "PS Passthrough" with a PS4 compatible controller/dongle',
 	'hotkey-settings-label': 'Hotkey Settings',
 	'hotkey-settings-sub-header':
 		"The <1>Fn</1> slider provides a mappable Function button in the <3 exact='true' to='/pin-mapping'>Pin Mapping</3> page. By selecting the <1>Fn</1> slider option, the Function button must be held along with the selected hotkey settings.<5 />Additionally, select <1>None</1> from the dropdown to unassign any button.",

--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -212,7 +212,7 @@ const verifyAndSavePS4 = async () => {
 
 		if (success) {
 			document.getElementById('ps4alert').textContent =
-				'Verified and Saved PS4 Mode! Reboot to take effect';
+				'Verified and Saved PS4 File Authentication! Reboot to take effect';
 			document.getElementById('save').click();
 		} else {
 			throw Error('ERROR: Failed to upload the key to the board');
@@ -518,7 +518,7 @@ const schema = yup.object().shape({
 		.label('Player Number')
 		.validateRangeWhenValue('PlayerNumAddonEnabled', 1, 4),
 
-	PS4ModeAddonEnabled: yup.number().required().label('PS4 Mode Add-on Enabled'),
+	PS4ModeAddonEnabled: yup.number().required().label('PS4 File Authentication Add-on Enabled'),
 
 	ReverseInputEnabled: yup.number().required().label('Reverse Input Enabled'),
 	reversePin: yup
@@ -2352,7 +2352,7 @@ export default function AddonsConfigPage() {
 									</h2>
 									<p>
 										Please upload the 3 required files and click the
-										&quot;Verify & Save&quot; button to use PS4 Mode.
+										&quot;Verify & Save&quot; button to use PS4 File Authentication.
 									</p>
 								</Trans>
 							</Row>

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -315,7 +315,7 @@ export default function SettingsPage() {
 												Stick" and enable PS Passthrough add-on
 												<br />
 												For <strong>PS4 support</strong>, use "Controller" and
-												enable PS4 Mode add-on if you have the necessary files
+												enable PS4 File Authentication add-on if you have the necessary files
 											</Trans>
 										</div>
 									)}


### PR DESCRIPTION
The phrase "PS4 Mode" is used throughout documentation for both the ds4 emulation and the addon that handles authentication. With addition of passthrough authentication it got even more confusing.

This change renames the addon from "PS4 Mode" to "PS4 File Authentication" which better reflects addon's nature.