### PR TITLE
Tilt state refactor and analog mid adjustments

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -241,14 +241,14 @@
 // TILTAdd-on Options
 #define PIN_TILT_1 -1
 #define TILT1_FACTOR_LEFT_X  35  //Default value for the TILT button to function.
-#define TILT1_FACTOR_LEFT_Y  45  //Default value for the TILT button to function.
+#define TILT1_FACTOR_LEFT_Y 35 //Default value for the TILT button to function.
 #define TILT1_FACTOR_RIGHT_X 35  //Default value for the TILT button to function.
-#define TILT1_FACTOR_RIGHT_Y 170 //Default value for the TILT button to function.
+#define TILT1_FACTOR_RIGHT_Y 35 //Default value for the TILT button to function.
 #define PIN_TILT_2 -1
 #define TILT2_FACTOR_LEFT_X  65  //Default value for the TILT button to function.
-#define TILT2_FACTOR_LEFT_Y  35  //Default value for the TILT button to function.
-#define TILT2_FACTOR_RIGHT_X 30  //Default value for the TILT button to function.
-#define TILT2_FACTOR_RIGHT_Y 30  //Default value for the TILT button to function.
+#define TILT2_FACTOR_LEFT_Y  65  //Default value for the TILT button to function.
+#define TILT2_FACTOR_RIGHT_X 65  //Default value for the TILT button to function.
+#define TILT2_FACTOR_RIGHT_Y 65  //Default value for the TILT button to function.
 #define PIN_TILT_FUNCTION -1
 #define PIN_TILT_LEFT_ANALOG_UP -1
 #define PIN_TILT_LEFT_ANALOG_DOWN -1

--- a/docs/add-ons/tilt-input.md
+++ b/docs/add-ons/tilt-input.md
@@ -1,9 +1,19 @@
 # Tilt Input
 
+Purpose: The Tilt Input add-on allows users to send analog inputs from the Left and Right analog sticks that are some percent of the maximum directional input (e.g. send 65% of a Down-Right input on the Right analog stick).
+
 ![GP2040-CE Configuration - Add-Ons Tilt Input](../assets/images/gpc-add-ons-tilt.png)
 
 * `Tilt 1 Pin` - The GPIO pin used for the Tilt 1 direction.
+* `Tilt 1 Factor Left X` - The percentage of the X-axis input for the Left analog stick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
+* `Tilt 1 Factor Left Y` - The percentage of the Y-axis input for the Left analog stick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
+* `Tilt 1 Factor Left X` - The percentage of the X-axis input for the Right analog stick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
+* `Tilt 1 Factor Left Y` - The percentage of the Y-axis input for the Right analog stick sent when `Tilt 1 Pin` is activated. (Min. 0, Max 100)
 * `Tilt 2 Pin` - The GPIO pin used for the Tilt 2 direction.
+* `Tilt 2 Factor Left X` - The percentage of the X-axis input for the Left analog stick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
+* `Tilt 2 Factor Left Y` - The percentage of the Y-axis input for the Left analog stick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
+* `Tilt 2 Factor Left X` - The percentage of the X-axis input for the Right analog stick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
+* `Tilt 2 Factor Left Y` - The percentage of the Y-axis input for the Right analog stick sent when `Tilt 2 Pin` is activated. (Min. 0, Max 100)
 * `Tilt Left Analog Up Pin` - The GPIO pin used for the Up direction on the Left analog stick.
 * `Tilt Left Analog Down Pin` - The GPIO pin used for the Down direction on the Left analog stick.
 * `Tilt Left Analog Left Pin` - The GPIO pin used for the Left direction on the Left analog stick.
@@ -14,12 +24,13 @@
 * `Tilt Right Analog Right Pin` - The GPIO pin used for the Right direction on the Right analog stick.
 * `Tilt SOCD Mode` - Choose the default SOCD Cleaning Mode (Neutral, Last Win, First Win). 
 
-The Tilt feature in this add-on allows users to control analog stick values on both Left and Right Analogs.
+Hardware Requirements:
 
-Tilt 1 and Tilt 2 buttons, when pressed with directional buttons, adjust the analog values.
+- Additional buttons, switches, or joysticks, are recommended for this add-on as this add-on entirely prevents the primary Dpad from being set as the Left analog or Right analog stick. 
 
