### PR TITLE
web settings  : show button label according to current button  lable type

### DIFF
--- a/www/src/Data/Buttons.js
+++ b/www/src/Data/Buttons.js
@@ -135,6 +135,7 @@ export const BUTTONS = {
 		R3: 'R3',
 		A1: 'PS',
 		A2: 'Touchpad',
+		Fn: 'Function',
 	},
 	dinput: {
 		label: 'DirectInput',

--- a/www/src/Data/Buttons.js
+++ b/www/src/Data/Buttons.js
@@ -232,3 +232,20 @@ export const BUTTON_MASKS = [
 ];
 
 export const ANALOG_PINS = [26, 27, 28, 29];
+
+// deep copy and swp
+export const getButtonLabels = (labelType, swapTpShareLabels = false)=> {
+	const buttons = BUTTONS[labelType];
+
+	if (labelType == 'ps4' && swapTpShareLabels) {
+		const buttonLabelS1 = buttons['S1'];
+		const buttonLabelA2 = buttons['A2'];
+		return {
+			...buttons,
+			"S1": buttonLabelA2,
+			"A2": buttonLabelS1,
+		}
+	} else {
+		return buttons
+	}
+}

--- a/www/src/Pages/LEDConfigPage.jsx
+++ b/www/src/Pages/LEDConfigPage.jsx
@@ -14,7 +14,7 @@ import Section from '../Components/Section';
 import DraggableListGroup from '../Components/DraggableListGroup';
 import FormControl from '../Components/FormControl';
 import FormSelect from '../Components/FormSelect';
-import { BUTTONS } from '../Data/Buttons';
+import { getButtonLabels } from '../Data/Buttons';
 import LEDColors from '../Data/LEDColors';
 import { hexToInt } from '../Services/Utilities';
 import WebApi from '../Services/WebApi';
@@ -137,19 +137,13 @@ const schema = yup.object().shape({
 });
 
 const getLedButtons = (buttonLabels, map, excludeNulls, swapTpShareLabels) => {
+	const current_buttons = getButtonLabels(buttonLabels, swapTpShareLabels);
 	return orderBy(
-		Object.keys(BUTTONS[buttonLabels])
+		Object.keys(current_buttons)
 			.filter((p) => p !== 'label' && p !== 'value')
 			.filter((p) => (excludeNulls ? map[p] > -1 : true))
 			.map((p) => {
-				let label = BUTTONS[buttonLabels][p];
-				if (p === 'S1' && swapTpShareLabels && buttonLabels === 'ps4') {
-					label = BUTTONS[buttonLabels]['A2'];
-				}
-				if (p === 'A2' && swapTpShareLabels && buttonLabels === 'ps4') {
-					label = BUTTONS[buttonLabels]['S1'];
-				}
-				return { id: p, label: BUTTONS[buttonLabels][p], value: map[p] };
+				return { id: p, label: current_buttons[p], value: map[p] };
 			}),
 		'value',
 	);
@@ -158,7 +152,8 @@ const getLedButtons = (buttonLabels, map, excludeNulls, swapTpShareLabels) => {
 const getLedMap = (buttonLabels, ledButtons, excludeNulls) => {
 	if (!ledButtons) return;
 
-	const map = Object.keys(BUTTONS[buttonLabels])
+	const buttons = getButtonLabels(buttonLabels, false);
+	const map = Object.keys(buttons)
 		.filter((p) => p !== 'label' && p !== 'value')
 		.filter((p) => (excludeNulls ? ledButtons[p].value > -1 : true))
 		.reduce((p, n) => {

--- a/www/src/Pages/PinMapping.jsx
+++ b/www/src/Pages/PinMapping.jsx
@@ -6,7 +6,7 @@ import Section from '../Components/Section';
 import CaptureButton from '../Components/CaptureButton';
 import WebApi, { baseButtonMappings } from '../Services/WebApi';
 import boards from '../Data/Boards.json';
-import { BUTTONS } from '../Data/Buttons';
+import { getButtonLabels} from '../Data/Buttons';
 import './PinMappings.scss';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -30,8 +30,9 @@ export default function PinMappingPage() {
 	const [isCapturingPinsInProgress, setIsCapturingPinsInProgress] = useState(false);
 	const controller = useRef();
 	const { buttonLabelType, swapTpShareLabels } = buttonLabels;
+	const CURRENT_BUTTONS = getButtonLabels(buttonLabelType, swapTpShareLabels)
 	const { setLoading } = useContext(AppContext);
-	const buttonNames = Object.keys(BUTTONS[buttonLabelType])?.filter((p) => p !== 'label' && p !== 'value');
+	const buttonNames = Object.keys(CURRENT_BUTTONS)?.filter((p) => p !== 'label' && p !== 'value');
 
 	const { t } = useTranslation('');
 
@@ -135,7 +136,7 @@ export default function PinMappingPage() {
 			return (
 				<span key="required" className="error-message">
 					{t('PinMapping:errors.required', {
-						button: BUTTONS[buttonLabelType][button],
+						button: CURRENT_BUTTONS[button],
 					})}
 				</span>
 			);
@@ -143,7 +144,7 @@ export default function PinMappingPage() {
 			const conflictedMappings = Object.keys(buttonMappings)
 				.filter((b) => b !== button)
 				.filter((b) => buttonMappings[b].pin === buttonMappings[button].pin)
-				.map((b) => BUTTONS[buttonLabelType][b]);
+				.map((b) => CURRENT_BUTTONS[b]);
 
 			return (
 				<span key="conflict" className="error-message">
@@ -223,28 +224,14 @@ export default function PinMappingPage() {
 					<thead className="table">
 						<tr>
 							<th className="table-header-button-label">
-								{BUTTONS[buttonLabelType].label}
+								{CURRENT_BUTTONS.label}
 							</th>
 							<th>{t('PinMapping:pin-header-label')}</th>
 						</tr>
 					</thead>
 					<tbody>
 						{buttonNames.map((button, i) => {
-								let label = BUTTONS[buttonLabelType][button];
-								if (
-									button === 'S1' &&
-									swapTpShareLabels &&
-									buttonLabelType === 'ps4'
-								) {
-									label = BUTTONS[buttonLabelType]['A2'];
-								}
-								if (
-									button === 'A2' &&
-									swapTpShareLabels &&
-									buttonLabelType === 'ps4'
-								) {
-									label = BUTTONS[buttonLabelType]['S1'];
-								}
+								let label = CURRENT_BUTTONS[button];
 								return (
 									<tr
 										key={`button-map-${i}`}

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -8,7 +8,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import Section from '../Components/Section';
 import WebApi from '../Services/WebApi';
-import { BUTTONS, BUTTON_MASKS } from '../Data/Buttons';
+import { BUTTON_MASKS, getButtonLabels} from '../Data/Buttons';
 
 const PS4Mode = 4;
 const INPUT_MODES = [
@@ -222,12 +222,7 @@ export default function SettingsPage() {
 
 	const { buttonLabelType, swapTpShareLabels } = buttonLabels;
 
-	const buttonLabelS1 =
-		BUTTONS[buttonLabelType][
-			swapTpShareLabels && buttonLabelType === 'ps4' ? 'A2' : 'S1'
-		];
-	const buttonLabelS2 = BUTTONS[buttonLabelType]['S2'];
-	const buttonLabelA1 = BUTTONS[buttonLabelType]['A1'];
+	const currentButtonLabels= getButtonLabels(buttonLabelType, swapTpShareLabels);
 
 	const { t } = useTranslation('');
 
@@ -507,7 +502,7 @@ export default function SettingsPage() {
 																		key={`hotkey-${i}-button${i2}`}
 																		value={o.value}
 																	>
-																		{ (o.label in BUTTONS[buttonLabelType])? BUTTONS[buttonLabelType][o.label]:o.label}
+																		{ (o.label in currentButtonLabels)? currentButtonLabels[o.label]:o.label}
 																	</option>
 																))}
 															</Form.Select>
@@ -537,7 +532,7 @@ export default function SettingsPage() {
 															key={`hotkey-${i}-buttonZero-${i2}`}
 															value={o.value}
 														>
-														{ (o.label in BUTTONS[buttonLabelType])? BUTTONS[buttonLabelType][o.label]:o.label}
+														{ (o.label in currentButtonLabels)? currentButtonLabels[o.label]:o.label}
 														</option>
 													))}
 												</Form.Select>

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -537,7 +537,7 @@ export default function SettingsPage() {
 															key={`hotkey-${i}-buttonZero-${i2}`}
 															value={o.value}
 														>
-															{o.label}
+														{ (o.label in BUTTONS[buttonLabelType])? BUTTONS[buttonLabelType][o.label]:o.label}
 														</option>
 													))}
 												</Form.Select>

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -507,7 +507,7 @@ export default function SettingsPage() {
 																		key={`hotkey-${i}-button${i2}`}
 																		value={o.value}
 																	>
-																		{o.label}
+																		{ (o.label in BUTTONS[buttonLabelType])? BUTTONS[buttonLabelType][o.label]:o.label}
 																	</option>
 																))}
 															</Form.Select>


### PR DESCRIPTION
while setup fn hotkeys on page Settings  ,  i found it hard to setup hotkeys,  cause not familiar with gp2040 button label names

here minor changes in  jsx to  show button label   by   current  button label type ( ps4 , gp2040,  etc..)type

before

![图片](https://github.com/OpenStickCommunity/GP2040-CE/assets/352727/17963612-0af9-4aad-a776-f7a8750d4a05)

after 

![图片](https://github.com/OpenStickCommunity/GP2040-CE/assets/352727/b031d1c7-a9b7-4d47-92a9-e7503916d338)


change 1:  setting page,  hotkeys  show  buttons  by  current button label type
change 2:  configuration>>pin mapping page,  show function pin input   in pin page , for button label type is ps4
