### PR TITLE
Minor documentation cleanup

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,11 +18,10 @@ If you would like to customize your device, check out the built-in [Web Configur
 
 **The instructions will slightly vary based on your device. These instructions are for a Raspberry Pi Pico.**
 
-
 1. Download the latest `GP2040-CE_X.X.X_Pico.uf2` file for the Raspberry Pi Pico from the [Download](download) page.
 2. Unplug your Pico.
 3. Hold the BOOTSEL button on the Pico and plug into your computer.
-4. Drag and drop the `GP2040-CE_X.X.X_Pico.uf2` file into the removable drive. 
+4. Drag and drop the `GP2040-CE_X.X.X_Pico.uf2` file into the removable drive.
 5. Wait for the Pico to automatically disconnect.
 
 ## Flash Nuke process
@@ -35,4 +34,3 @@ If you would like to customize your device, check out the built-in [Web Configur
 4. ***Wait for the drive to disconnect and reconnect without unplugging***
 5. Drag your firmware onto the RPI drive and wait for disconnect
 6. Check that the controller connects using this [gamepad tester](https://hardwaretester.com/gamepad) and pressing a button.
-

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -8,13 +8,14 @@ Not sure if your board can run GP2040-CE? As long as it has a RP2040 microproces
 
 This section of the documentation is primarily geared towards end users who are looking to use their controllers without diving into the minutiae of configuring and customizing their device. Given a controller, how to get to using it as soon as possible. It consists of the following sections.
 
-- [Firmware Installation](installation "GP2040-CE | Firmware Installation"): In the event that you need to install firmware (e.g. setting up a new board, updating to a new version, or as part of troubleshooting) 
+- [Firmware Installation](installation "GP2040-CE | Firmware Installation"): In the event that you need to install firmware (e.g. setting up a new board, updating to a new version, or as part of troubleshooting)
 - [Usage](usage "GP2040-CE | Usage"): Descriptions of the various features and functions available for use with GP2040-CE
-- [Hotkeys](hotkeys "GP2040-CE | Hotkeys"): A list of the various hotkey shortcuts available for use with GP2040-CE. 
+- [Hotkeys](hotkeys "GP2040-CE | Hotkeys"): A list of the various hotkey shortcuts available for use with GP2040-CE.
 
-> The actual buttons for the shortcut may differ as they are customizable and can be set by your device's vendor or seller. 
+> The actual buttons for the shortcut may differ as they are customizable and can be set by your device's vendor or seller.
 
 - [Getting Help/Support](getting-help-support "GP2040-CE | Getting Help"): How to get help in the event of issues or malfunction
+
 ## Additional Resources
 
 If you feel ready to start customizing your controller's functions or building your own device, have a look at the `Web Configurator` or `Controller Building` section in the sidebar.

--- a/docs/site.css
+++ b/docs/site.css
@@ -31,7 +31,7 @@ hr {
 
 .sticky-label-select {
 	/* width: 100%; */
-	position: fixed!important;
+	position: fixed !important;
 	top: var(--sidebar-toggle-offset-top);
 	height: var(--sidebar-toggle-height);
 	right: 0px;

--- a/docs/site.css
+++ b/docs/site.css
@@ -8,7 +8,7 @@
 	/* --sidebar-padding: 0 0.75rem; */
 	--content-max-width: 70em;
 	--docsifytabs-border-color: #ededed;
-    --docsifytabs-tab-highlight-color: #C73C8B;
+	--docsifytabs-tab-highlight-color: #C73C8B;
 }
 
 hr {

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -4,7 +4,7 @@
 
 ### README Template
 
-```
+```md
 # Board Name
 
 ![Image of Board](assets/board-image.jpeg)
@@ -54,7 +54,7 @@ Hardware Availability: List where one can purchase the boards that share this co
 
 ### Add-On Template
 
-```
+```md
 ## Add-On Name
 
 Purpose: The intended function and purpose of this add-on for an end user.

--- a/docs/web-configurator.md
+++ b/docs/web-configurator.md
@@ -16,7 +16,7 @@ The options in the main menu are:
 * [Settings](#settings) - Adjust settings like input mode, d-pad mode, etc.
 * [Configuration > Pin Mapping](#pin-mapping) - Allows for remapping of GPIO pins to different buttons.
 * [Configuration > Keyboard Mapping](#keyboard-mapping) - Allows for remapping of keyboard keys to different controller inputs.
-* * [Configuration > Profile Settings](#profile-settings) - Allows for remapping of GPIO pins to different buttons.
+* [Configuration > Profile Settings](#profile-settings) - Allows for remapping of GPIO pins to different buttons.
 * [Configuration > LED Configuration](#led-configuration) - Enable and configure RGB LEDs here.
 * [Configuration > Display Configuration](#display-configuration) - Enable and configure display options.
 * [Configuration > Add-Ons Configuration](#add-ons-configuration) - Enable and configure available add-ons.
@@ -37,7 +37,6 @@ Here you can select the basic settings which are normally available via hotkeys.
 * `4-Way Joystick Mode` - Enables 4-Way Jostick mode which will prevent cardinal directions.
 
 Please note that if you choose `PS4` mode you will have an additional option to set the device as a `Controller` or a `Fightstick`.  If you choose `Fightstick` and want to use this device with compatible PS5 games you will need to enable the `PS Passthrough` add-on and have a way to connect the device you with to use for passthrough authentication to the RP2040-CE based device via a USB passthrough port.  
-
 
 ### Hotkey Settings
 
@@ -163,7 +162,7 @@ This section is for custom add-ons that can be enabled to expand the functionali
 
 ![GP2040-CE Configurator - Reset Settings](assets/images/gpc-reset-settings.png)
 
-# Linux Setup
+## Linux Setup
 
 When you plug in your controller while holding <hotkey v-bind:buttons='["S2"]'></hotkey>, you should see it connect in the kernel logs if you run `dmesg`:
 


### PR DESCRIPTION
 * Add `md` tag to code blocks containing markdown
 * Remove unnecessary whitespace
 * Fix a typo in a list
 * Convert "Linux Setup" to an h2, as there should only be one h1