### PR TITLE
docToPin: only unset the old pin to NONE if it's a valid pin

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -118,7 +118,10 @@ static void __attribute__((noinline)) docToPin(Pin_t& pin, const DynamicJsonDocu
 		else
 		{
 			pin = -1;
-			*gpioMappings[oldPin] = GpioAction::NONE;
+			if (isValidPin(oldPin))
+			{
+				*gpioMappings[oldPin] = GpioAction::NONE;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This resolves a webconfig crash where setting an addon pin from -1 to -1 would crash the board until it was powercycled.