-Default settings tilt the Left stick at 65% for Tilt 1 and 35% for Tilt 2.
+Notes
 
-The Right stick shifts down for Tilt 1 and up for Tilt 2 by default.
-
-Additionally, pressing Tilt 1 and Tilt 2 simultaneously allows the Right stick to function as the D-Pad directions.
+- Because this add-on disables the Dpad from being set as Left analog and Right analog, using the hotkeys `Dpad Left Analog` and `Dpad Right Analog` deactivates the Dpad and using the `Dpad Digital` will reactivate the Dpad once more.
+- Not all Tilt analog pins are required to be set, but not setting the pins will prevent you from using that input without using the Web Configurator to remap the inputs.
+- Additionally, pressing Tilt 1 and Tilt 2 simultaneously while inputting Right analog stick directions allows the Right analog stick to function as the D-Pad directions.
+- Pressing Tilt 1 and Tilt 2 simultaneously while inputting Left analog stick will prioritize Tilt 1 and ignore Tilt 2.

--- a/headers/addons/tilt.h
+++ b/headers/addons/tilt.h
@@ -14,19 +14,19 @@
 #endif
 
 #ifndef TILT1_FACTOR_LEFT_X
-#define TILT1_FACTOR_LEFT_X -1
+#define TILT1_FACTOR_LEFT_X 35
 #endif
 
 #ifndef TILT1_FACTOR_LEFT_Y
-#define TILT1_FACTOR_LEFT_Y -1
+#define TILT1_FACTOR_LEFT_Y 35
 #endif
 
 #ifndef TILT1_FACTOR_RIGHT_X
-#define TILT1_FACTOR_RIGHT_X -1
+#define TILT1_FACTOR_RIGHT_X 35
 #endif
 
 #ifndef TILT1_FACTOR_RIGHT_Y
-#define TILT1_FACTOR_RIGHT_Y -1
+#define TILT1_FACTOR_RIGHT_Y 35
 #endif
 
 #ifndef PIN_TILT_2
@@ -34,21 +34,20 @@
 #endif
 
 #ifndef TILT2_FACTOR_LEFT_X
-#define TILT2_FACTOR_LEFT_X -1
+#define TILT2_FACTOR_LEFT_X 65
 #endif
 
 #ifndef TILT2_FACTOR_LEFT_Y
-#define TILT2_FACTOR_LEFT_Y -1
+#define TILT2_FACTOR_LEFT_Y 65
 #endif
 
 #ifndef TILT2_FACTOR_RIGHT_X
-#define TILT2_FACTOR_RIGHT_X -1
+#define TILT2_FACTOR_RIGHT_X 65
 #endif
 
 #ifndef TILT2_FACTOR_RIGHT_Y
-#define TILT2_FACTOR_RIGHT_Y -1
+#define TILT2_FACTOR_RIGHT_Y 65
 #endif
-
 
 #ifndef PIN_TILT_LEFT_ANALOG_UP
 #define PIN_TILT_LEFT_ANALOG_UP -1
@@ -105,11 +104,13 @@ private:
 	uint8_t dDebLeftState;          // Debounce State (stored)
 	uint8_t dDebRightState;          // Debounce State (stored)
 	uint8_t tiltLeftState;          // Tilt State
-	uint8_t tiltRightState;          // Tilt Righjt Analog State
+	uint8_t tiltRightState;          // Tilt Right Analog State
 	DpadDirection lastGPUD; // Gamepad Last Up-Down
 	DpadDirection lastGPLR; // Gamepad Last Left-Right
-	DpadDirection lastTiltUD; // Tilt Last Up-Down
-	DpadDirection lastTiltLR; // Gamepad Last Left-Right
+	DpadDirection leftLastTiltUD; // Tilt Last Up-Down
+	DpadDirection leftLastTiltLR; // Gamepad Last Left-Right
+	DpadDirection rightLastTiltUD; // Tilt Last Up-Down
+	DpadDirection rightLastTiltLR; // Gamepad Last Left-Right
 	uint32_t dpadTime[4];
 	uint8_t pinTilt1;
 	uint8_t tilt1FactorLeftX;

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -190,39 +190,14 @@ void TiltInput::OverrideGamepad(Gamepad* gamepad, uint8_t dpad1, uint8_t dpad2) 
 
             gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogX(dpad2, input_mode)) * scaledTilt2FactorRightX;
             gamepad->state.ry = dpadToAnalogY(dpad2, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogY(dpad2, input_mode)) * scaledTilt2FactorRightY;
