### PR TITLE
Documentation - Update workflow to use Github Action to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,42 +4,37 @@ on:
   push:
     branches:
       - main
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
 permissions:
-  contents: write
+  id-token: write
+  pages: write
 
 jobs:
   deploy:
-    name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Build steps
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: npm
-
       - name: Install dependencies
         run: npm install --frozen-lockfile
         working-directory: site
-      - name: Build website
+      - name: Build
         run: npm run build
         working-directory: site
 
-      # Popular action to deploy to GitHub Pages:
-      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          github_token: ${{ secrets.ACTION_SECRET }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: site/build
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          path: site/build
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/site/docs/development/firmware-development.mdx
+++ b/site/docs/development/firmware-development.mdx
@@ -4,6 +4,7 @@ title: Firmware Development
 # -
 pagination_next: null
 pagination_prev: null
+description: "Documentation on building and developing for GP2040-CE Firmware"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/site/docs/downloads/download-page.mdx
+++ b/site/docs/downloads/download-page.mdx
@@ -4,6 +4,7 @@ title: Downloads
 # -
 pagination_next: null
 pagination_prev: null
+description: "Pre-compiled firmware builds for supported devices. Verify that a firmware build (.uf2) is compatible with your device before flashing."
 ---
 
 import {

--- a/site/docs/hotkeys.mdx
+++ b/site/docs/hotkeys.mdx
@@ -4,6 +4,7 @@ title: Hotkeys
 # -
 pagination_next: null
 pagination_prev: null
+description: "Hotkey descriptions available for use with GP2040-CE"
 ---
 
 import InputLabelSelector, {

--- a/site/docs/rgb-leds.mdx
+++ b/site/docs/rgb-leds.mdx
@@ -1,12 +1,15 @@
 ---
 title: RGB LEDs
 # tags:
-# - 
+# -
 pagination_next: null
 pagination_prev: null
+description: "Add addressable RGB LEDs to your controller"
 ---
 
-import InputLabelSelector, { Hotkey } from "@site/src/components/LabelSelector.tsx";
+import InputLabelSelector, {
+	Hotkey,
+} from "@site/src/components/LabelSelector.tsx";
 
 # RGB LEDs
 
@@ -22,16 +25,16 @@ The exception to this are [Player LEDs](./add-ons/player-number.mdx), which can 
 
 ## RGB LED Hotkeys
 
-| Hotkey | Description |
-| - | - |
-|  <Hotkey buttons={["S1", "S2", "B3"]}/>  | Next Animation |
-|  <Hotkey buttons={["S1", "S2", "B1"]}/>  | Previous Animation |
-|  <Hotkey buttons={["S1", "S2", "B4"]}/>  | Brightness Up |
-|  <Hotkey buttons={["S1", "S2", "B2"]}/>  | Brightness Down |
-|  <Hotkey buttons={["S1", "S2", "R1"]}/>  | LED Parameter Up |
-|  <Hotkey buttons={["S1", "S2", "R2"]}/>  | LED Parameter Down |
-|  <Hotkey buttons={["S1", "S2", "L1"]}/>  | Pressed Parameter Up |
-|  <Hotkey buttons={["S1", "S2", "L2"]}/>  | Pressed Parameter Down |
+| Hotkey                                 | Description            |
+| -------------------------------------- | ---------------------- |
+| <Hotkey buttons={["S1", "S2", "B3"]}/> | Next Animation         |
+| <Hotkey buttons={["S1", "S2", "B1"]}/> | Previous Animation     |
+| <Hotkey buttons={["S1", "S2", "B4"]}/> | Brightness Up          |
+| <Hotkey buttons={["S1", "S2", "B2"]}/> | Brightness Down        |
+| <Hotkey buttons={["S1", "S2", "R1"]}/> | LED Parameter Up       |
+| <Hotkey buttons={["S1", "S2", "R2"]}/> | LED Parameter Down     |
+| <Hotkey buttons={["S1", "S2", "L1"]}/> | Pressed Parameter Up   |
+| <Hotkey buttons={["S1", "S2", "L2"]}/> | Pressed Parameter Down |
 
 :::note
 
@@ -43,35 +46,35 @@ The `LED Parameter` hotkeys may affect color, speed or theme depending on the cu
 
 The following animations are available:
 
-| Name | Description | LED Parameter |
-| - | - | - |
-| Off | Turn off per-button RGB LEDs | - |
-| Static Color | Sets all LEDs to the same color | Cycle through colors: *Red*, *Orange*, *Yellow*, *Lime Green*, *Green*, *Seafoam*, *Aqua*, *Sky Blue*, *Blue*, *Purple*, *Pink*, *Magenta* |
-| Rainbow Cycle | All LEDs cycle through the color wheel displaying the same color | Adjust animation speed |
-| Rainbow Chase | A fading, rainbow cycling lines travels across the LED chain | Adjust animation speed |
-| Static Theme | Set the LEDs to a pre-defined static theme | Cycle through themes, see [RGB LED Static Themes](#rgb-led-static-themes) for details. |
+| Name          | Description                                                      | LED Parameter                                                                                                                              |
+| ------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Off           | Turn off per-button RGB LEDs                                     | -                                                                                                                                          |
+| Static Color  | Sets all LEDs to the same color                                  | Cycle through colors: _Red_, _Orange_, _Yellow_, _Lime Green_, _Green_, _Seafoam_, _Aqua_, _Sky Blue_, _Blue_, _Purple_, _Pink_, _Magenta_ |
+| Rainbow Cycle | All LEDs cycle through the color wheel displaying the same color | Adjust animation speed                                                                                                                     |
+| Rainbow Chase | A fading, rainbow cycling lines travels across the LED chain     | Adjust animation speed                                                                                                                     |
+| Static Theme  | Set the LEDs to a pre-defined static theme                       | Cycle through themes, see [RGB LED Static Themes](#rgb-led-static-themes) for details.                                                     |
 
 ## RGB LED Static Themes
 
-| Name | Preview |
-| - | - |
-| **Static Rainbow** | ![Static Rainbow](./assets/images/led-themes/static-rainbow.png) |
-| **Xbox** | ![Xbox](./assets/images/led-themes/xbox.png) |
-| **Xbox (All)** | ![Xbox (All)](./assets/images/led-themes/xbox-all.png) |
-| **Super Famicom** | ![Super Famicom](./assets/images/led-themes/super-famicom.png) |
-| **Super Famicom (All)** | ![Super Famicom (All)](./assets/images/led-themes/super-famicom-all.png) |
-| **PlayStation** | ![Xbox](./assets/images/led-themes/playstation.png) |
-| **PlayStation (All)** | ![Xbox (All)](./assets/images/led-themes/playstation-all.png) |
-| **Neo Geo Straight** | ![Neo Geo Classic](./assets/images/led-themes/neogeo-straight.png) |
-| **Neo Geo Curved** | ![Neo Geo Curved](./assets/images/led-themes/neogeo-curved.png) |
-| **Neo Geo Modern** | ![Neo Geo Modern](./assets/images/led-themes/neogeo-modern.png) |
-| **Six Button Fighter** | ![Six Button Fighter](./assets/images/led-themes/six-button-fighter.png) |
+| Name                     | Preview                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| **Static Rainbow**       | ![Static Rainbow](./assets/images/led-themes/static-rainbow.png)                |
+| **Xbox**                 | ![Xbox](./assets/images/led-themes/xbox.png)                                    |
+| **Xbox (All)**           | ![Xbox (All)](./assets/images/led-themes/xbox-all.png)                          |
+| **Super Famicom**        | ![Super Famicom](./assets/images/led-themes/super-famicom.png)                  |
+| **Super Famicom (All)**  | ![Super Famicom (All)](./assets/images/led-themes/super-famicom-all.png)        |
+| **PlayStation**          | ![Xbox](./assets/images/led-themes/playstation.png)                             |
+| **PlayStation (All)**    | ![Xbox (All)](./assets/images/led-themes/playstation-all.png)                   |
+| **Neo Geo Straight**     | ![Neo Geo Classic](./assets/images/led-themes/neogeo-straight.png)              |
+| **Neo Geo Curved**       | ![Neo Geo Curved](./assets/images/led-themes/neogeo-curved.png)                 |
+| **Neo Geo Modern**       | ![Neo Geo Modern](./assets/images/led-themes/neogeo-modern.png)                 |
+| **Six Button Fighter**   | ![Six Button Fighter](./assets/images/led-themes/six-button-fighter.png)        |
 | **Six Button Fighter +** | ![Six Button Fighter +](./assets/images/led-themes/six-button-fighter-plus.png) |
-| **Street Fighter 2** | ![Street Fighter 2](./assets/images/led-themes/street-fighter-2.png) |
-| **Tekken** | ![Tekken](./assets/images/led-themes/tekken.png) |
-| **Guilty Gear Type-A** | ![Guilty Gear Type-A](./assets/images/led-themes/guilty-gear-type-a.png) |
-| **Guilty Gear Type-B** | ![Guilty Gear Type-B](./assets/images/led-themes/guilty-gear-type-b.png) |
-| **Guilty Gear Type-C** | ![Guilty Gear Type-C](./assets/images/led-themes/guilty-gear-type-c.png) |
-| **Guilty Gear Type-D** | ![Guilty Gear Type-D](./assets/images/led-themes/guilty-gear-type-d.png) |
-| **Guilty Gear Type-E** | ![Guilty Gear Type-E](./assets/images/led-themes/guilty-gear-type-e.png) |
-| **Fightboard** | ![Fightboard](./assets/images/led-themes/fightboard.png) |
+| **Street Fighter 2**     | ![Street Fighter 2](./assets/images/led-themes/street-fighter-2.png)            |
+| **Tekken**               | ![Tekken](./assets/images/led-themes/tekken.png)                                |
+| **Guilty Gear Type-A**   | ![Guilty Gear Type-A](./assets/images/led-themes/guilty-gear-type-a.png)        |
+| **Guilty Gear Type-B**   | ![Guilty Gear Type-B](./assets/images/led-themes/guilty-gear-type-b.png)        |
+| **Guilty Gear Type-C**   | ![Guilty Gear Type-C](./assets/images/led-themes/guilty-gear-type-c.png)        |
+| **Guilty Gear Type-D**   | ![Guilty Gear Type-D](./assets/images/led-themes/guilty-gear-type-d.png)        |
+| **Guilty Gear Type-E**   | ![Guilty Gear Type-E](./assets/images/led-themes/guilty-gear-type-e.png)        |
+| **Fightboard**           | ![Fightboard](./assets/images/led-themes/fightboard.png)                        |

--- a/site/docs/usage.mdx
+++ b/site/docs/usage.mdx
@@ -54,23 +54,23 @@ Bootsel Mode is the state of the board where firmware can be flashed onto the bo
 
 You can boot into Bootsel Mode by either holding <Hotkey buttons={["S1", "S2", "Up"]}/> buttons while plugging in the controller or by booting into the Web Configurator and then restarting in Bootsel Mode.
 
-## Webconfig Mode
+## WebConfig Mode
 
-Webconfig Mode is the state of the board where built-in web browser-based configuration application is launched. From here, you can customize and configure your controller as needed.
+WebConfig Mode is the state of the board where built-in web browser-based configuration application is launched. From here, you can customize and configure your controller as needed. For more information, click [here](./web-configurator/web-configurator.mdx) for more information.
 
-You can boot into Webconfig Mode by holding the <Hotkey buttons={["S2"]}/> button while plugging in the controller.
+You can boot into WebConfig Mode by holding the <Hotkey buttons={["S2"]}/> button while plugging in the controller.
 
 ## Input Modes
 
 GP2040-CE is compatible with a number of systems and input modes. To change the input mode, **hold one of the following buttons as the controller is plugged in:**
 
-| Input Mode      | Button Held |
-| :-------------- | :---------: |
-| Nintendo Switch |  <Hotkey buttons={["B1"]}/>   |
-| XInput          |  <Hotkey buttons={["B2"]}/>   |
-| DirectInput/PS3 |  <Hotkey buttons={["B3"]}/>   |
-| PS4             |  <Hotkey buttons={["B4"]}/>   |
-| Keyboard        |  <Hotkey buttons={["R2"]}/>   |
+| Input Mode      |        Button Held         |
+| :-------------- | :------------------------: |
+| Nintendo Switch | <Hotkey buttons={["B1"]}/> |
+| XInput          | <Hotkey buttons={["B2"]}/> |
+| DirectInput/PS3 | <Hotkey buttons={["B3"]}/> |
+| PS4             | <Hotkey buttons={["B4"]}/> |
+| Keyboard        | <Hotkey buttons={["R2"]}/> |
 
 :::note
 

--- a/site/docs/web-configurator/web-configurator.mdx
+++ b/site/docs/web-configurator/web-configurator.mdx
@@ -4,6 +4,7 @@ title: GP2040-CE Web Configurator
 # -
 pagination_next: null
 pagination_prev: null
+description: "GP2040-CE's Web-Based Configuration Application: Just press S2 on boot and go to http://192.168.7.1"
 ---
 
 import InputLabelSelector, {
@@ -19,7 +20,7 @@ Select the button labels to be displayed in the usage guide:
 
 GP2040-CE contains a built-in web-based configuration application which can be started up by holding <Hotkey buttons={["S2"]}/> when plugging your controller into a PC. Then access <http://192.168.7.1> in a web browser to begin configuration.
 
-This mode is compatible with Windows, Mac, Linux and SteamOS.
+This mode is compatible with Windows, Mac, Linux and SteamOS. Android and iOS devices are not supported at this time.
 
 :::note
 


### PR DESCRIPTION
This PR changes the documentation deployment process from committing to the `gh-pages` branch and then running the `pages build and deployment` action to running a single action, `Deploy to GitHub Pages`, on push to main. It also removes the need to have a personal access token and additional commit from the PAT holder.

Additional minor documentation updates were included in this PR.

### Changes required from Repo Owners:

- Change the `Build and deployment` source from `Deploy from a branch` to `GitHub Actions`.

Once these changes are made, the original PAT can be removed from the repo secrets and the `gh-pages` branch deleted.

![image](https://github.com/OpenStickCommunity/GP2040-CE/assets/44279698/f0a6cb8b-83b7-4226-ab44-d8a1c1f204b8)

![image](https://github.com/OpenStickCommunity/GP2040-CE/assets/44279698/ebfbf625-9a31-4bd9-963c-d1f11d3b8e77)

![image](https://github.com/OpenStickCommunity/GP2040-CE/assets/44279698/0f957c9f-a9ef-40fc-8611-e73d3dd5143a)

![image](https://github.com/OpenStickCommunity/GP2040-CE/assets/44279698/6a6dcdfc-98eb-4c93-a128-e17c5ef7c9e6)

![image](https://github.com/OpenStickCommunity/GP2040-CE/assets/44279698/ef7fecb0-ac69-49d1-a38a-97b56b6631bc)
