### PR TITLE
run 4-way filtering before SOCD cleaning

### DIFF
--- a/src/addons/dualdirectional.cpp
+++ b/src/addons/dualdirectional.cpp
@@ -65,6 +65,7 @@ void DualDirectionalInput::debounce()
 
 void DualDirectionalInput::preprocess()
 {
+    const DualDirectionalOptions& options = Storage::getInstance().getAddonOptions().dualDirectionalOptions;
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
 
  	// Need to invert since we're using pullups
@@ -88,6 +89,11 @@ void DualDirectionalInput::preprocess()
     // Convert gamepad from process() output to uint8 value
     uint8_t gamepadState = gamepad->state.dpad;
     const SOCDMode socdMode = getSOCDMode(gamepad->getOptions());
+
+    // 4-way before SOCD, might have better history without losing any coherent functionality
+    if (options.fourWayMode) {
+        dualState = filterToFourWayMode(dualState);
+    }
 
     // Combined Mode
     if ( combineMode == DUAL_COMBINE_MODE_MIXED ) {
@@ -126,11 +132,6 @@ void DualDirectionalInput::process()
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
     uint8_t dualOut = dualState;
     const SOCDMode socdMode = getSOCDMode(gamepad->getOptions());
-
-    // SOCD cleaning already happened, allows for control over which diagonal to take/filter
-    if (options.fourWayMode) {
-        dualOut = filterToFourWayMode(dualOut);
-    }
 
     // If we're in mixed mode
     if (combineMode == DUAL_COMBINE_MODE_MIXED) {

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -201,12 +201,12 @@ void Gamepad::process()
 			state.dpad |= mapDpadUp->buttonMask;
 	}
 
-	state.dpad = runSOCDCleaner(resolveSOCDMode(options), state.dpad);
-
-	// SOCD cleaning first, allows for control over which diagonal to take/filter
+	// 4-way before SOCD, might have better history without losing any coherent functionality
 	if (options.fourWayMode) {
 		state.dpad = filterToFourWayMode(state.dpad);
 	}
+
+	state.dpad = runSOCDCleaner(resolveSOCDMode(options), state.dpad);
 
 	switch (options.dpadMode)
 	{


### PR DESCRIPTION
This addresses Example 1 of #532 without any immediately obvious detriment to the 4-way/SOCD interaction, other than it has an order of operations problem (L > D > R = nothing, but R > D > L = L).

However, #533 fixes that issue by implementing filtering better, and it fixes Example 2 of #532.

@TheTrainGoes is going to do more testing, but in my testing, these two PRs together fix #532.