+        } else {
+            gamepad->state.lx = dpadToAnalogX(dpad1, input_mode);
+            gamepad->state.ly = dpadToAnalogY(dpad1, input_mode);
+
+            gamepad->state.rx = dpadToAnalogX(dpad2, input_mode);
+            gamepad->state.ry = dpadToAnalogY(dpad2, input_mode);
         }
     }
-
-/*
-	if (pinTilt1Pressed) {
-        gamepad->state.lx = dpadToAnalogX(dpad1, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad1, input_mode)) * scaledTilt1FactorLeftX;
-        gamepad->state.ly = dpadToAnalogY(dpad1, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogY(dpad1, input_mode)) * scaledTilt1FactorLeftY;
-    }
-    else if (pinTilt2Pressed) {
-        gamepad->state.lx = dpadToAnalogX(dpad1, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad1, input_mode)) * scaledTilt2FactorLeftX;
-        gamepad->state.ly = dpadToAnalogY(dpad1, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogY(dpad1, input_mode)) * scaledTilt2FactorLeftY;
-    }
-	else {
-		gamepad->state.lx = dpadToAnalogX(dpad1, input_mode);
-		gamepad->state.ly = dpadToAnalogY(dpad1, input_mode);
-	}
-
-	if (pinTilt1Pressed && pinTilt2Pressed) {
-		gamepad->state.dpad = dpad2; //Hold tilt1 + tilt2 turn on D-Pad
-	}
-	else if (pinTilt1Pressed) {
-		gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad2, input_mode)) * scaledTilt1FactorRightX;
-        gamepad->state.ry = dpadToAnalogY(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogY(dpad2, input_mode)) * scaledTilt1FactorRightY;
-	}
-	else if (pinTilt2Pressed) {
-        gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad2, input_mode)) * scaledTilt2FactorRightX;
-        gamepad->state.ry = dpadToAnalogY(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogY(dpad2, input_mode)) * scaledTilt2FactorRightY;
-	}
-	else {
-		gamepad->state.rx = dpadToAnalogX(dpad2, input_mode);
-		gamepad->state.ry = dpadToAnalogY(dpad2, input_mode);
-	}
-*/
 }
 
 

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -61,8 +61,11 @@ void TiltInput::setup() {
 	lastGPUD = DIRECTION_NONE;
 	lastGPLR = DIRECTION_NONE;
 
-	lastTiltUD = DIRECTION_NONE;
-	lastTiltLR = DIRECTION_NONE;
+	leftLastTiltUD = DIRECTION_NONE;
+	leftLastTiltLR = DIRECTION_NONE;
+
+	rightLastTiltUD = DIRECTION_NONE;
+	rightLastTiltLR = DIRECTION_NONE;
 
 	uint32_t now = getMillis();
 	for (int i = 0; i < 4; i++) {
@@ -143,11 +146,9 @@ void TiltInput::process()
 	SOCDTiltClean(tiltSOCDMode);
 
 	Gamepad* gamepad = Storage::getInstance().GetGamepad();
-	uint8_t tiltLeftOut = tiltLeftState;
-	uint8_t tiltRightOut = tiltRightState;
 
 	// Set Tilt Output
-	OverrideGamepad(gamepad, tiltLeftOut, tiltRightOut);
+	OverrideGamepad(gamepad, tiltLeftState, tiltRightState);
 }
 
 //The character's movement changes depending on the degree to which the stick is tilted.
@@ -160,18 +161,40 @@ void TiltInput::OverrideGamepad(Gamepad* gamepad, uint8_t dpad1, uint8_t dpad2) 
 	bool pinTilt1Pressed = (pinTilt1 != (uint8_t)-1) ? !gpio_get(pinTilt1) : false;
 	bool pinTilt2Pressed = (pinTilt2 != (uint8_t)-1) ? !gpio_get(pinTilt2) : false;
 
-	double scaledTilt1FactorLeftX  = tilt1FactorLeftX  / 100.0;
-	double scaledTilt1FactorLeftY  = tilt1FactorLeftY  / 100.0;
-	double scaledTilt1FactorRightX = tilt1FactorRightX / 100.0;
-	double scaledTilt1FactorRightY = tilt1FactorRightY / 100.0;
-	double scaledTilt2FactorLeftX  = tilt2FactorLeftX  / 100.0;
-	double scaledTilt2FactorLeftY  = tilt2FactorLeftY  / 100.0;
-	double scaledTilt2FactorRightX = tilt2FactorRightX / 100.0;
-	double scaledTilt2FactorRightY = tilt2FactorRightY / 100.0;
+	// Scales input from 0-100% of maximum input
+	double scaledTilt1FactorLeftX  = 1.0 - (tilt1FactorLeftX  / 100.0);
+	double scaledTilt1FactorLeftY  = 1.0 - (tilt1FactorLeftY  / 100.0);
+	double scaledTilt1FactorRightX = 1.0 - (tilt1FactorRightX / 100.0);
+	double scaledTilt1FactorRightY = 1.0 - (tilt1FactorRightY / 100.0);
+	double scaledTilt2FactorLeftX  = 1.0 - (tilt2FactorLeftX  / 100.0);
+	double scaledTilt2FactorLeftY  = 1.0 - (tilt2FactorLeftY  / 100.0);
+	double scaledTilt2FactorRightX = 1.0 - (tilt2FactorRightX / 100.0);
+	double scaledTilt2FactorRightY = 1.0 - (tilt2FactorRightY / 100.0);
 
 	uint8_t input_mode = gamepad->getOptions().inputMode;
 
-    if (pinTilt1Pressed) {
+    if (pinTilt1Pressed && pinTilt2Pressed) {
+        // inputs act as dpad
+        gamepad->state.dpad = dpad1|dpad2;
+    } else {
+        // analog input mode
+        if (pinTilt1Pressed) {
+            gamepad->state.lx = dpadToAnalogX(dpad1, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogX(dpad1, input_mode)) * scaledTilt1FactorLeftX;
+            gamepad->state.ly = dpadToAnalogY(dpad1, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogY(dpad1, input_mode)) * scaledTilt1FactorLeftY;
+
+            gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogX(dpad2, input_mode)) * scaledTilt1FactorRightX;
+            gamepad->state.ry = dpadToAnalogY(dpad2, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogY(dpad2, input_mode)) * scaledTilt1FactorRightY;
+        } else if (pinTilt2Pressed) {
+            gamepad->state.lx = dpadToAnalogX(dpad1, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogX(dpad1, input_mode)) * scaledTilt2FactorLeftX;
+            gamepad->state.ly = dpadToAnalogY(dpad1, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogY(dpad1, input_mode)) * scaledTilt2FactorLeftY;
+
+            gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogX(dpad2, input_mode)) * scaledTilt2FactorRightX;
+            gamepad->state.ry = dpadToAnalogY(dpad2, input_mode) + (GetJoystickMidValue(input_mode) - dpadToAnalogY(dpad2, input_mode)) * scaledTilt2FactorRightY;
+        }
+    }
+
+/*
+	if (pinTilt1Pressed) {
         gamepad->state.lx = dpadToAnalogX(dpad1, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad1, input_mode)) * scaledTilt1FactorLeftX;
         gamepad->state.ly = dpadToAnalogY(dpad1, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogY(dpad1, input_mode)) * scaledTilt1FactorLeftY;
     }
@@ -188,79 +211,120 @@ void TiltInput::OverrideGamepad(Gamepad* gamepad, uint8_t dpad1, uint8_t dpad2) 
 		gamepad->state.dpad = dpad2; //Hold tilt1 + tilt2 turn on D-Pad
 	}
 	else if (pinTilt1Pressed) {
-		if (dpad2 & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT)) {
-			gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad2, input_mode)) * scaledTilt1FactorRightX;
-			gamepad->state.ry = GAMEPAD_JOYSTICK_MID * scaledTilt1FactorRightY;
-		}
-		else {
-			gamepad->state.rx = dpadToAnalogX(dpad2, input_mode);
-			gamepad->state.ry = dpadToAnalogY(dpad2, input_mode);
-		}
+		gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad2, input_mode)) * scaledTilt1FactorRightX;
+        gamepad->state.ry = dpadToAnalogY(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogY(dpad2, input_mode)) * scaledTilt1FactorRightY;
 	}
 	else if (pinTilt2Pressed) {
-		if (dpad2 & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT)) {
-			gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad2, input_mode)) * scaledTilt2FactorRightX;
-			gamepad->state.ry = GAMEPAD_JOYSTICK_MID * scaledTilt2FactorRightY;
-		}
-		else {
-			gamepad->state.rx = dpadToAnalogX(dpad2, input_mode);
-			gamepad->state.ry = dpadToAnalogY(dpad2, input_mode);
-		}
+        gamepad->state.rx = dpadToAnalogX(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogX(dpad2, input_mode)) * scaledTilt2FactorRightX;
+        gamepad->state.ry = dpadToAnalogY(dpad2, input_mode) + (GAMEPAD_JOYSTICK_MID - dpadToAnalogY(dpad2, input_mode)) * scaledTilt2FactorRightY;
 	}
 	else {
 		gamepad->state.rx = dpadToAnalogX(dpad2, input_mode);
 		gamepad->state.ry = dpadToAnalogY(dpad2, input_mode);
 	}
+*/
 }
 
 
 void TiltInput::SOCDTiltClean(SOCDMode socdMode) {
+    // Left Stick SOCD Cleaning
 	// Tilt SOCD Last-Win Clean
 	switch (tiltLeftState & (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN)) {
 	case (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN): // If last state was Up or Down, exclude it from our gamepad
 		if (socdMode == SOCD_MODE_UP_PRIORITY) {
 			tiltLeftState ^= GAMEPAD_MASK_DOWN; // Remove Down
-			lastTiltUD = DIRECTION_UP; // We're in UP mode
+			leftLastTiltUD = DIRECTION_UP; // We're in UP mode
 		}
-		else if (socdMode == SOCD_MODE_SECOND_INPUT_PRIORITY && lastTiltUD != DIRECTION_NONE) {
-			tiltLeftState ^= (lastTiltUD == DIRECTION_UP) ? GAMEPAD_MASK_UP : GAMEPAD_MASK_DOWN;
+		else if (socdMode == SOCD_MODE_SECOND_INPUT_PRIORITY && leftLastTiltUD != DIRECTION_NONE) {
+			tiltLeftState ^= (leftLastTiltUD == DIRECTION_UP) ? GAMEPAD_MASK_UP : GAMEPAD_MASK_DOWN;
 		}
 		else {
 			tiltLeftState ^= (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN); // Remove UP and Down in Neutral
-			lastTiltUD = DIRECTION_NONE;
+			leftLastTiltUD = DIRECTION_NONE;
 		}
 		break;
 	case GAMEPAD_MASK_UP:
-		lastTiltUD = DIRECTION_UP;
+		leftLastTiltUD = DIRECTION_UP;
 		break;
 	case GAMEPAD_MASK_DOWN:
-		lastTiltUD = DIRECTION_DOWN;
+		leftLastTiltUD = DIRECTION_DOWN;
 		break;
 	default:
-		lastTiltUD = DIRECTION_NONE;
+		leftLastTiltUD = DIRECTION_NONE;
 		break;
 	}
 	switch (tiltLeftState & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT)) {
 	case (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT):
 		if (socdMode == SOCD_MODE_UP_PRIORITY || socdMode == SOCD_MODE_NEUTRAL) {
 			tiltLeftState ^= (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT); // Remove L + R to Neutral
-			lastTiltLR = DIRECTION_NONE;
+			leftLastTiltLR = DIRECTION_NONE;
 		}
 		else if (socdMode == SOCD_MODE_SECOND_INPUT_PRIORITY) {
-			if (lastTiltLR != DIRECTION_NONE)
-				tiltLeftState ^= (lastTiltLR == DIRECTION_LEFT) ? GAMEPAD_MASK_LEFT : GAMEPAD_MASK_RIGHT; // Last Win
+			if (leftLastTiltLR != DIRECTION_NONE)
+				tiltLeftState ^= (leftLastTiltLR == DIRECTION_LEFT) ? GAMEPAD_MASK_LEFT : GAMEPAD_MASK_RIGHT; // Last Win
 			else
-				lastTiltLR = DIRECTION_NONE;
+				leftLastTiltLR = DIRECTION_NONE;
 		}
 		break;
 	case GAMEPAD_MASK_LEFT:
-		lastTiltLR = DIRECTION_LEFT;
+		leftLastTiltLR = DIRECTION_LEFT;
 		break;
 	case GAMEPAD_MASK_RIGHT:
-		lastTiltLR = DIRECTION_RIGHT;
+		leftLastTiltLR = DIRECTION_RIGHT;
 		break;
 	default:
-		lastTiltLR = DIRECTION_NONE;
+		leftLastTiltLR = DIRECTION_NONE;
+		break;
+	}
+	// Right Stick SOCD Cleaning
+	// Tilt SOCD Last-Win Clean
+	switch (tiltRightState & (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN)) {
+	case (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN): // If last state was Up or Down, exclude it from our gamepad
+		if (socdMode == SOCD_MODE_UP_PRIORITY) {
+			tiltRightState ^= GAMEPAD_MASK_DOWN; // Remove Down
+			rightLastTiltUD = DIRECTION_UP; // We're in UP mode
+		}
+		else if (socdMode == SOCD_MODE_SECOND_INPUT_PRIORITY && rightLastTiltUD != DIRECTION_NONE) {
+			tiltRightState ^= (rightLastTiltUD == DIRECTION_UP) ? GAMEPAD_MASK_UP : GAMEPAD_MASK_DOWN;
+		}
+		else {
+			tiltRightState ^= (GAMEPAD_MASK_UP | GAMEPAD_MASK_DOWN); // Remove UP and Down in Neutral
+			rightLastTiltUD = DIRECTION_NONE;
+		}
+		break;
+	case GAMEPAD_MASK_UP:
+		rightLastTiltUD = DIRECTION_UP;
+		break;
+	case GAMEPAD_MASK_DOWN:
+		rightLastTiltUD = DIRECTION_DOWN;
+		break;
+	default:
+		rightLastTiltUD = DIRECTION_NONE;
+		break;
+	}
+    
+	switch (tiltRightState & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT)) {
+	case (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT):
+		if (socdMode == SOCD_MODE_UP_PRIORITY || socdMode == SOCD_MODE_NEUTRAL) {
+			tiltRightState ^= (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT); // Remove L + R to Neutral
+			rightLastTiltLR = DIRECTION_NONE;
+		}
+		else if (socdMode == SOCD_MODE_SECOND_INPUT_PRIORITY) {
+			if (rightLastTiltLR != DIRECTION_NONE)
+				tiltRightState ^= (rightLastTiltLR == DIRECTION_LEFT) ? GAMEPAD_MASK_LEFT : GAMEPAD_MASK_RIGHT; // Last Win
+			else
+				rightLastTiltLR = DIRECTION_NONE;
+		}
+		break;
+	case GAMEPAD_MASK_LEFT:
+		rightLastTiltLR = DIRECTION_LEFT;
+		break;
+	case GAMEPAD_MASK_RIGHT:
+		rightLastTiltLR = DIRECTION_RIGHT;
+		break;
+	default:
+		rightLastTiltLR = DIRECTION_NONE;
 		break;
 	}
 }
