### PR TITLE
Sychronize send_report with host SOF packet. Should fix main problem mentioned in issue #488

### DIFF
--- a/lib/TinyUSB_Gamepad/src/hid_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/hid_driver.cpp
@@ -63,4 +63,4 @@ const usbd_class_driver_t hid_driver = {
 	.open = hidd_open,
 	.control_xfer_cb = hid_control_xfer_cb,
 	.xfer_cb = hidd_xfer_cb,
-	.sof = NULL};
+	.sof = sof_callback};

--- a/lib/TinyUSB_Gamepad/src/hid_driver.h
+++ b/lib/TinyUSB_Gamepad/src/hid_driver.h
@@ -10,6 +10,7 @@
 #include "gamepad/descriptors/SwitchDescriptors.h"
 
 extern const usbd_class_driver_t hid_driver;
+extern void sof_callback(uint8_t rhport, uint32_t frame_count);
 
 bool send_hid_report(uint8_t report_id, void *report, uint8_t report_size);
 bool send_keyboard_report(void *report);

--- a/lib/TinyUSB_Gamepad/src/ps4_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/ps4_driver.cpp
@@ -209,4 +209,4 @@ const usbd_class_driver_t ps4_driver =
 		.open = hidd_open,
 		.control_xfer_cb = hidd_control_xfer_cb,
 		.xfer_cb = hidd_xfer_cb,
-		.sof = NULL};
+		.sof = sof_callback};

--- a/lib/TinyUSB_Gamepad/src/ps4_driver.h
+++ b/lib/TinyUSB_Gamepad/src/ps4_driver.h
@@ -25,6 +25,7 @@ typedef enum
 
 // USB endpoint state vars
 extern const usbd_class_driver_t ps4_driver;
+extern void sof_callback(uint8_t rhport, uint32_t frame_count);
 
 ssize_t get_ps4_report(uint8_t report_id, uint8_t * buf, uint16_t reqlen);
 void set_ps4_report(uint8_t report_id, uint8_t const * buf, uint16_t reqlen);

--- a/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
@@ -22,7 +22,8 @@ UsbMode usb_mode = USB_MODE_HID;
 InputMode input_mode = INPUT_MODE_XINPUT;
 static bool usb_mounted = false;
 static bool usb_suspended = false;
-bool sof_ready = false;
+uint64_t last_sof_time = 0;
+bool report_sent = false;
 
 InputMode get_input_mode(void)
 {
@@ -214,5 +215,6 @@ void sof_callback(uint8_t rhport, uint32_t frame_count)
 {
 	(void)rhport;
 	(void)frame_count;
-	sof_ready = true;
+	last_sof_time = to_us_since_boot(get_absolute_time());
+	report_sent = false;
 }

--- a/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
@@ -22,6 +22,7 @@ UsbMode usb_mode = USB_MODE_HID;
 InputMode input_mode = INPUT_MODE_XINPUT;
 static bool usb_mounted = false;
 static bool usb_suspended = false;
+bool sof_ready = false;
 
 InputMode get_input_mode(void)
 {
@@ -45,6 +46,7 @@ void initialize_driver(InputMode mode)
 		usb_mode = USB_MODE_NET;
 
 	tud_init(TUD_OPT_RHPORT);
+	usbd_sof_enable(BOARD_TUD_RHPORT, true);
 }
 
 void receive_report(uint8_t *buffer)
@@ -204,4 +206,13 @@ void tud_suspend_cb(bool remote_wakeup_en)
 void tud_resume_cb(void)
 {
 	usb_suspended = false;
+}
+
+// Start Of Frame SOF packet callback
+// Used to sycnrhonize send_report() call with host input polling
+void sof_callback(uint8_t rhport, uint32_t frame_count)
+{
+	(void)rhport;
+	(void)frame_count;
+	sof_ready = true;
 }

--- a/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
@@ -215,6 +215,8 @@ void sof_callback(uint8_t rhport, uint32_t frame_count)
 {
 	(void)rhport;
 	(void)frame_count;
-	last_sof_time = to_us_since_boot(get_absolute_time());
-	report_sent = false;
+	if (gamepad_report == NULL) {
+		return;
+	}
+	send_report(gamepad_report, gamepad_report_size);
 }

--- a/lib/TinyUSB_Gamepad/src/usb_driver.h
+++ b/lib/TinyUSB_Gamepad/src/usb_driver.h
@@ -15,8 +15,8 @@ typedef enum
 	USB_MODE_NET,
 } UsbMode;
 
-extern uint64_t last_sof_time;
-extern bool report_sent;
+extern void* gamepad_report;
+extern uint16_t gamepad_report_size;
 
 InputMode get_input_mode(void);
 bool get_usb_mounted(void);

--- a/lib/TinyUSB_Gamepad/src/usb_driver.h
+++ b/lib/TinyUSB_Gamepad/src/usb_driver.h
@@ -7,6 +7,7 @@
 
 #include "gamepad/GamepadDescriptors.h"
 #include "enums.pb.h"
