### PR TITLE
lib/ADS1219: use rp2040 i2c directly

### DIFF
--- a/lib/ADS1219/CMakeLists.txt
+++ b/lib/ADS1219/CMakeLists.txt
@@ -1,6 +1,3 @@
 add_library(ADS1219 ADS1219.cpp)
-target_link_libraries(ADS1219 PUBLIC BitBang_I2C)
+target_link_libraries(ADS1219 PUBLIC hardware_i2c)
 target_include_directories(ADS1219 INTERFACE .)
-target_include_directories(ADS1219 PUBLIC
-BitBang_I2C
-)


### PR DESCRIPTION
Drop the Bitbang_I2C dependency and use rp2040 i2c directly. This is pretty straightforward as only read/write and init functions are used which are rather small.

Unfortunately this is only build-tested as I don't have ads1219 hardware at hand.