### PR TITLE
Update docs with minor improvements for add-on discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Links
 
-[Downloads](https://gp2040-ce.info/#/download) | [Installation](https://gp2040-ce.info/#/installation) | [Wiring](https://gp2040-ce.info/#/wiring) | [Usage](https://gp2040-ce.info/#/usage) | [FAQ](https://gp2040-ce.info/#/faq)
+[Downloads](https://gp2040-ce.info/#/download) | [Installation](https://gp2040-ce.info/#/installation) | [Wiring](https://gp2040-ce.info/#/wiring) | [Usage](https://gp2040-ce.info/#/usage) | [FAQ](https://gp2040-ce.info/#/faq) | [GitHub](https://github.com/OpenStickCommunity/GP2040-CE)
 
 Full documentation can be found at <https://gp2040-ce.info>
 
@@ -38,7 +38,7 @@ Full documentation can be found at <https://gp2040-ce.info>
 * Left and Right stick emulation via D-pad inputs as well as dedicated toggle switches.
 * Dual direction via D-pad + LS/RS.
 * Reversed input via a button.
-* Turbo and Turbo LED with selectable speed
+* [Turbo and Turbo LED](https://gp2040-ce.info/#/web-configurator-add-ons?id=turbo) with selectable speed
 * Per-button RGB LED support.
 * PWM Player indicator LED support (XInput only).
 * Multiple LED profiles support.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,9 +38,11 @@ Unlike other controllers, Keyboard gets different keys for directional buttons.
 
 ?> You can change the key mappings for Keyboard mode in [Webconfig mode](web-configurator.md)
 
-## Additional Features: Turbo & LS/RS Emulation
+## Additional Features and Add-Ons
 
 Please note that the documentation for these new features is yet to be written. A future version will include updated docs.
+
+There are a number of add-ons that expand the functionality of GP2040-CE, such as [analog stick emulation emulation](https://gp2040-ce.info/#/web-configurator-add-ons?id=analog) and [turbo functions](https://gp2040-ce.info/#/web-configurator-add-ons?id=turbo). Due to the large number of add-ons created by the community, they are located in a separate documentation page. Navigate to [Web Configurator - Add-ons](https://gp2040-ce.info/#/web-configurator-add-ons) for more information.
 
 ## Bootsel Mode
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,7 +42,7 @@ Unlike other controllers, Keyboard gets different keys for directional buttons.
 
 Please note that the documentation for these new features is yet to be written. A future version will include updated docs.
 
-There are a number of add-ons that expand the functionality of GP2040-CE, such as [analog stick emulation emulation](https://gp2040-ce.info/#/web-configurator-add-ons?id=analog) and [turbo functions](https://gp2040-ce.info/#/web-configurator-add-ons?id=turbo). Due to the large number of add-ons created by the community, they are located in a separate documentation page. Navigate to [Web Configurator - Add-ons](https://gp2040-ce.info/#/web-configurator-add-ons) for more information.
+There are a number of add-ons that expand the functionality of GP2040-CE, such as [analog stick emulation](web-configurator-add-ons#analog) and [turbo functions](web-configurator-add-ons#turbo). Due to the large number of add-ons created by the community, they are located in a separate documentation page. Navigate to [Web Configurator - Add-ons](web-configurator-add-ons) for more information.
 
 ## Bootsel Mode
 

--- a/docs/web-configurator-add-ons.md
+++ b/docs/web-configurator-add-ons.md
@@ -1,6 +1,6 @@
 # Add-Ons Configuration
 
-This section is for custom add-ons that can be enabled to expand the functionality of GP2040-CE.  Please note that not all add-ons may work together.  These should be considered experimental.
+This section is for custom add-ons that can be enabled to expand the functionality of GP2040-CE.  Some of these add-ons are experimental.  Please note that not all add-ons may work together.
 
 ## BOOTSEL Button Configuration
 
@@ -24,7 +24,7 @@ Please note that this can only be used on devices that have a BOOTSEL button.  P
 
 * `Analog Stick 1 X Pin` - The GPIO pin used for the Analog Stick 1 X value.  Only ADC pins 26, 27, 28 and 29 are allowed here.
 * `Analog Stick 1 Y Pin` - The GPIO pin used for the Analog Stick 1 Y value.  Only ADC pins 26, 27, 28 and 29 are allowed here.
-* `Analog Stick 1 Mode` - Choose if Analog Stick 1 is to be used for Left Analog or Right Analog.  
+* `Analog Stick 1 Mode` - Choose if Analog Stick 1 is to be used for Left Analog or Right Analog.
 * `Analog Stick 1 Invert` - Choose if you would like to flip the X or Y axis Analog Stick 1 inputs (or both).
 * `Analog Stick 2 X Pin` - The GPIO pin used for the Analog Stick 2 X value.  Only ADC pins 26, 27, 28 and 29 are allowed here.
 * `Analog Stick 2 Y Pin` - The GPIO pin used for the Analog Stick 2 Y value.  Only ADC pins 26, 27, 28 and 29 are allowed here.
@@ -216,7 +216,7 @@ These addons are predicated on having and using a USB Host Port on the device. T
 
 ![GP2040-CE Configurator - PS Passthrough](assets/images/gpc-add-ons-ps-passthrough.png)
 
-Enabling this add-on will allow you to use a licenced 3rd party device to authenticate off of.  This addon requires that you have something like the ![USB Passthrough Board](https://github.com/OpenStickCommunity/Hardware/tree/main/USB%20Passthrough%20Board) or a board with a USB passthrough port on it already.  If you have passthrough enabled you can turn off the above `PS4 Mode` addon as the two will not work together.  Please also ensure that under the `Settings` section you have chosen PS4 mode and picked if you want the GP2040-CE unit to function as a controller or as a fightstick.   
+Enabling this add-on will allow you to use a licenced 3rd party device to authenticate off of.  This addon requires that you have something like the ![USB Passthrough Board](https://github.com/OpenStickCommunity/Hardware/tree/main/USB%20Passthrough%20Board) or a board with a USB passthrough port on it already.  If you have passthrough enabled you can turn off the above `PS4 Mode` addon as the two will not work together.  Please also ensure that under the `Settings` section you have chosen PS4 mode and picked if you want the GP2040-CE unit to function as a controller or as a fightstick.
 
 ### Keyboard Host Configuration
 


### PR DESCRIPTION
I wanted to make some changes to the docs to help with discoverability of some features, most notably for add-ons. I'm not an expert on markdown, so the links for now are URL links instead of links between markdown pages. 

Summary of changes:

`README.md`: added a link to the github page (as far as I know, this is the page that generates https://gp2040-ce.info/, and there was no link back to the github repo) and a direct link to Turbo functionality under the features list. In future this could be expanded to direct link all the features to their documentation, but I'm leaving it for now so that this PR can be incremental

`docs/usage.md`: I pulled the paragraph from InfraredAces on discord from our discussion to replace the "unfinished docs" section on turbo and analog stick emulation, but with extra links to turbo and analog stick add-ons (to preserve the link from this page to that concept)

`docs/web-configurator-add-ons.md`: Reworded the "experimental" phrasing, since from discussion with InfraredAces, not all add-ons should be considered experimental. Some trailing spaces were also removed.