### PR TITLE
Fixes to gpioMappings migration and webconfig

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -249,7 +249,6 @@
 #define TILT2_FACTOR_LEFT_Y  65  //Default value for the TILT button to function.
 #define TILT2_FACTOR_RIGHT_X 65  //Default value for the TILT button to function.
 #define TILT2_FACTOR_RIGHT_Y 65  //Default value for the TILT button to function.
-#define PIN_TILT_FUNCTION -1
 #define PIN_TILT_LEFT_ANALOG_UP -1
 #define PIN_TILT_LEFT_ANALOG_DOWN -1
 #define PIN_TILT_LEFT_ANALOG_LEFT -1

--- a/configs/PicoW/BoardConfig.h
+++ b/configs/PicoW/BoardConfig.h
@@ -235,7 +235,6 @@
 // TILTAdd-on Options
 #define PIN_TILT_1 -1
 #define PIN_TILT_2 -1
-#define PIN_TILT_FUNCTION -1
 #define PIN_TILT_LEFT_ANALOG_UP -1
 #define PIN_TILT_LEFT_ANALOG_DOWN -1
 #define PIN_TILT_LEFT_ANALOG_LEFT -1

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -410,7 +410,7 @@ message TiltOptions
 
 	optional int32 tilt1Pin = 2;
 	optional int32 tilt2Pin = 3;
-	optional int32 tiltFunctionPin = 4;
+	optional int32 deprecatedTiltFunctionPin = 4;
 	optional int32 tiltLeftAnalogUpPin = 5;
 	optional int32 tiltLeftAnalogDownPin = 6;
 	optional int32 tiltLeftAnalogLeftPin = 7;

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -168,27 +168,6 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     // forcedSetupMode
     INIT_UNSET_PROPERTY(config.forcedSetupOptions, mode, DEFAULT_FORCED_SETUP_MODE);
 
-    // pinMappings
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinDpadUp, PIN_DPAD_UP);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinDpadDown, PIN_DPAD_DOWN);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinDpadLeft, PIN_DPAD_LEFT);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinDpadRight, PIN_DPAD_RIGHT);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonB1, PIN_BUTTON_B1);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonB2, PIN_BUTTON_B2);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonB3, PIN_BUTTON_B3);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonB4, PIN_BUTTON_B4);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonL1, PIN_BUTTON_L1);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonR1, PIN_BUTTON_R1);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonL2, PIN_BUTTON_L2);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonR2, PIN_BUTTON_R2);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonS1, PIN_BUTTON_S1);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonS2, PIN_BUTTON_S2);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonL3, PIN_BUTTON_L3);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonR3, PIN_BUTTON_R3);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonA1, PIN_BUTTON_A1);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonA2, PIN_BUTTON_A2);
-    INIT_UNSET_PROPERTY(config.deprecatedPinMappings, pinButtonFn, PIN_BUTTON_FN);
-
     // keyboardMapping
     INIT_UNSET_PROPERTY(config.keyboardMapping, keyDpadUp, KEY_DPAD_UP);
     INIT_UNSET_PROPERTY(config.keyboardMapping, keyDpadDown, KEY_DPAD_DOWN);

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -1019,7 +1019,6 @@ void ConfigUtils::load(Config& config)
 
     // run migrations
     if (!config.migrations.hotkeysMigrated) hotkeysMigration(config);
-    if (!config.migrations.gpioMappingsMigrated) gpioMappingsMigrationCore(config);
 
     // Make sure that fields that were not deserialized are properly initialized.
     // They were probably added with a newer version of the firmware.
@@ -1028,6 +1027,9 @@ void ConfigUtils::load(Config& config)
     // ----------------------------------------
     // Further migrations can be performed here
     // ----------------------------------------
+
+    // run migrations that need to happen after initUnset...
+    if (!config.migrations.gpioMappingsMigrated) gpioMappingsMigrationCore(config);
 
     // Update boardVersion, in case we migrated from an older version
     strncpy(config.boardVersion, GP2040VERSION, sizeof(config.boardVersion));

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -821,7 +821,6 @@ void gpioMappingsMigrationCore(Config& config)
     markAddonPinIfUsed(config.addonOptions.analogADS1219Options.i2cSDAPin);
     markAddonPinIfUsed(config.addonOptions.tiltOptions.tilt1Pin);
     markAddonPinIfUsed(config.addonOptions.tiltOptions.tilt2Pin);
-    markAddonPinIfUsed(config.addonOptions.tiltOptions.tiltFunctionPin);
     markAddonPinIfUsed(config.addonOptions.tiltOptions.tiltLeftAnalogUpPin);
     markAddonPinIfUsed(config.addonOptions.tiltOptions.tiltLeftAnalogDownPin);
     markAddonPinIfUsed(config.addonOptions.tiltOptions.tiltLeftAnalogLeftPin);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -670,10 +670,10 @@ std::string setLedOptions()
 	readIndex(ledOptions.indexA1, "ledButtonMap", "A1");
 	readIndex(ledOptions.indexA2, "ledButtonMap", "A2");
 	readDoc(ledOptions.pledType, doc, "pledType");
-	readDoc(ledOptions.pledPin1, doc, "pledPin1");
-	readDoc(ledOptions.pledPin2, doc, "pledPin2");
-	readDoc(ledOptions.pledPin3, doc, "pledPin3");
-	readDoc(ledOptions.pledPin4, doc, "pledPin4");
+	docToPin(ledOptions.pledPin1, doc, "pledPin1");
+	docToPin(ledOptions.pledPin2, doc, "pledPin2");
+	docToPin(ledOptions.pledPin3, doc, "pledPin3");
+	docToPin(ledOptions.pledPin4, doc, "pledPin4");
 	readDoc(ledOptions.pledColor, doc, "pledColor");
 
 	Storage::getInstance().save();


### PR DESCRIPTION
This addresses the following identified issues:
* gpioMappings losing mappings on GPIO 0 and 1 due to erroneous detection of enabled addons
* being unable to un-ASSIGNED_TO_ADDON the PLED pins when setting them to -1 in webconfig
* (re)initializing the deprecated buttonMappings for no reason

It does not address:
* the fact PLEDs are migrated as ASSIGNED_TO_ADDON when not in use because some BoardConfig.h files nevertheless enabled them
* the large growth of fsdata.c