### PR TITLE
Moving report counter back into PS4 with proper 6-bit roll-over

### DIFF
--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -606,6 +606,10 @@ PS4Report *Gamepad::getPS4Report()
 	ps4Report.button_home     = pressedA1();
 	ps4Report.button_touchpad = options.switchTpShareForDs4 ? pressedS1() : pressedA2();
 
+	// report counter is 6 bits
+	last_report_counter = (last_report_counter+1) & 63;
+	ps4Report.report_counter = last_report_counter;
+
 	ps4Report.left_stick_x = static_cast<uint8_t>(state.lx >> 8);
 	ps4Report.left_stick_y = static_cast<uint8_t>(state.ly >> 8);
 	ps4Report.right_stick_x = static_cast<uint8_t>(state.rx >> 8);


### PR DESCRIPTION
There's been observable drops in inputs when report counter is missing in the PS4 reporting structure.

Playing "Ultimate Chicken Horse" on PS5, it is observed that rapid inputs will eventually cause the gamepad to lock when report counter is missing.

Still confirming adding report counter back in fixes the issue, but it appears it is important somewhere in the gamepad stack on the PS4/PS5.