### PR TITLE
Full sleep removal from core0 and core1 loops

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -21,9 +21,6 @@
 extern uint32_t getMillis();
 extern uint64_t getMicro();
 
-#define GAMEPAD_POLL_MS 1
-#define GAMEPAD_POLL_MICRO 100
-
 #define GAMEPAD_FEATURE_REPORT_SIZE 32
 
 struct GamepadButtonMapping

--- a/headers/gp2040.h
+++ b/headers/gp2040.h
@@ -19,7 +19,6 @@ public:
     void setup();           // setup core0
     void run();             // loop core0
 private:
-    uint64_t nextRuntime;
     Gamepad snapshot;
     AddonManager addons;
 

--- a/headers/gp2040aux.h
+++ b/headers/gp2040aux.h
@@ -18,7 +18,6 @@ public:
     void setup();           // setup core1
     void run();             // loop core1
 private:
-    uint64_t nextRuntime;
     AddonManager addons;
 };
 

--- a/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
@@ -50,16 +50,17 @@ void receive_report(uint8_t *buffer)
 	}
 }
 
-void send_report(void *report, uint16_t report_size)
+bool send_report(void *report, uint16_t report_size)
 {
 	static uint8_t previous_report[CFG_TUD_ENDPOINT0_SIZE] = { };
+
+	bool sent = false;
 
 	if (tud_suspended())
 		tud_remote_wakeup();
 
 	if (memcmp(previous_report, report, report_size) != 0)
 	{
-		bool sent = false;
 		switch (input_mode)
 		{
 			case INPUT_MODE_XINPUT:
@@ -77,6 +78,8 @@ void send_report(void *report, uint16_t report_size)
 		if (sent)
 			memcpy(previous_report, report, report_size);
 	}
+	
+	return sent;
 }
 
 /* USB Driver Callback (Required for XInput) */

--- a/lib/TinyUSB_Gamepad/src/usb_driver.h
+++ b/lib/TinyUSB_Gamepad/src/usb_driver.h
@@ -18,5 +18,5 @@ InputMode get_input_mode(void);
 bool get_usb_mounted(void);
 void initialize_driver(InputMode mode);
 void receive_report(uint8_t *buffer);
-void send_report(void *report, uint16_t report_size);
+bool send_report(void *report, uint16_t report_size);
 

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -40,7 +40,7 @@
 static const uint32_t REBOOT_HOTKEY_ACTIVATION_TIME_MS = 50;
 static const uint32_t REBOOT_HOTKEY_HOLD_TIME_MS = 4000;
 
-GP2040::GP2040() : nextRuntime(0) {
+GP2040::GP2040() {
 	Storage::getInstance().SetGamepad(new Gamepad(GAMEPAD_DEBOUNCE_MILLIS));
 	Storage::getInstance().SetProcessedGamepad(new Gamepad(GAMEPAD_DEBOUNCE_MILLIS));
 }
@@ -139,20 +139,12 @@ void GP2040::run() {
 		// Config Loop (Web-Config does not require gamepad)
 		if (configMode == true) {
 			ConfigManager::getInstance().loop();
-
 			gamepad->read();
 			rebootHotkeys.process(gamepad, configMode);
-
 			continue;
 		}
 
 		USBHostManager::getInstance().process();
-
-		// We can't send faster than USB can poll
-		if (nextRuntime > getMicro()) { // fix for unsigned
-			sleep_us(50); // Give some time back to our CPU (lower power consumption)
-			continue;
-		}
 
 		// Gamepad Features
 		gamepad->read(); 	// gpio pin reads
@@ -174,16 +166,13 @@ void GP2040::run() {
 		memcpy(&processedGamepad->state, &gamepad->state, sizeof(GamepadState));
 
 		// USB FEATURES : Send/Get USB Features (including Player LEDs on X-Input)
-		send_report(gamepad->getReport(), gamepad->getReportSize());
-		Storage::getInstance().ClearFeatureData();
-		receive_report(Storage::getInstance().GetFeatureData());
-
-		// Process USB Reports
-		addons.ProcessAddons(ADDON_PROCESS::CORE0_USBREPORT);
-
+		if ( send_report(gamepad->getReport(), gamepad->getReportSize()) == true ) {
+			Storage::getInstance().ClearFeatureData();
+			receive_report(Storage::getInstance().GetFeatureData());
+			// Process USB Reports
+			addons.ProcessAddons(ADDON_PROCESS::CORE0_USBREPORT);
+		}
 		tud_task(); // TinyUSB Task update
-
-		nextRuntime = getMicro() + GAMEPAD_POLL_MICRO;
 	}
 }
 

--- a/src/gp2040aux.cpp
+++ b/src/gp2040aux.cpp
@@ -16,7 +16,7 @@
 
 #include <iterator>
 
-GP2040Aux::GP2040Aux() : nextRuntime(0) {
+GP2040Aux::GP2040Aux() {
 }
 
 GP2040Aux::~GP2040Aux() {
@@ -38,11 +38,6 @@ void GP2040Aux::setup() {
 
 void GP2040Aux::run() {
 	while (1) {
-		if (nextRuntime > getMicro()) { // fix for unsigned
-			continue;
-		}
-		
-		addons.ProcessAddons(CORE1_LOOP);	
-		nextRuntime = getMicro() + GAMEPAD_POLL_MICRO;
+		addons.ProcessAddons(CORE1_LOOP);
 	}
 }


### PR DESCRIPTION
Need to do more testing on this, but this matches what @mthiesen originally thought about removing sleeps. I think the missing piece was not clearing feature data and requesting a "get report" if the endpoints are busy.

I need to test this more, so this is a draft copy