### PR TITLE
Change target button for DirectInput/PS3 Mode in documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,7 +56,7 @@ GP2040-CE is compatible with a number of systems and input modes. To change the 
 |:----------------|:-----------------------------------------:|
 | Nintendo Switch | <hotkey v-bind:buttons='["B1"]'></hotkey> |
 | XInput          | <hotkey v-bind:buttons='["B2"]'></hotkey> |
-| DirectInput/PS3 | <hotkey v-bind:buttons='["B2"]'></hotkey> |
+| DirectInput/PS3 | <hotkey v-bind:buttons='["B3"]'></hotkey> |
 | PS4             | <hotkey v-bind:buttons='["B4"]'></hotkey> |
 | Keyboard        | <hotkey v-bind:buttons='["R2"]'></hotkey> |
 


### PR DESCRIPTION
Currently both Xinput and DirectInput/PS3 Modes are labeled in usage.md as being invoked by B2. This is to change the DirectInput/PS3 button to be B3.