### PR TITLE
Re-implementation of input history

### DIFF
--- a/headers/addons/i2cdisplay.h
+++ b/headers/addons/i2cdisplay.h
@@ -7,6 +7,8 @@
 #define DISPLAY_H_
 
 #include <string>
+#include <deque>
+#include <array>
 #include <hardware/i2c.h>
 #include "OneBitDisplay.h"
 #include "BoardConfig.h"
@@ -150,6 +152,7 @@ private:
 	void drawWasdBox(int startX, int startY, int buttonRadius, int buttonPadding);
 	void drawArcadeStick(int startX, int startY, int buttonRadius, int buttonPadding);
 	void drawStatusBar(Gamepad*);
+	void drawHistory(Gamepad*);
 	void drawText(int startX, int startY, std::string text);
 	void initMenu(char**);
 	//Adding my stuff here, remember to sort before PR
@@ -198,6 +201,8 @@ private:
 	std::string statusBar;
 	Gamepad* gamepad;
 	Gamepad* pGamepad;
+	std::deque<std::string> history;
+	std::array<bool, 17> last;
 	bool configMode;
 
 	enum DisplayMode {


### PR DESCRIPTION
This is a re-implementation of the previous input history RP that was submitted by Thnikk (https://github.com/OpenStickCommunity/GP2040-CE/pull/53).

Changes:
- Removed all layout changes
- Added PS4 mode

This PR is not finished.  It needs to be added into an addon and have a web-config component added to it.  There is also currently no mapping for the HID Keyboard mode which casues issues.  As a nice to have I am going to look into making a square and triangle for PS4 and PS3 mode.