### PR TITLE
Reset timer in Turbo extension when turbo button is pressed

### DIFF
--- a/headers/addons/turbo.h
+++ b/headers/addons/turbo.h
@@ -83,6 +83,11 @@
 #define PIN_SHMUP_DIAL -1
 #endif
 
+// RESET TIMER
+#ifndef RESET_TIMER_ENABLED
+#define RESET_TIMER_ENABLED 0
+#endif
+
 // Turbo Module Name
 #define TurboName "Turbo"
 
@@ -117,5 +122,6 @@ private:
     uint8_t turboDialIncrements;    // Turbo Increments based on max/min
     uint8_t shmupBtnPin[4];     // Turbo SHMUP Non-Turbo Pins
     uint16_t shmupBtnMask[4]; // Turbo SHMUP Non-Turbo Button Masks
+    uint16_t lastButtons;
 };
 #endif  // TURBO_H_

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -304,6 +304,8 @@ message TurboOptions
 	optional uint32 shmupBtnMask3 = 17;
 	optional uint32 shmupBtnMask4 = 18;
 	optional ShmupMixMode shmupMixMode = 19;
+	
+	optional bool resetTimer = 20;
 }
 
 message SliderOptions

--- a/src/addons/turbo.cpp
+++ b/src/addons/turbo.cpp
@@ -177,6 +177,15 @@ void TurboInput::process()
         dialValue = rawValue;
     }
 
+    // Reset timer if no turbo buttons were pressed last time and one or more are pressed now
+    if ( options.resetTimer ) {
+        if((lastButtons & turboButtonsPressed) == 0 && (gamepad->state.buttons & turboButtonsPressed) != 0){
+            bTurboFlicker = false; // reset flicker state to ON
+            nextTimer = getMillis() + uIntervalMS; // interval to flicker-off button
+        }
+        lastButtons = gamepad->state.buttons;
+    }
+
     // Set TURBO LED if a button is going or turbo is too fast
     if ( isValidPin(options.ledPin) ) {
         if ((gamepad->state.buttons & turboButtonsPressed) && !bTurboFlicker) {

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -391,6 +391,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.addonOptions.turboOptions, shmupBtnMask3, SHMUP_BUTTON3);
     INIT_UNSET_PROPERTY(config.addonOptions.turboOptions, shmupBtnMask4, SHMUP_BUTTON4);
     INIT_UNSET_PROPERTY(config.addonOptions.turboOptions, shmupMixMode, SHMUP_MIX_MODE);
+    INIT_UNSET_PROPERTY(config.addonOptions.turboOptions, resetTimer, !!RESET_TIMER_ENABLED);
 
     // addonOptions.sliderOptions
     INIT_UNSET_PROPERTY(config.addonOptions.sliderOptions, enabled, !!JSLIDER_ENABLED);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1095,6 +1095,7 @@ std::string setAddonOptions()
 	docToValue(turboOptions.shmupBtnMask3, doc, "shmupBtnMask3");
 	docToValue(turboOptions.shmupBtnMask4, doc, "shmupBtnMask4");
 	docToPin(turboOptions.shmupDialPin, doc, "pinShmupDial");
+	docToValue(turboOptions.resetTimer, doc, "resetTimer");
 	docToValue(turboOptions.enabled, doc, "TurboInputEnabled");
 
     WiiOptions& wiiOptions = Storage::getInstance().getAddonOptions().wiiOptions;
@@ -1507,6 +1508,7 @@ std::string getAddonOptions()
 	writeDoc(doc, "shmupBtnMask3", turboOptions.shmupBtnMask3);
 	writeDoc(doc, "shmupBtnMask4", turboOptions.shmupBtnMask4);
 	writeDoc(doc, "pinShmupDial", cleanPin(turboOptions.shmupDialPin));
+	writeDoc(doc, "resetTimer", turboOptions.resetTimer);
 	writeDoc(doc, "TurboInputEnabled", turboOptions.enabled);
 
     const WiiOptions& wiiOptions = Storage::getInstance().getAddonOptions().wiiOptions;

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -472,6 +472,7 @@ app.get('/api/getAddonsOptions', (req, res) => {
 		WiiExtensionAddonEnabled: 1,
 		SNESpadAddonEnabled: 1,
 		PSPassthroughAddonEnabled: 1,
+		resetTimer: 0,
 		usedPins: Object.values(picoController),
 	});
 });

