### PR TITLE
Add feature to capture button held pins from board

### DIFF
--- a/www/server/app.js
+++ b/www/server/app.js
@@ -433,6 +433,15 @@ app.get('/api/getMemoryReport', (req, res) => {
 	});
 });
 
+app.get('/api/getHeldPins', async (req, res) => {
+	await new Promise(resolve => setTimeout(resolve, 2000));
+	return res.send({
+		heldPins: [7]
+	});
+});
+
+app.get('/api/abortGetHeldPins', async (req, res) => {return res.send()});
+
 app.post('/api/*', (req, res) => {
 	console.log(req.body);
 	return res.send(req.body);

--- a/www/src/Components/CaptureButton.jsx
+++ b/www/src/Components/CaptureButton.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, Modal } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import WebApi from '../Services/WebApi';
+
+const CaptureButton = ({ buttonName, onChange, abortSignalRef, triggerCapture, onTriggeredCaptureComplete, onStopCaptureSequence }) => {
+	const { t } = useTranslation('');
+	const controller = abortSignalRef || useRef();
+    const triggerNextRef = useRef(true);
+	const [modalVisible, setModalVisible] = useState(false);
+
+	const newAbortSignal = () => {
+		controller.current = new AbortController();
+		return controller.current.signal;
+	};
+
+	const timeout = (ms) => (new Promise(resolve => setTimeout(resolve, ms)));
+
+	const getHeldPins = async () => {
+		await timeout(50); // Workaround to prevent hardfault, probably has to do with the extra `loop` call
+		const data = await WebApi.getHeldPins(setModalVisible, newAbortSignal);
+        const pin = data?.heldPins?.at(0);
+		if (!isNaN(pin))
+			onChange(pin);
+        if (triggerNextRef.current) {
+            if (triggerCapture) onTriggeredCaptureComplete();
+        }
+	};
+
+	useEffect(() => () => controller?.current?.abort(), []);
+
+	const closeModal = async () => {
+		controller?.current?.abort();
+		await timeout(50);
+		await WebApi.abortGetHeldPins();
+		await timeout(50);
+		setModalVisible(false);
+	};
+
+    useEffect(() => {
+        console.log('triggerCapture', triggerCapture); if (triggerCapture) {
+            getHeldPins().then();
+            triggerNextRef.current = true;
+        }
+    }, [triggerCapture]);
+
+	return (
+		<>
+			<Modal centered show={modalVisible} onHide={() => closeModal()}>
+				<Modal.Header closeButton>
+					<Modal.Title className="me-auto">{`${t('CaptureButton:capture-button-modal-title')} (${buttonName})`}</Modal.Title>
+				</Modal.Header>
+				<Modal.Body className="row">
+                    <span className="col-sm-10">{`${t('CaptureButton:capture-button-modal-content')}`}</span>
+					<span className="col-sm-1">
+						<span className="spinner-border" />
+					</span>
+				</Modal.Body>
+				<Modal.Footer>
+					<Button variant="secondary" onClick={() => closeModal()}>
+						Cancel
+					</Button>
+					{triggerCapture && onStopCaptureSequence && 
+                    <Button variant="danger"
+                        onClick={async () => {
+                            triggerNextRef.current = false;
+                            onStopCaptureSequence();
+                            await closeModal();
+                        }}>
+						Stop Capture
+					</Button>}
+				</Modal.Footer>
+			</Modal>
+			<Button
+				className="ms-3"
+				variant="secondary"
+				onClick={() => getHeldPins()}
+			>
+				{t('CaptureButton:capture-button-button-label')}
+			</Button>
+		</>
+	);
+};
+
+export default CaptureButton;

--- a/www/src/Components/Section.scss
+++ b/www/src/Components/Section.scss
@@ -6,3 +6,8 @@
 	height: 6rem;
 	width: 6rem;
 }
+
+.loading-small {
+	height: 1rem !important;
+	width: 1rem !important;
+}

--- a/www/src/Locales/en/CaptureButton.jsx
+++ b/www/src/Locales/en/CaptureButton.jsx
@@ -1,0 +1,5 @@
+export default {	
+	'capture-button-button-label': '🎮',
+	'capture-button-modal-title': 'Waiting for button press',
+	'capture-button-modal-content': 'Press ESC to skip this button.',
+};

--- a/www/src/Locales/en/Index.jsx
+++ b/www/src/Locales/en/Index.jsx
@@ -12,6 +12,7 @@ import CustomTheme from './CustomTheme';
 import BackupPage from './BackupPage';
 import DisplayConfig from './DisplayConfig';
 import AddonsConfig from './AddonsConfig';
