### PR TITLE
Remove PS4 counter

### DIFF
--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -606,9 +606,6 @@ PS4Report *Gamepad::getPS4Report()
 	ps4Report.button_home     = pressedA1();
 	ps4Report.button_touchpad = options.switchTpShareForDs4 ? pressedS1() : pressedA2();
 
-	// report counter is 6 bits, but we circle 0-255
-	ps4Report.report_counter = last_report_counter++;
-
 	ps4Report.left_stick_x = static_cast<uint8_t>(state.lx >> 8);
 	ps4Report.left_stick_y = static_cast<uint8_t>(state.ly >> 8);
 	ps4Report.right_stick_x = static_cast<uint8_t>(state.rx >> 8);


### PR DESCRIPTION
Gets rid of the counter in the PS4 input report.

It doesn't do anything except add 1ms of latency.