### PR TITLE
Small fixes to LED Animation system

### DIFF
--- a/lib/AnimationStation/src/Animation.hpp
+++ b/lib/AnimationStation/src/Animation.hpp
@@ -10,7 +10,11 @@
 #include "NeoPico.hpp"
 
 struct RGB {
-  RGB() : r(0), g(0), b(0) {}
+  // defaults allows trivial constructor, avoiding compiler complaints and avoiding unnessecary initialization
+  // animation always memsets the frame before use, to this is safe.
+  RGB() = default; 
+  RGB(const RGB&) = default;
+
 
   constexpr RGB(uint8_t r, uint8_t g, uint8_t b) : r(r), g(g), b(b), w(0) {}
 

--- a/lib/AnimationStation/src/AnimationStation.cpp
+++ b/lib/AnimationStation/src/AnimationStation.cpp
@@ -28,6 +28,7 @@ void AnimationStation::HandleEvent(AnimationHotkey action) {
   if (action == HOTKEY_LEDS_NONE || !time_reached(AnimationStation::nextChange)) {
     return;
   }
+  AnimationStation::nextChange = make_timeout_time_ms(250);
 
   if (action == HOTKEY_LEDS_BRIGHTNESS_UP) {
     AnimationStation::IncreaseBrightness();
@@ -45,6 +46,11 @@ void AnimationStation::HandleEvent(AnimationHotkey action) {
     ChangeAnimation(-1);
   }
 
+
+  if (this->baseAnimation == nullptr || this->buttonAnimation == nullptr) {
+    return;
+  }
+  
   if (action == HOTKEY_LEDS_PARAMETER_UP) {
     this->baseAnimation->ParameterUp();
   }
@@ -60,8 +66,7 @@ void AnimationStation::HandleEvent(AnimationHotkey action) {
   if (action == HOTKEY_LEDS_PRESS_PARAMETER_DOWN) {
     this->buttonAnimation->ParameterDown();
   }
-
-  AnimationStation::nextChange = make_timeout_time_ms(250);
+  
 }
 
 void AnimationStation::ChangeAnimation(int changeSize) {

--- a/lib/AnimationStation/src/Effects/Chase.cpp
+++ b/lib/AnimationStation/src/Effects/Chase.cpp
@@ -85,13 +85,20 @@ int Chase::WheelFrame(int i) {
   return frame;
 }
 
+#define CHASE_CYCLE_INCREMENT 10
 void Chase::ParameterUp() {
-  AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime + 10;
-}
-
-void Chase::ParameterDown() {
-  if (AnimationStation::options.chaseCycleTime > 0) {
-    AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime - 10;
+  if (AnimationStation::options.chaseCycleTime < 65535 - CHASE_CYCLE_INCREMENT) {
+    AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime + CHASE_CYCLE_INCREMENT;
+  } else {
+    AnimationStation::options.chaseCycleTime = 65535;
   }
 }
 
+void Chase::ParameterDown() {
+  if (AnimationStation::options.chaseCycleTime > CHASE_CYCLE_INCREMENT) {
+    AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime - CHASE_CYCLE_INCREMENT;
+  } else {
+    AnimationStation::options.chaseCycleTime = 1;
+  }
+}
+#undef CHASE_CYCLE_INCREMENT

--- a/lib/AnimationStation/src/Effects/Chase.cpp
+++ b/lib/AnimationStation/src/Effects/Chase.cpp
@@ -85,20 +85,23 @@ int Chase::WheelFrame(int i) {
   return frame;
 }
 
-#define CHASE_CYCLE_INCREMENT 10
+// clamp chaseCycleTime to [1 ... INT16_MAX]
+#define CHASE_CYCLE_INCREMENT   10
+#define CHASE_CYCLE_MAX         INT16_MAX - CHASE_CYCLE_INCREMENT
+#define CHASE_CYCLE_MIN         1         + CHASE_CYCLE_INCREMENT
+
 void Chase::ParameterUp() {
-  if (AnimationStation::options.chaseCycleTime < 65535 - CHASE_CYCLE_INCREMENT) {
+  if (AnimationStation::options.chaseCycleTime < CHASE_CYCLE_MAX) {
     AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime + CHASE_CYCLE_INCREMENT;
   } else {
-    AnimationStation::options.chaseCycleTime = 65535;
+    AnimationStation::options.chaseCycleTime = INT16_MAX;
   }
 }
 
 void Chase::ParameterDown() {
-  if (AnimationStation::options.chaseCycleTime > CHASE_CYCLE_INCREMENT) {
+  if (AnimationStation::options.chaseCycleTime > CHASE_CYCLE_MIN) {
     AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime - CHASE_CYCLE_INCREMENT;
   } else {
     AnimationStation::options.chaseCycleTime = 1;
   }
 }
-#undef CHASE_CYCLE_INCREMENT

--- a/lib/AnimationStation/src/Effects/Chase.cpp
+++ b/lib/AnimationStation/src/Effects/Chase.cpp
@@ -1,5 +1,9 @@
 #include "Chase.hpp"
 
+#define CHASE_CYCLE_INCREMENT   10
+#define CHASE_CYCLE_MAX         INT16_MAX/2
+#define CHASE_CYCLE_MIN         10
+
 Chase::Chase(PixelMatrix &matrix) : Animation(matrix) {
 }
 
@@ -47,6 +51,14 @@ void Chase::Animate(RGB (&frame)[100]) {
     }
   }
 
+  // this really shouldn't be nessecary, but something outside the param down might be changing this
+  if ( AnimationStation::options.chaseCycleTime < CHASE_CYCLE_MIN ){
+    AnimationStation::options.chaseCycleTime = CHASE_CYCLE_MIN;
+  } 
+  else if (AnimationStation::options.chaseCycleTime > CHASE_CYCLE_MAX) {
+    AnimationStation::options.chaseCycleTime = CHASE_CYCLE_MAX;
+  }
+
   this->nextRunTime = make_timeout_time_ms(AnimationStation::options.chaseCycleTime);
 }
 
@@ -85,23 +97,16 @@ int Chase::WheelFrame(int i) {
   return frame;
 }
 
-// clamp chaseCycleTime to [1 ... INT16_MAX]
-#define CHASE_CYCLE_INCREMENT   10
-#define CHASE_CYCLE_MAX         INT16_MAX - CHASE_CYCLE_INCREMENT
-#define CHASE_CYCLE_MIN         1         + CHASE_CYCLE_INCREMENT
-
 void Chase::ParameterUp() {
-  if (AnimationStation::options.chaseCycleTime < CHASE_CYCLE_MAX) {
-    AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime + CHASE_CYCLE_INCREMENT;
-  } else {
-    AnimationStation::options.chaseCycleTime = INT16_MAX;
+  AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime + CHASE_CYCLE_INCREMENT;
+  if (AnimationStation::options.chaseCycleTime > CHASE_CYCLE_MAX) {
+    AnimationStation::options.chaseCycleTime = CHASE_CYCLE_MAX;
   }
 }
 
 void Chase::ParameterDown() {
-  if (AnimationStation::options.chaseCycleTime > CHASE_CYCLE_MIN) {
-    AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime - CHASE_CYCLE_INCREMENT;
-  } else {
-    AnimationStation::options.chaseCycleTime = 1;
+  AnimationStation::options.chaseCycleTime = AnimationStation::options.chaseCycleTime - CHASE_CYCLE_INCREMENT;
+  if ( AnimationStation::options.chaseCycleTime < CHASE_CYCLE_MIN ){
+    AnimationStation::options.chaseCycleTime = CHASE_CYCLE_MIN;
   }
 }

--- a/lib/AnimationStation/src/Effects/Rainbow.cpp
+++ b/lib/AnimationStation/src/Effects/Rainbow.cpp
@@ -38,20 +38,23 @@ void Rainbow::Animate(RGB (&frame)[100]) {
   this->nextRunTime = make_timeout_time_ms(AnimationStation::options.rainbowCycleTime);
 }
 
-#define RAINBOW_CYCLE_INCREMENT 10
+// clamp rainbowCycleTime to [1 ... INT16_MAX]
+#define RAINBOW_CYCLE_INCREMENT   10
+#define RAINBOW_CYCLE_MAX         INT16_MAX - RAINBOW_CYCLE_INCREMENT
+#define RAINBOW_CYCLE_MIN         1         + RAINBOW_CYCLE_INCREMENT
+
 void Rainbow::ParameterUp() {
-  if (AnimationStation::options.chaseCycleTime < 65535 - RAINBOW_CYCLE_INCREMENT) {
+  if (AnimationStation::options.rainbowCycleTime < RAINBOW_CYCLE_MAX) {
     AnimationStation::options.rainbowCycleTime = AnimationStation::options.rainbowCycleTime + RAINBOW_CYCLE_INCREMENT;
   } else {
-    AnimationStation::options.rainbowCycleTime = 65535;
+    AnimationStation::options.rainbowCycleTime = INT16_MAX;
   }
 }
 
 void Rainbow::ParameterDown() {
-  if (AnimationStation::options.rainbowCycleTime > RAINBOW_CYCLE_INCREMENT) {
+  if (AnimationStation::options.rainbowCycleTime > RAINBOW_CYCLE_MIN) {
     AnimationStation::options.rainbowCycleTime = AnimationStation::options.rainbowCycleTime - RAINBOW_CYCLE_INCREMENT;
   } else {
     AnimationStation::options.rainbowCycleTime = 1;
   }
 }
-#undef RAINBOW_CYCLE_INCREMENT

--- a/lib/AnimationStation/src/Effects/Rainbow.cpp
+++ b/lib/AnimationStation/src/Effects/Rainbow.cpp
@@ -38,12 +38,20 @@ void Rainbow::Animate(RGB (&frame)[100]) {
   this->nextRunTime = make_timeout_time_ms(AnimationStation::options.rainbowCycleTime);
 }
 
+#define RAINBOW_CYCLE_INCREMENT 10
 void Rainbow::ParameterUp() {
-  AnimationStation::options.rainbowCycleTime =AnimationStation::options.rainbowCycleTime + 10;
+  if (AnimationStation::options.chaseCycleTime < 65535 - RAINBOW_CYCLE_INCREMENT) {
+    AnimationStation::options.rainbowCycleTime = AnimationStation::options.rainbowCycleTime + RAINBOW_CYCLE_INCREMENT;
+  } else {
+    AnimationStation::options.rainbowCycleTime = 65535;
+  }
 }
 
 void Rainbow::ParameterDown() {
-  if (AnimationStation::options.rainbowCycleTime > 0) {
-    AnimationStation::options.rainbowCycleTime = AnimationStation::options.rainbowCycleTime - 10;
+  if (AnimationStation::options.rainbowCycleTime > RAINBOW_CYCLE_INCREMENT) {
+    AnimationStation::options.rainbowCycleTime = AnimationStation::options.rainbowCycleTime - RAINBOW_CYCLE_INCREMENT;
+  } else {
+    AnimationStation::options.rainbowCycleTime = 1;
   }
 }
+#undef RAINBOW_CYCLE_INCREMENT

--- a/src/addons/neopicoleds.cpp
+++ b/src/addons/neopicoleds.cpp
@@ -489,7 +489,7 @@ uint8_t NeoPicoLEDAddon::setupButtonPositions()
 	buttonPositions.emplace(BUTTON_LABEL_A1, ledOptions.indexA1);
 	buttonPositions.emplace(BUTTON_LABEL_A2, ledOptions.indexA2);
 	uint8_t buttonCount = 0;
-	for (auto const buttonPosition : buttonPositions)
+	for (auto const& buttonPosition : buttonPositions)
 	{
 		if (buttonPosition.second > -1)
 			buttonCount++;


### PR DESCRIPTION
Fix for https://github.com/OpenStickCommunity/GP2040-CE/issues/431, animation state breaks for cycling animations when they are made too fast. 
Also includes a fix to a potential memory corruption via Animation pointers in the AnimationStation.
Another small change to the RBG struct constructors to make them Trivial classes.

Please note, as my hitbox has not yet arrived I am unable to test these changes past simply ensuring they compile.