### PR TITLE
Feature: Allow Tilt1 and Tilt2 to Operate Without PinMapping

### DIFF
--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -165,8 +165,8 @@ void TiltInput::process()
 //Since this is an auxiliary function for appeals and such,
 //pressing Tilt1 and Tilt2 at the same time will cause the light analog stick to correspond to each of the DPad methods.
 void TiltInput::OverrideGamepad(Gamepad* gamepad, uint8_t dpad1, uint8_t dpad2) {
-	bool pinTilt1Pressed = pinTilt1 != (uint8_t)-1 && !gpio_get(pinTilt1);
-	bool pinTilt2Pressed = pinTilt2 != (uint8_t)-1 && !gpio_get(pinTilt2);
+	bool pinTilt1Pressed = (pinTilt1 != (uint8_t)-1) ? !gpio_get(pinTilt1) : false;
+	bool pinTilt2Pressed = (pinTilt2 != (uint8_t)-1) ? !gpio_get(pinTilt2) : false;
 
 	if (pinTilt1Pressed) {
 		gamepad->state.lx = dpadToAnalogX(dpad1) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad1)) * TILT1_FACTOR_LEFT_X;


### PR DESCRIPTION
## Changes
- Modified the code to allow Tilt1 and Tilt2 to function even if they are not mapped to any pins.

## Motivation
- This change makes the Tilt1 and Tilt2 features more flexible and allows users who do not require PinMapping to still benefit from these functionalities.

## Testing
- Tests have been carried out to ensure that the features work as expected both when pins are mapped and when they are not.

Please review and let me know if any changes are required.