### PR TITLE
GPIO labels

### DIFF
--- a/www/src/Locales/en/PinMapping.jsx
+++ b/www/src/Locales/en/PinMapping.jsx
@@ -1,5 +1,5 @@
 export default {
-	'header-text': 'GPIO Mapping',
+	'header-text': 'GPIO Pin Mapping',
 	'sub-header-text':
 		'Use the form below to reconfigure your button-to-GPIO pin mapping.',
 	'alert-text':

--- a/www/src/Locales/en/PinMapping.jsx
+++ b/www/src/Locales/en/PinMapping.jsx
@@ -1,14 +1,14 @@
 export default {
-	'header-text': 'Pin Mapping',
+	'header-text': 'GPIO Mapping',
 	'sub-header-text':
-		'Use the form below to reconfigure your button-to-pin mapping.',
+		'Use the form below to reconfigure your button-to-GPIO pin mapping.',
 	'alert-text':
-		"Mapping buttons to pins that aren't connected or available can leave the device in non-functional state. To clear the the invalid configuration go to the <1>Reset Settings</1> page.",
-	'pin-header-label': 'Pin',
+		"Mapping buttons to GPIO pins that aren't connected or available can leave the device in non-functional state. To clear the the invalid configuration go to the <1>Reset Settings</1> page.",
+	'pin-header-label': 'GPIO',
 	errors: {
-		conflict: 'Pin {{pin}} is already assigned to {{conflictedMappings}}',
+		conflict: 'GPIO {{pin}} is already assigned to {{conflictedMappings}}',
 		required: '{{button}} is required',
-		invalid: '{{pin}} is invalid for this board',
-		used: '{{pin}} is already assigned to another feature',
+		invalid: 'GPIO {{pin}} is invalid for this board',
+		used: 'GPIO {{pin}} is already assigned to another feature',
 	},
 };


### PR DESCRIPTION
Clarify the fact that these are logical GPIO numbers, as opposed to physical pin numbers - since actual pin numbers are device-dependent, and since there is a risk of someone ignorant (like me!) thinking these are *actual* pin numbers, it's probably safer to designate them as "GPIO" pins.