+import CaptureButton from './CaptureButton';
 
 export default {
 	Common,
@@ -28,4 +29,5 @@ export default {
 	BackupPage,
 	DisplayConfig,
 	AddonsConfig,
+	CaptureButton,
 };

--- a/www/src/Locales/en/PinMapping.jsx
+++ b/www/src/Locales/en/PinMapping.jsx
@@ -11,4 +11,5 @@ export default {
 		invalid: '{{pin}} is invalid for this board',
 		used: '{{pin}} is already assigned to another feature',
 	},
+	'all-capture-button-label': 'Assign Gamepad Pins\u00A0\u00A0🎮',
 };

--- a/www/src/Pages/PinMapping.jsx
+++ b/www/src/Pages/PinMapping.jsx
@@ -1,8 +1,9 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState, useRef } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Button, Form } from 'react-bootstrap';
 import { AppContext } from '../Contexts/AppContext';
 import Section from '../Components/Section';
+import CaptureButton from '../Components/CaptureButton';
 import WebApi, { baseButtonMappings } from '../Services/WebApi';
 import boards from '../Data/Boards.json';
 import { BUTTONS } from '../Data/Buttons';
@@ -25,8 +26,12 @@ export default function PinMappingPage() {
 	const [buttonMappings, setButtonMappings] = useState(baseButtonMappings);
 	const [selectedController] = useState(import.meta.env.VITE_GP2040_CONTROLLER);
 	const [selectedBoard] = useState(import.meta.env.VITE_GP2040_BOARD);
+	const [capturingButtonIndex, setCapturingButtonIndex] = useState(-1);
+	const [isCapturingPinsInProgress, setIsCapturingPinsInProgress] = useState(false);
+	const controller = useRef();
 	const { buttonLabelType, swapTpShareLabels } = buttonLabels;
 	const { setLoading } = useContext(AppContext);
+	const buttonNames = Object.keys(BUTTONS[buttonLabelType])?.filter((p) => p !== 'label' && p !== 'value');
 
 	const { t } = useTranslation('');
 
@@ -48,12 +53,12 @@ export default function PinMappingPage() {
 		fetchData();
 	}, [setButtonMappings, selectedController]);
 
