### PR TITLE
Add PS4/PS5 authentication to board-led add-on

### DIFF
--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -73,6 +73,7 @@ enum OnBoardLedMode
     ON_BOARD_LED_MODE_OFF = 0;
     ON_BOARD_LED_MODE_MODE_INDICATOR = 1;
     ON_BOARD_LED_MODE_INPUT_TEST = 2;
+    ON_BOARD_LED_MODE_PS_AUTH = 3;
 }
 
 enum InputMode

--- a/src/addons/board_led.cpp
+++ b/src/addons/board_led.cpp
@@ -24,13 +24,6 @@ void BoardLedAddon::process() {
     bool state = 0;
     Gamepad * processedGamepad;
     switch (onBoardLedMode) {
-        case OnBoardLedMode::ON_BOARD_LED_MODE_PS_AUTH:
-            state = PS4Data::getInstance().authsent == true;
-            if (prevState != state) {
-                gpio_put(BOARD_LED_PIN, state ? 1 : 0);
-            }
-            prevState = state;
-            break;
         case OnBoardLedMode::ON_BOARD_LED_MODE_INPUT_TEST: // Blinks on input
             processedGamepad = Storage::getInstance().GetProcessedGamepad();
             state =    (processedGamepad->state.buttons != 0)
@@ -71,8 +64,15 @@ void BoardLedAddon::process() {
                 }
             }
             break;
+        case OnBoardLedMode::ON_BOARD_LED_MODE_PS_AUTH:
+            state = PS4Data::getInstance().authsent == true;
+            if (prevState != state) {
+                gpio_put(BOARD_LED_PIN, state ? 1 : 0);
+            }
+            prevState = state;
+            break;
         case OnBoardLedMode::ON_BOARD_LED_MODE_OFF:
-            return;
+        default:
             break;
     }
 }

--- a/src/addons/board_led.cpp
+++ b/src/addons/board_led.cpp
@@ -1,5 +1,6 @@
 #include "addons/board_led.h"
 #include "usb_driver.h" // Required to check USB state
+#include "ps4_driver.h"
 #include "helper.h"
 #include "config.pb.h"
 
@@ -23,6 +24,13 @@ void BoardLedAddon::process() {
     bool state = 0;
     Gamepad * processedGamepad;
     switch (onBoardLedMode) {
+        case OnBoardLedMode::ON_BOARD_LED_MODE_PS_AUTH:
+            state = PS4Data::getInstance().authsent == true;
+            if (prevState != state) {
+                gpio_put(BOARD_LED_PIN, state ? 1 : 0);
+            }
+            prevState = state;
+            break;
         case OnBoardLedMode::ON_BOARD_LED_MODE_INPUT_TEST: // Blinks on input
             processedGamepad = Storage::getInstance().GetProcessedGamepad();
             state =    (processedGamepad->state.buttons != 0)

--- a/www/src/Pages/AddonsConfigPage.jsx
+++ b/www/src/Pages/AddonsConfigPage.jsx
@@ -25,6 +25,7 @@ const ON_BOARD_LED_MODES = [
 	{ label: 'Off', value: 0 },
 	{ label: 'Mode Indicator', value: 1 },
 	{ label: 'Input Test', value: 2 },
+	{ label: 'PS4/5 Authentication', value: 3},
 ];
 
 const DUAL_STICK_MODES = [


### PR DESCRIPTION
Added PS4/PS5 authentication to board-led add-on. The light turns on after authentication occurs.