### PR TITLE
Fix error display string template in Ps4.tsx. Add missing Web API import.

### DIFF
--- a/www/src/Addons/Ps4.tsx
+++ b/www/src/Addons/Ps4.tsx
@@ -5,6 +5,7 @@ import * as yup from 'yup';
 import JSEncrypt from 'jsencrypt';
 import CryptoJS from 'crypto-js';
 import isNil from 'lodash/isNil';
+import WebApi from '../Services/WebApi';
 
 import Section from '../Components/Section';
 
@@ -120,7 +121,7 @@ const verifyAndSavePS4 = async () => {
 		}
 	} catch (e) {
 		document.getElementById('ps4alert').textContent =
-			'ERROR: Could not verify required files: ${e}';
+			`ERROR: Could not verify required files: ${e}`;
 	}
 };
 


### PR DESCRIPTION
I wasn't able to get the PS4 Mode addon to work, it just showed the following error at me after clicking Verify and Save:  'ERROR: Could not verify required files: ${e}'

Turns out that was a string literal instead of a template. Replacing the ' with ` in Ps4.tsx made it a template and enabled printing the actual error.

The actual error was that WebAPI wasn't found. I added the missing import and it started working.