+

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -5,7 +5,7 @@
 
 bool TiltInput::available() {
     const TiltOptions& options = Storage::getInstance().getAddonOptions().tiltOptions;
-	return options.enabled && ((options.tilt1Pin != -1) || (options.tilt2Pin != -1));
+    return options.enabled && ((options.tilt1Pin != -1) || (options.tilt2Pin != -1));
 }
 
 void TiltInput::setup() {

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -4,11 +4,12 @@
 #include "config.pb.h"
 
 bool TiltInput::available() {
-	return Storage::getInstance().getAddonOptions().tiltOptions.enabled;
+    const TiltOptions& options = Storage::getInstance().getAddonOptions().tiltOptions;
+	return options.enabled && ((options.tilt1Pin != -1) || (options.tilt2Pin != -1));
 }
 
 void TiltInput::setup() {
-	const TiltOptions& options = Storage::getInstance().getAddonOptions().tiltOptions;	
+	const TiltOptions& options = Storage::getInstance().getAddonOptions().tiltOptions;
 	tiltSOCDMode = options.tiltSOCDMode;
 
 	pinTilt1 = options.tilt1Pin;

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -175,7 +175,7 @@ void TiltInput::OverrideGamepad(Gamepad* gamepad, uint8_t dpad1, uint8_t dpad2) 
 
     if (pinTilt1Pressed && pinTilt2Pressed) {
         // inputs act as dpad
-        gamepad->state.dpad = dpad1|dpad2;
+        gamepad->state.dpad |= dpad1|dpad2;
     } else {
         // analog input mode
         if (pinTilt1Pressed) {

--- a/www/src/Addons/Tilt.tsx
+++ b/www/src/Addons/Tilt.tsx
@@ -18,19 +18,19 @@ export const tiltScheme = {
 	factorTilt1LeftX: yup
 		.number()
 		.label('Tilt 1 Factor Left X')
-		.validateNumberWhenValue('TiltInputEnabled'),
+		.validateRangeWhenValue('TiltInputEnabled', 0, 100),
 	factorTilt1LeftY: yup
 		.number()
 		.label('Tilt 1 Factor Left Y')
-		.validateNumberWhenValue('TiltInputEnabled'),
+		.validateRangeWhenValue('TiltInputEnabled', 0, 100),
 	factorTilt1RightX: yup
 		.number()
 		.label('Tilt 1 Factor Right X')
-		.validateNumberWhenValue('TiltInputEnabled'),
+		.validateRangeWhenValue('TiltInputEnabled', 0, 100),
 	factorTilt1RightY: yup
 		.number()
 		.label('Tilt 1 Factor Right Y')
-		.validateNumberWhenValue('TiltInputEnabled'),
+		.validateRangeWhenValue('TiltInputEnabled', 0, 100),
 	tilt2Pin: yup
 		.number()
 		.label('Tilt 2 Pin')
@@ -38,19 +38,19 @@ export const tiltScheme = {
 	factorTilt2LeftX: yup
 		.number()
 		.label('Tilt 2 Factor Left X')
-		.validateNumberWhenValue('TiltInputEnabled'),
+		.validateRangeWhenValue('TiltInputEnabled', 0, 100),
 	factorTilt2LeftY: yup
 		.number()
 		.label('Tilt 2 Factor Left Y')
-		.validateNumberWhenValue('TiltInputEnabled'),
+		.validateRangeWhenValue('TiltInputEnabled', 0, 100),
 	factorTilt2RightX: yup
 		.number()
 		.label('Tilt 2 Factor Right X')
-		.validateNumberWhenValue('TiltInputEnabled'),
+		.validateRangeWhenValue('TiltInputEnabled', 0, 100),
 	factorTilt2RightY: yup
 		.number()
 		.label('Tilt 2 Factor Right Y')
-		.validateNumberWhenValue('TiltInputEnabled'),
+		.validateRangeWhenValue('TiltInputEnabled', 0, 100),
 	tiltLeftAnalogUpPin: yup
 		.number()
 		.label('Tilt Left Analog Up Pin')
@@ -92,15 +92,15 @@ export const tiltScheme = {
 export const tiltState = {
 	TiltInputEnabled: 0,
 	tilt1Pin: -1,
-	factorTilt1LeftX: -1,
-	factorTilt1LeftY: -1,
-	factorTilt1RightX: -1,
-	factorTilt1ightY: -1,
+	factorTilt1LeftX: 0,
+	factorTilt1LeftY: 0,
+	factorTilt1RightX: 0,
+	factorTilt1ightY: 0,
 	tilt2Pin: -1,
-	factorTilt2LeftX: -1,
-	factorTilt2LeftY: -1,
-	factorTilt2RightX: -1,
-	factorTilt2RightY: -1,
+	factorTilt2LeftX: 0,
+	factorTilt2LeftY: 0,
+	factorTilt2RightX: 0,
+	factorTilt2RightY: 0,
 	tiltLeftAnalogUpPin: -1,
 	tiltLeftAnalogDownPin: -1,
 	tiltLeftAnalogLeftPin: -1,


### PR DESCRIPTION
Reworked @InfraredAces #577 to include the recent Analog middle value changes from #582.  Also refactors the state checking when pressing the modifiers to remove redundant logic.