### PR TITLE
Change target button for DirectInput/PS3 Mode in documentation

### DIFF
--- a/site/docs/usage.mdx
+++ b/site/docs/usage.mdx
@@ -77,7 +77,7 @@ GP2040-CE is compatible with a number of systems and input modes. To change the 
 | :-------------- | :---------: |
 | Nintendo Switch |  <Hotkey buttons={["B1"]}/>   |
 | XInput          |  <Hotkey buttons={["B2"]}/>   |
-| DirectInput/PS3 |  <Hotkey buttons={["B2"]}/>   |
+| DirectInput/PS3 |  <Hotkey buttons={["B3"]}/>   |
 | PS4             |  <Hotkey buttons={["B4"]}/>   |
 | Keyboard        |  <Hotkey buttons={["R2"]}/>   |
 


### PR DESCRIPTION
The recent reversion (#612) undid the edit from #570 

The target hotkey for DirectInput/PS3 has been corrected to be B3 again.