### PR TITLE
Fix hotkeys with input addons

### DIFF
--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -159,11 +159,11 @@ void GP2040::run() {
 	#if GAMEPAD_DEBOUNCE_MILLIS > 0
 		gamepad->debounce();
 	#endif
-		gamepad->hotkey(); 	// check for MPGS hotkeys
-		rebootHotkeys.process(gamepad, configMode);
-
 		// Pre-Process add-ons for MPGS
 		addons.PreprocessAddons(ADDON_PROCESS::CORE0_INPUT);
+
+		gamepad->hotkey(); 	// check for MPGS hotkeys
+		rebootHotkeys.process(gamepad, configMode);
 		
 		gamepad->process(); // process through MPGS
 


### PR DESCRIPTION
This is a simple fix that allows input addons to use the hotkeys feature.
This was tested on the Keyboard Host addon and is to be noted that the boot selection (selection of controller types/web-config) didn't work due to the delay in USB initialization which might not be present in other addons.

Please test and merge, thanks!