-	const handlePinChange = (e, prop) => {
+	const handlePinChange = (e, prop, unassignOthersOnConflict) => {
 		const newMappings = { ...buttonMappings };
 		if (e.target.value) newMappings[prop].pin = parseInt(e.target.value);
 		else newMappings[prop].pin = '';
 
-		validateMappings(newMappings);
+		validateMappings(newMappings, unassignOthersOnConflict, prop);
 	};
 
 	const handleSubmit = async (e) => {
@@ -77,7 +82,7 @@ export default function PinMappingPage() {
 		);
 	};
 
-	const validateMappings = (mappings) => {
+	const validateMappings = (mappings, unassignOthersOnConflict, targetButton) => {
 		const buttons = Object.keys(mappings);
 
 		// Create some mapped pin groups for easier error checking
@@ -102,7 +107,6 @@ export default function PinMappingPage() {
 
 		for (let button of buttons) {
 			mappings[button].error = '';
-
 			// Validate required button
 			if (
 				(mappings[button].pin < boards[selectedBoard].minPin ||
@@ -112,7 +116,8 @@ export default function PinMappingPage() {
 				mappings[button].error = translatedErrorType.required;
 			// Identify conflicted pins
 			else if (conflictedPins.indexOf(mappings[button].pin) > -1)
-				mappings[button].error = translatedErrorType.conflict;
+				if (unassignOthersOnConflict && targetButton !== button) mappings[button].pin = -1;
+				else if (!unassignOthersOnConflict) mappings[button].error = translatedErrorType.conflict;
 			// Identify invalid pin assignments
 			else if (invalidPins.indexOf(mappings[button].pin) > -1)
 				mappings[button].error = translatedErrorType.invalid;
@@ -170,6 +175,27 @@ export default function PinMappingPage() {
 		return <></>;
 	};
 
+	const setAllButtonsPins = () => {
+		setIsCapturingPinsInProgress(true);	
+		setCapturingButtonIndex(0);
+	}
+
+	const onTriggeredCaptureComplete = () => {
+		if (!isCapturingPinsInProgress) return;
+		if (capturingButtonIndex + 1 < buttonNames.length)
+			setCapturingButtonIndex(capturingButtonIndex + 1);
+		else {
+			setIsCapturingPinsInProgress(false);
+			setCapturingButtonIndex(-1);
+		}
+	}
+
+	const onStopCaptureSequence = () => {
+		if (!isCapturingPinsInProgress) return;
+		setCapturingButtonIndex(-1);
+		setIsCapturingPinsInProgress(false);
+	};
+
 	return (
 		<Section title={t('PinMapping:header-text')}>
 			<Form noValidate validated={validated} onSubmit={handleSubmit}>
@@ -189,6 +215,10 @@ export default function PinMappingPage() {
 						page.
 					</Trans>
 				</div>
+				<Button className="mb-3"
+					onClick={setAllButtonsPins}>
+						{t("PinMapping:all-capture-button-label")}
+				</Button>
 				<table className="table table-sm pin-mapping-table">
 					<thead className="table">
 						<tr>
@@ -199,9 +229,7 @@ export default function PinMappingPage() {
 						</tr>
 					</thead>
 					<tbody>
-						{Object.keys(BUTTONS[buttonLabelType])
-							?.filter((p) => p !== 'label' && p !== 'value')
-							.map((button, i) => {
+						{buttonNames.map((button, i) => {
 								let label = BUTTONS[buttonLabelType][button];
 								if (
 									button === 'S1' &&
@@ -237,6 +265,15 @@ export default function PinMappingPage() {
 												isInvalid={buttonMappings[button].error}
 												onChange={(e) => handlePinChange(e, button)}
 											></Form.Control>
+											<CaptureButton
+												onChange={(pin) =>
+													handlePinChange({ target: { value: pin } }, button, true)}
+												abortRef={controller}
+												triggerCapture={button === buttonNames[capturingButtonIndex]}
+												buttonName={button}
+												onTriggeredCaptureComplete={onTriggeredCaptureComplete}
+												onStopCaptureSequence={onStopCaptureSequence}
+											/>
 											<Form.Control.Feedback type="invalid">
 												{renderError(button)}
 											</Form.Control.Feedback>

--- a/www/src/Pages/PinMapping.jsx
+++ b/www/src/Pages/PinMapping.jsx
@@ -270,7 +270,7 @@ export default function PinMappingPage() {
 													handlePinChange({ target: { value: pin } }, button, true)}
 												abortRef={controller}
 												triggerCapture={button === buttonNames[capturingButtonIndex]}
-												buttonName={button}
+												buttonName={label}
 												onTriggeredCaptureComplete={onTriggeredCaptureComplete}
 												onStopCaptureSequence={onStopCaptureSequence}
 											/>

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { intToHex, hexToInt, rgbIntToHex } from './Utilities';
 
 const baseUrl =
-	process.env.NODE_ENV === 'production' ? '' : 'http://192.168.7.1';
+	process.env.NODE_ENV === 'production' ? '' : 'http://localhost:8080';
 
 export const baseButtonMappings = {
 	Up: { pin: -1, key: 0, error: null },

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { intToHex, hexToInt, rgbIntToHex } from './Utilities';
 
 const baseUrl =
-	process.env.NODE_ENV === 'production' ? '' : 'http://localhost:8080';
+	process.env.NODE_ENV === 'production' ? '' : 'http://192.168.7.1';
 
 export const baseButtonMappings = {
 	Up: { pin: -1, key: 0, error: null },
@@ -474,17 +474,19 @@ async function getUsedPins(setLoading) {
 }
 
 async function getHeldPins(setLoading, createAbortSignal) {
-	setLoading(true);
+	setLoading && setLoading(true);
 
 	try {
 		const response = await axios.get(`${baseUrl}/api/getHeldPins`, {
 			signal: createAbortSignal()
 		});
-		setLoading(false);
+		setLoading && setLoading(false);
 		return response.data;
 	} catch (error) {
-		setLoading(false);
-		console.error(error);
+		setLoading && setLoading(false);
+		if (error?.code === 'ERR_CANCELED')
+			return { canceled: true };
+		else console.error(error);
 	}
 }
 
@@ -492,7 +494,7 @@ async function abortGetHeldPins() {
 	try {
 		await axios.get(`${baseUrl}/api/abortGetHeldPins`);
 	} catch (error) {
-		console.error(error);
+		// Expected to fail
 	}
 }
 

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -473,6 +473,29 @@ async function getUsedPins(setLoading) {
 	}
 }
 
+async function getHeldPins(setLoading, createAbortSignal) {
+	setLoading(true);
+
+	try {
+		const response = await axios.get(`${baseUrl}/api/getHeldPins`, {
+			signal: createAbortSignal()
+		});
+		setLoading(false);
+		return response.data;
+	} catch (error) {
+		setLoading(false);
+		console.error(error);
+	}
+}
+
+async function abortGetHeldPins() {
+	try {
+		await axios.get(`${baseUrl}/api/abortGetHeldPins`);
+	} catch (error) {
+		console.error(error);
+	}
+}
+
 async function reboot(bootMode) {
 	return axios
 		.post(`${baseUrl}/api/reboot`, { bootMode })
@@ -514,6 +537,8 @@ const WebApi = {
 	getFirmwareVersion,
 	getMemoryReport,
 	getUsedPins,
+	getHeldPins,
+	abortGetHeldPins,
 	reboot,
 };
 


### PR DESCRIPTION
This PR adds a new functionality to the Pin Mapping configuration screen. It allows the user to press buttons on their controller to assign pins. It can be done for each button individually or all buttons one-by-one.

Currently, as per the implementation, it initializes all valid pins. Within a window of 5 seconds, if the user does nothing, it returns empty. Before anything is returned, all unused pins are also uninitialized.

Please review and merge, thanks!