### PR TITLE
Truncated mask broke high pin dpad inputs

### DIFF
--- a/headers/addons/reverse.h
+++ b/headers/addons/reverse.h
@@ -25,7 +25,7 @@ public:
     virtual std::string name() { return ReverseName; }
 private:
     void update();
-    uint8_t input(uint8_t valueMask, uint16_t buttonMask, uint16_t buttonMaskReverse, uint8_t action, bool invertAxis);
+    uint8_t input(uint32_t valueMask, uint16_t buttonMask, uint16_t buttonMaskReverse, uint8_t action, bool invertAxis);
 
 	bool state;
 

--- a/src/addons/reverse.cpp
+++ b/src/addons/reverse.cpp
@@ -48,7 +48,7 @@ void ReverseInput::update() {
     state = !gpio_get(pinButtonReverse);
 }
 
-uint8_t ReverseInput::input(uint8_t valueMask, uint16_t buttonMask, uint16_t buttonMaskReverse, uint8_t action, bool invertAxis) {
+uint8_t ReverseInput::input(uint32_t valueMask, uint16_t buttonMask, uint16_t buttonMaskReverse, uint8_t action, bool invertAxis) {
     if (state && action == 2) {
         return 0;
     }


### PR DESCRIPTION
Fix for [#498](https://github.com/OpenStickCommunity/GP2040-CE/issues/498)
Reverse Inputs addon would break all dpad inputs if they were assigned to high pins ( pin 8, mask >= 256 ).
This was due to truncation of the mask in the ReverseInput::input parameters.

Recreated and fixed with standard pico:
Reverse pin 22
DPad pins: 6 7 8 9
This caused 8 and 9 to not function before the fix.