### PR TITLE
Update analog trigger mode to include digital state

### DIFF
--- a/headers/addons/wiiext.h
+++ b/headers/addons/wiiext.h
@@ -297,6 +297,8 @@ private:
     bool dpadLeft   = false;
     bool dpadRight  = false;
 
+    bool isAnalogTriggers = false;
+
     uint16_t triggerLeft  = 0;
     uint16_t triggerRight = 0;
     uint16_t lastTriggerLeft  = 0;

--- a/src/addons/keyboard_host.cpp
+++ b/src/addons/keyboard_host.cpp
@@ -69,8 +69,10 @@ void KeyboardHostAddon::preprocess() {
   gamepad->state.ly       |= _keyboard_host_state.ly;
   gamepad->state.rx       |= _keyboard_host_state.rx;
   gamepad->state.ry       |= _keyboard_host_state.ry;
-  gamepad->state.lt       |= _keyboard_host_state.lt;
-  gamepad->state.rt       |= _keyboard_host_state.rt;
+  if (!gamepad->hasAnalogTriggers) {
+    gamepad->state.lt       |= _keyboard_host_state.lt;
+    gamepad->state.rt       |= _keyboard_host_state.rt;
+  }
 }
 
 void KeyboardHostAddon::mount(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len) {

--- a/src/addons/wiiext.cpp
+++ b/src/addons/wiiext.cpp
@@ -105,6 +105,8 @@ void WiiExtensionInput::update() {
         //    WII_SET_MASK(buttonState, wii->getController()->buttons[extensionButton], value);
         //}
 
+        isAnalogTriggers = false;
+
         if (wii->extensionType == WII_EXTENSION_NUNCHUCK) {
             buttonZ = wii->getController()->buttons[WiiButtons::WII_BUTTON_Z];
             buttonC = wii->getController()->buttons[WiiButtons::WII_BUTTON_C];
@@ -136,6 +138,7 @@ void WiiExtensionInput::update() {
             if (wii->extensionType == WII_EXTENSION_CLASSIC) {
                 triggerLeft  = wii->getController()->analogState[WiiAnalogs::WII_ANALOG_LEFT_TRIGGER];
                 triggerRight = wii->getController()->analogState[WiiAnalogs::WII_ANALOG_RIGHT_TRIGGER];
+                isAnalogTriggers = true;
             }
 
             leftX = map(wii->getController()->analogState[WiiAnalogs::WII_ANALOG_LEFT_X],0,WII_ANALOG_PRECISION_3,GAMEPAD_JOYSTICK_MIN,GAMEPAD_JOYSTICK_MAX);
@@ -211,6 +214,8 @@ void WiiExtensionInput::update() {
 
             triggerLeft  = wii->getController()->analogState[TurntableAnalogs::TURNTABLE_EFFECTS];
             triggerRight = wii->getController()->analogState[TurntableAnalogs::TURNTABLE_CROSSFADE];
+
+            isAnalogTriggers = true;
         }
     } else {
         currentConfig = NULL;
@@ -330,7 +335,7 @@ void WiiExtensionInput::queueAnalogChange(uint16_t analogInput, uint16_t analogV
 
 void WiiExtensionInput::updateAnalogState() {
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
-    gamepad->hasAnalogTriggers = true;
+    gamepad->hasAnalogTriggers = isAnalogTriggers;
 
     uint16_t axisType;
     uint16_t analogInput;
@@ -362,6 +367,8 @@ void WiiExtensionInput::updateAnalogState() {
 
             axisToChange = WII_ANALOG_TYPE_NONE;
             adjustedValue = 0;
+
+            if (!isAnalogTriggers && ((analogInput == WiiAnalogs::WII_ANALOG_LEFT_TRIGGER) || (analogInput == WiiAnalogs::WII_ANALOG_RIGHT_TRIGGER))) continue;
 
             // define ranges
             switch (analogInput) {

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -617,8 +617,8 @@ PS4Report *Gamepad::getPS4Report()
 
 	if (hasAnalogTriggers)
 	{
-		ps4Report.left_trigger = pressedL2() ? 0xFF : state.lt;
-		ps4Report.right_trigger = pressedR2() ? 0xFF : state.rt;
+		ps4Report.left_trigger = state.lt;
+		ps4Report.right_trigger = state.rt;
 	}
 	else
 	{

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -563,8 +563,8 @@ XInputReport *Gamepad::getXInputReport()
 
 	if (hasAnalogTriggers)
 	{
-		xinputReport.lt = state.lt;
-		xinputReport.rt = state.rt;
+		xinputReport.lt = pressedL2() ? 0xFF : state.lt;
+		xinputReport.rt = pressedR2() ? 0xFF : state.rt;
 	}
 	else
 	{
@@ -617,8 +617,8 @@ PS4Report *Gamepad::getPS4Report()
 
 	if (hasAnalogTriggers)
 	{
-		ps4Report.left_trigger = state.lt;
-		ps4Report.right_trigger = state.rt;
+		ps4Report.left_trigger = pressedL2() ? 0xFF : state.lt;
+		ps4Report.right_trigger = pressedR2() ? 0xFF : state.rt;
 	}
 	else
 	{

--- a/www/src/Addons/Wii.tsx
+++ b/www/src/Addons/Wii.tsx
@@ -103,7 +103,8 @@ const Wii = ({ values, errors, handleChange, handleCheckbox }) => {
         .reduce(
             (o, i) => {
                 let modeID = i.value;
-                let joyMode = getJoystickMode(modeID);
+                let axes = i.getAttribute('axiscount') || 2;
+                let joyMode = (axes == 2 ? getJoystickMode(modeID) : null);
                 if (joyMode && joyMode.options) {
                     let r = o;
                     Object.keys(joyMode.options).forEach(key => {
@@ -130,10 +131,10 @@ const Wii = ({ values, errors, handleChange, handleCheckbox }) => {
 
     const getJoystickMode = (searchValue: number) => WII_JOYSTICK_MODES.find(({ value }) => parseInt(value) === parseInt(searchValue));
 
-    const setWiiAnalogEntry = (controlID,analogID,e) => {
+    const setWiiAnalogEntry = (controlID,analogID,axes,e) => {
         let analogEntry = {};
         let modeID = e.target.value;
-        let joyMode = getJoystickMode(modeID);
+        let joyMode = (axes == 2 ? getJoystickMode(modeID) : null);
         if (joyMode && joyMode.options) {
             let r = analogEntry;
             Object.keys(joyMode.options).forEach(key => {
@@ -280,7 +281,7 @@ const Wii = ({ values, errors, handleChange, handleCheckbox }) => {
                                                 <div className="col-sm-12 col-md-6 col-lg-2 mb-2">
                                                     {analogObj.axes?.length == 1 &&
                                                     <div className="row">
-                                                        <select className="form-select-sm form-control wii-analogs" controlid={`${controlObj.id.toLowerCase()}`} analogid={`${analogObj.id}`} axisid={`${analogObj.axes[0].axis}`} id={`wiiExtensionController${controlObj.id}Analog${analogObj.id}`} value={wiiControls[controlObj.id.toLowerCase()+'.analog'+analogObj.id+'.axisType']} onChange={(e) => setWiiAnalogEntry(controlObj.id, analogObj.id, e)}>
+                                                        <select className="form-select-sm form-control wii-analogs" controlid={`${controlObj.id.toLowerCase()}`} analogid={`${analogObj.id}`} axisid={`${analogObj.axes[0].axis}`} axiscount={analogObj.axes?.length} id={`wiiExtensionController${controlObj.id}Analog${analogObj.id}`} value={wiiControls[controlObj.id.toLowerCase()+'.analog'+analogObj.id+'.axisType']} onChange={(e) => setWiiAnalogEntry(controlObj.id, analogObj.id, analogObj.axes?.length, e)}>
                                                             {ANALOG_SINGLE_AXIS_MODES.map((o,i) => (
                                                                 <option key={`wiiSingleAxisMode${controlObj.id}${analogID}${i}`} value={o.value}>{o.label}</option>
                                                             ))}
@@ -289,7 +290,7 @@ const Wii = ({ values, errors, handleChange, handleCheckbox }) => {
                                                     }
                                                     {analogObj.axes?.length == 2 &&
                                                     <div className="row">
-                                                        <select className="form-select-sm form-control wii-analogs" controlid={`${controlObj.id.toLowerCase()}`} analogid={`${analogObj.id}`} axisid={`${analogObj.axes[0].axis}`} id={`wiiExtensionController${controlObj.id}Analog${analogObj.id}`} value={getJoystickModeValue(controlObj, analogObj)} onChange={(e) => setWiiAnalogEntry(controlObj.id, analogObj.id, e)}>
+                                                        <select className="form-select-sm form-control wii-analogs" controlid={`${controlObj.id.toLowerCase()}`} analogid={`${analogObj.id}`} axisid={`${analogObj.axes[0].axis}`} axiscount={analogObj.axes?.length} id={`wiiExtensionController${controlObj.id}Analog${analogObj.id}`} value={getJoystickModeValue(controlObj, analogObj)} onChange={(e) => setWiiAnalogEntry(controlObj.id, analogObj.id, analogObj.axes?.length, e)}>
                                                             {WII_JOYSTICK_MODES.map((o,i) => (
                                                                 <option key={`wiiJoystickMode${controlObj.id}${analogID}${i}`} value={o.value}>{o.label}</option>
                                                             ))}


### PR DESCRIPTION
Allow digital input state and analog value state to co-exist for triggers when Gamepad.hasAnalogTriggers is true.
Added analog trigger check for keyboard host to avoid potential issues.