--- a/www/src/Addons/Turbo.tsx
+++ b/www/src/Addons/Turbo.tsx
@@ -103,6 +103,10 @@ export const turboScheme = {
 		.number()
 		.label('Charge Shot Button 4 Map')
 		.validateSelectionWhenValue('TurboInputEnabled', BUTTON_MASKS),
+	resetTimer: yup
+		.number()
+		.label('Reset Timer')
+		.validateRangeWhenValue('TurboInputEnabled', 0, 1),
 };
 
 export const turboState = {
@@ -125,6 +129,7 @@ export const turboState = {
 	turboPin: -1,
 	turboPinLED: -1,
 	turboShotCount: 5,
+	resetTimer: 0,
 };
 
 const Turbo = ({ values, errors, handleChange, handleCheckbox }) => {
@@ -403,6 +408,20 @@ const Turbo = ({ values, errors, handleChange, handleCheckbox }) => {
 							))}
 						</FormSelect>
 					</div>
+					<Row className="mb-3">
+						<FormCheck
+							label={t('AddonsConfig:reset-timer-label')}
+							type="switch"
+							id="ResetTimer"
+							className="col-sm-3 ms-2"
+							isInvalid={false}
+							checked={Boolean(values.resetTimer)}
+							onChange={(e) => {
+								handleCheckbox('resetTimer', values);
+								handleChange(e);
+							}}
+						/>
+					</Row>
 				</Row>
 			</div>
 			<FormCheck

--- a/www/src/Locales/en/AddonsConfig.jsx
+++ b/www/src/Locales/en/AddonsConfig.jsx
@@ -43,6 +43,7 @@ export default {
 	'turbo-shmup-button-mask-3-label': 'Charge Button 3 Assignment',
 	'turbo-shmup-button-mask-4-label': 'Charge Button 4 Assignment',
 	'turbo-shmup-mix-mode-label': 'Simultaneous Priority Mode',
+	'reset-timer-label': 'Reset Timer at Pushing Button',
 	'joystick-selection-slider-header-text': 'Joystick Selection Slider',
 	'joystick-selection-slider-pin-one-label': 'Slider Pin One',
 	'joystick-selection-slider-pin-two-label': 'Slider Pin Two',

--- a/www/src/Locales/pt-BR/AddonsConfig.jsx
+++ b/www/src/Locales/pt-BR/AddonsConfig.jsx
@@ -43,6 +43,7 @@ export default {
 	'turbo-shmup-button-mask-3-label': 'Atribuição do Botão de Carregamento 3',
 	'turbo-shmup-button-mask-4-label': 'Atribuição do Botão de Carregamento 4',
 	'turbo-shmup-mix-mode-label': 'Modo de Prioridade Simultânea',
+	'reset-timer-label': 'Reiniciar o timer ao pressionar o botão',
 	'joystick-selection-slider-header-text':
 		'Controle Deslizante de Seleção de Joystick',
 	'joystick-selection-slider-pin-one-label': 'Pino Um do Controle Deslizante',

--- a/www/src/Locales/zh-CN/AddonsConfig.jsx
+++ b/www/src/Locales/zh-CN/AddonsConfig.jsx
@@ -42,6 +42,7 @@ export default {
 	'turbo-shmup-button-mask-3-label': '蓄力按钮 3 分配',
 	'turbo-shmup-button-mask-4-label': '蓄力按钮 4 分配',
 	'turbo-shmup-mix-mode-label': '同时优先模式',
+	'reset-timer-label': '按下按钮重置计时器',
 	'joystick-selection-slider-header-text': '方向模式选择',
 	'joystick-selection-slider-pin-one-label': '引脚1',
 	'joystick-selection-slider-pin-two-label': '引脚2',


### PR DESCRIPTION
This is for avoiding ignoring beginning of input if the input began during bTurboFlicker==true.
In order to avoid the ignoring, this change make bTurboFlicker=false and reset timer for inverting bTurboBlicker in case no turbo button was pressed at last sampling and some of turbo button is pressed at the time.