+#include <atomic>
 
 typedef enum
 {
@@ -14,10 +15,14 @@ typedef enum
 	USB_MODE_NET,
 } UsbMode;
 
+extern bool sof_ready;
+
 InputMode get_input_mode(void);
 bool get_usb_mounted(void);
 bool get_usb_suspended(void);
 void initialize_driver(InputMode mode);
 void receive_report(uint8_t *buffer);
 bool send_report(void *report, uint16_t report_size);
+void sof_callback(uint8_t rhport, uint32_t frame_count);
+
 

--- a/lib/TinyUSB_Gamepad/src/usb_driver.h
+++ b/lib/TinyUSB_Gamepad/src/usb_driver.h
@@ -15,7 +15,8 @@ typedef enum
 	USB_MODE_NET,
 } UsbMode;
 
-extern bool sof_ready;
+extern uint64_t last_sof_time;
+extern bool report_sent;
 
 InputMode get_input_mode(void);
 bool get_usb_mounted(void);

--- a/lib/TinyUSB_Gamepad/src/xinput_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/xinput_driver.cpp
@@ -115,4 +115,4 @@ const usbd_class_driver_t xinput_driver =
 		.open = xinput_open,
 		.control_xfer_cb = xinput_device_control_request,
 		.xfer_cb = xinput_xfer_callback,
-		.sof = NULL};
+		.sof = sof_callback};

--- a/lib/TinyUSB_Gamepad/src/xinput_driver.h
+++ b/lib/TinyUSB_Gamepad/src/xinput_driver.h
@@ -40,4 +40,6 @@ extern const usbd_class_driver_t xinput_driver;
 void receive_xinput_report(void);
 bool send_xinput_report(void *report, uint8_t report_size);
 
+extern void sof_callback(uint8_t rhport, uint32_t frame_count);
+
 #pragma once

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -170,7 +170,12 @@ void GP2040::run() {
 		memcpy(&processedGamepad->state, &gamepad->state, sizeof(GamepadState));
 
 		// USB FEATURES : Send/Get USB Features (including Player LEDs on X-Input)
-		send_report(gamepad->getReport(), gamepad->getReportSize());
+		if (sof_ready) {
+			bool sent = send_report(gamepad->getReport(), gamepad->getReportSize());
+			if (sent) {
+				sof_ready = false;
+			}
+		}
 		
 		// GET USB REPORT (If Endpoint Available)
 		receive_report(featureData);

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -41,6 +41,9 @@
 static const uint32_t REBOOT_HOTKEY_ACTIVATION_TIME_MS = 50;
 static const uint32_t REBOOT_HOTKEY_HOLD_TIME_MS = 4000;
 
+void* gamepad_report = NULL;
+uint16_t gamepad_report_size = 0;
+
 GP2040::GP2040() {
 	Storage::getInstance().SetGamepad(new Gamepad(GAMEPAD_DEBOUNCE_MILLIS));
 	Storage::getInstance().SetProcessedGamepad(new Gamepad(GAMEPAD_DEBOUNCE_MILLIS));
@@ -170,9 +173,9 @@ void GP2040::run() {
 		memcpy(&processedGamepad->state, &gamepad->state, sizeof(GamepadState));
 
 		// USB FEATURES : Send/Get USB Features (including Player LEDs on X-Input)
-		if (!report_sent && getMicro() >= last_sof_time + 900) {
-			report_sent = send_report(gamepad->getReport(), gamepad->getReportSize());
-		}
+		gamepad_report = gamepad->getReport();
+		gamepad_report_size = gamepad->getReportSize();
+
 		
 		// GET USB REPORT (If Endpoint Available)
 		receive_report(featureData);

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -170,11 +170,8 @@ void GP2040::run() {
 		memcpy(&processedGamepad->state, &gamepad->state, sizeof(GamepadState));
 
 		// USB FEATURES : Send/Get USB Features (including Player LEDs on X-Input)
-		if (sof_ready) {
-			bool sent = send_report(gamepad->getReport(), gamepad->getReportSize());
-			if (sent) {
-				sof_ready = false;
-			}
+		if (!report_sent && getMicro() >= last_sof_time + 900) {
+			report_sent = send_report(gamepad->getReport(), gamepad->getReportSize());
 		}
 		
 		// GET USB REPORT (If Endpoint Available)


### PR DESCRIPTION
This change makes it so that we don't attempt to run send_report unless the host has already sent an SOF packet. This should prevent prematurely locking in outdated inputs and delaying additional inputs in quick success (sub 1ms between button presses). This should also prevent introducing additional latency with noisy analog inputs or future additions such as motion data.

I unfortunately do not actually have the hardware set up to do latency tests for quick-succession button presses. What I can say is that the polling rate and jitter in XInput mode has not changed at all, as tested with XInputTest, when having the gamepad state change every single frame.