### PR TITLE
Adds search functionality to https://gp2040-ce.info/

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -159,6 +159,12 @@ window.$docsify = {
 	name: 'GP2040-CE',
 	repo: 'https://github.com/OpenStickCommunity/GP2040-CE',
 	homepage: 'https://raw.githubusercontent.com/OpenStickCommunity/GP2040-CE/main/README.md',
+	search: {
+		maxAge: 86400000, // Expiration time, the default one day
+		placeholder: 'Type to search',
+		depth: 6,
+		hideOtherSidebarContent: false,
+	},
 	logo: 'assets/images/gp2040-ce-logo.png',
 	loadSidebar: '_sidebar.md',
 	auto2top: true,

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,6 @@
 	<script src="//cdn.jsdelivr.net/npm/vue-sticky-element@1.1.2/dist/vue-sticky-element.min.js"></script>
 	<!-- Docsify v4 -->
 	<script src="//cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
-
 	<!-- docsify-themeable (latest v0.x.x) -->
 	<script src="//cdn.jsdelivr.net/npm/docsify-themeable@0/dist/js/docsify-themeable.min.js"></script>
 	<script src="//cdn.jsdelivr.net/npm/prismjs@1.x/components/prism-c.min.js"></script>
@@ -34,7 +33,9 @@
 	<script src="//cdn.jsdelivr.net/npm/prismjs@1.x/components/prism-ini.min.js"></script>
 	<!-- Font Awesome -->
 	<script src="//cdn.jsdelivr.net/gh/zignis/docsify-fa/script.min.js"></script>
-
 	<script src="app.js"></script>
+	<!-- Docsify Search -->
+	<script src="//cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
+
 </body>
 </html>

--- a/docs/site.css
+++ b/docs/site.css
@@ -48,6 +48,10 @@ hr {
 	margin-bottom: 4px;
 }
 
+.sidebar .search .clear-button {
+	margin: auto;
+}
+
 /*************/
 /* Downloads */
 /*************/


### PR DESCRIPTION
<img width="276" alt="Skärmavbild 2023-09-15 kl  12 09 10" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/5345892/b9ebb1a0-fc5d-4657-b856-858ab623aee0">


**Could not find a way to search for dynamically generated content in "Downloads"**
Before merging it might be worth considering if this caveat is a deal-breaker.
