### PR TITLE
Fix default On-Board LED enable issue

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -226,6 +226,7 @@
 //                  on the current mode (config, normal, or no USB data)
 // INPUT_TEST     - Blinks whenever any input is made
 
+#define BOARD_LED_ENABLED 0
 #define BOARD_LED_TYPE ON_BOARD_LED_MODE_OFF
 
 // Dual Directional Add-on Options

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -358,6 +358,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.addonOptions.bootselButtonOptions, buttonMap, BOOTSEL_BUTTON_MASK);
 
     // addonOptions.onBoardLedOptions
+    INIT_UNSET_PROPERTY(config.addonOptions.onBoardLedOptions, enabled, !!BOARD_LED_ENABLED);
     INIT_UNSET_PROPERTY(config.addonOptions.onBoardLedOptions, mode, BOARD_LED_TYPE);
 
     // addonOptions.analogOptions


### PR DESCRIPTION
This adds a missing initialization entry for enabling the On-Board LED addon via the `BoardConfig.h`.

Please review and merge, thanks!