### PR TITLE
convert GpioMappings to an array in protobuf

### DIFF
--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -37,7 +37,6 @@ public:
 	ForcedSetupOptions& getForcedSetupOptions() { return config.forcedSetupOptions; }
 	PinMappings& getDeprecatedPinMappings() { return config.deprecatedPinMappings; }
 	GpioMappings& getGpioMappings() { return config.gpioMappings; }
-	GpioAction** getGpioMappingsArray() { return gpioMappingsArray; }
 	KeyboardMapping& getKeyboardMapping() { return config.keyboardMapping; }
 	DisplayOptions& getDisplayOptions() { return config.displayOptions; }
 	DisplayOptions& getPreviewDisplayOptions() { return previewDisplayOptions; }
@@ -85,7 +84,6 @@ private:
 	uint32_t animationOptionsCrc = 0;
 	AnimationOptions animationOptionsToSave = {};
 	GpioAction functionalPinMappings[NUM_BANK0_GPIOS];
-	GpioAction* gpioMappingsArray[NUM_BANK0_GPIOS];
 };
 
 #endif

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -118,38 +118,14 @@ message PinMappings
 	optional int32 pinButtonFn = 19;
 }
 
+message GpioMappingInfo
+{
+	optional GpioAction action = 1;
+}
+
 message GpioMappings
 {
-	optional GpioAction pin00 = 1;
-	optional GpioAction pin01 = 2;
-	optional GpioAction pin02 = 3;
-	optional GpioAction pin03 = 4;
-	optional GpioAction pin04 = 5;
-	optional GpioAction pin05 = 6;
-	optional GpioAction pin06 = 7;
-	optional GpioAction pin07 = 8;
-	optional GpioAction pin08 = 9;
-	optional GpioAction pin09 = 10;
-	optional GpioAction pin10 = 11;
-	optional GpioAction pin11 = 12;
-	optional GpioAction pin12 = 13;
-	optional GpioAction pin13 = 14;
-	optional GpioAction pin14 = 15;
-	optional GpioAction pin15 = 16;
-	optional GpioAction pin16 = 17;
-	optional GpioAction pin17 = 18;
-	optional GpioAction pin18 = 19;
-	optional GpioAction pin19 = 20;
-	optional GpioAction pin20 = 21;
-	optional GpioAction pin21 = 22;
-	optional GpioAction pin22 = 23;
-	optional GpioAction pin23 = 24;
-	optional GpioAction pin24 = 25;
-	optional GpioAction pin25 = 26;
-	optional GpioAction pin26 = 27;
-	optional GpioAction pin27 = 28;
-	optional GpioAction pin28 = 29;
-	optional GpioAction pin29 = 30;
+	repeated GpioMappingInfo pins = 1 [(nanopb).max_count = 30];
 }
 
 

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -851,36 +851,11 @@ void gpioMappingsMigrationCore(Config& config)
     markAddonPinIfUsed(config.addonOptions.macroOptions.macroList[4].macroTriggerPin);
     markAddonPinIfUsed(config.addonOptions.macroOptions.macroList[5].macroTriggerPin);
 
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin00, actions[0]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin01, actions[1]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin02, actions[2]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin03, actions[3]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin04, actions[4]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin05, actions[5]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin06, actions[6]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin07, actions[7]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin08, actions[8]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin09, actions[9]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin10, actions[10]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin11, actions[11]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin12, actions[12]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin13, actions[13]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin14, actions[14]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin15, actions[15]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin16, actions[16]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin17, actions[17]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin18, actions[18]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin19, actions[19]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin20, actions[20]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin21, actions[21]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin22, actions[22]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin23, actions[23]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin24, actions[24]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin25, actions[25]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin26, actions[26]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin27, actions[27]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin28, actions[28]);
-    INIT_UNSET_PROPERTY(config.gpioMappings, pin29, actions[29]);
+    for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++) {
+        config.gpioMappings.pins[pin].action = actions[pin];
+    }
+    // reminder that this must be set or else nanopb won't retain anything
+    config.gpioMappings.pins_count = NUM_BANK0_GPIOS;
 
     config.migrations.gpioMappingsMigrated = true;
 }

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -110,17 +110,17 @@ static void __attribute__((noinline)) docToPin(Pin_t& pin, const DynamicJsonDocu
 	if (doc.containsKey(key))
 	{
 		pin = doc[key];
-		GpioAction** gpioMappings = Storage::getInstance().getGpioMappingsArray();
+		GpioMappingInfo* gpioMappings = Storage::getInstance().getGpioMappings().pins;
 		if (isValidPin(pin))
 		{
-			*gpioMappings[pin] = GpioAction::ASSIGNED_TO_ADDON;
+			gpioMappings[pin].action = GpioAction::ASSIGNED_TO_ADDON;
 		}
 		else
 		{
 			pin = -1;
 			if (isValidPin(oldPin))
 			{
-				*gpioMappings[oldPin] = GpioAction::NONE;
+				gpioMappings[oldPin].action = GpioAction::NONE;
 			}
 		}
 	}
@@ -351,11 +351,12 @@ void addUsedPinsArray(DynamicJsonDocument& doc)
 {
 	auto usedPins = doc.createNestedArray("usedPins");
 
-	GpioAction** gpioMappings = Storage::getInstance().getGpioMappingsArray();
+	GpioMappingInfo* gpioMappings = Storage::getInstance().getGpioMappings().pins;
 	for (unsigned int pin = 0; pin < NUM_BANK0_GPIOS; pin++) {
 		// NOTE: addons in webconfig break by seeing their own pins here; if/when they
 		// are refactored to ignore their own pins from this list, we can include them
-		if (*gpioMappings[pin] != GpioAction::NONE && *gpioMappings[pin] != GpioAction::ASSIGNED_TO_ADDON) {
+		if (gpioMappings[pin].action != GpioAction::NONE &&
+				gpioMappings[pin].action != GpioAction::ASSIGNED_TO_ADDON) {
 			usedPins.add(pin);
 		}
 	}
@@ -609,9 +610,9 @@ std::string getGamepadOptions()
 	writeDoc(doc, "debounceDelay", gamepadOptions.debounceDelay);
 
 	writeDoc(doc, "fnButtonPin", -1);
-	GpioAction** gpioMappings = Storage::getInstance().getGpioMappingsArray();
+	GpioMappingInfo* gpioMappings = Storage::getInstance().getGpioMappings().pins;
 	for (unsigned int pin = 0; pin < NUM_BANK0_GPIOS; pin++) {
-		if (*gpioMappings[pin] == GpioAction::BUTTON_PRESS_FN) {
+		if (gpioMappings[pin].action == GpioAction::BUTTON_PRESS_FN) {
 			writeDoc(doc, "fnButtonPin", pin);
 		}
 	}
@@ -846,17 +847,17 @@ std::string setPinMappings()
 {
 	DynamicJsonDocument doc = get_post_data();
 
-	GpioAction** gpioMappings = Storage::getInstance().getGpioMappingsArray();
+	GpioMappingInfo* gpioMappings = Storage::getInstance().getGpioMappings().pins;
 
 	char pinName[6];
 	for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++) {
 		snprintf(pinName, 6, "pin%0*d", 2, pin);
 		// setting a pin shouldn't change a new existing addon/reserved pin
-		if (*gpioMappings[pin] != GpioAction::RESERVED &&
-				*gpioMappings[pin] != GpioAction::ASSIGNED_TO_ADDON &&
+		if (gpioMappings[pin].action != GpioAction::RESERVED &&
+				gpioMappings[pin].action != GpioAction::ASSIGNED_TO_ADDON &&
 				(Pin_t)doc[pinName] != GpioAction::RESERVED &&
 				(Pin_t)doc[pinName] != GpioAction::ASSIGNED_TO_ADDON) {
-			readDoc(*gpioMappings[pin], doc, pinName);
+			gpioMappings[pin].action = doc[pinName];
 		}
 	}
 
@@ -869,38 +870,38 @@ std::string getPinMappings()
 {
 	DynamicJsonDocument doc(LWIP_HTTPD_POST_MAX_PAYLOAD_LEN);
 
-	GpioAction** gpioMappings = Storage::getInstance().getGpioMappingsArray();
+	GpioMappingInfo* gpioMappings = Storage::getInstance().getGpioMappings().pins;
 
-	writeDoc(doc, "pin00", *gpioMappings[0]);
-	writeDoc(doc, "pin01", *gpioMappings[1]);
-	writeDoc(doc, "pin02", *gpioMappings[2]);
-	writeDoc(doc, "pin03", *gpioMappings[3]);
-	writeDoc(doc, "pin04", *gpioMappings[4]);
-	writeDoc(doc, "pin05", *gpioMappings[5]);
-	writeDoc(doc, "pin06", *gpioMappings[6]);
-	writeDoc(doc, "pin07", *gpioMappings[7]);
-	writeDoc(doc, "pin08", *gpioMappings[8]);
-	writeDoc(doc, "pin09", *gpioMappings[9]);
-	writeDoc(doc, "pin10", *gpioMappings[10]);
-	writeDoc(doc, "pin11", *gpioMappings[11]);
-	writeDoc(doc, "pin12", *gpioMappings[12]);
-	writeDoc(doc, "pin13", *gpioMappings[13]);
-	writeDoc(doc, "pin14", *gpioMappings[14]);
-	writeDoc(doc, "pin15", *gpioMappings[15]);
-	writeDoc(doc, "pin16", *gpioMappings[16]);
-	writeDoc(doc, "pin17", *gpioMappings[17]);
-	writeDoc(doc, "pin18", *gpioMappings[18]);
-	writeDoc(doc, "pin19", *gpioMappings[19]);
-	writeDoc(doc, "pin20", *gpioMappings[20]);
-	writeDoc(doc, "pin21", *gpioMappings[21]);
-	writeDoc(doc, "pin22", *gpioMappings[22]);
-	writeDoc(doc, "pin23", *gpioMappings[23]);
-	writeDoc(doc, "pin24", *gpioMappings[24]);
-	writeDoc(doc, "pin25", *gpioMappings[25]);
-	writeDoc(doc, "pin26", *gpioMappings[26]);
-	writeDoc(doc, "pin27", *gpioMappings[27]);
-	writeDoc(doc, "pin28", *gpioMappings[28]);
-	writeDoc(doc, "pin29", *gpioMappings[29]);
+	writeDoc(doc, "pin00", gpioMappings[0].action);
+	writeDoc(doc, "pin01", gpioMappings[1].action);
+	writeDoc(doc, "pin02", gpioMappings[2].action);
+	writeDoc(doc, "pin03", gpioMappings[3].action);
+	writeDoc(doc, "pin04", gpioMappings[4].action);
+	writeDoc(doc, "pin05", gpioMappings[5].action);
+	writeDoc(doc, "pin06", gpioMappings[6].action);
+	writeDoc(doc, "pin07", gpioMappings[7].action);
+	writeDoc(doc, "pin08", gpioMappings[8].action);
+	writeDoc(doc, "pin09", gpioMappings[9].action);
+	writeDoc(doc, "pin10", gpioMappings[10].action);
+	writeDoc(doc, "pin11", gpioMappings[11].action);
+	writeDoc(doc, "pin12", gpioMappings[12].action);
+	writeDoc(doc, "pin13", gpioMappings[13].action);
+	writeDoc(doc, "pin14", gpioMappings[14].action);
+	writeDoc(doc, "pin15", gpioMappings[15].action);
+	writeDoc(doc, "pin16", gpioMappings[16].action);
+	writeDoc(doc, "pin17", gpioMappings[17].action);
+	writeDoc(doc, "pin18", gpioMappings[18].action);
+	writeDoc(doc, "pin19", gpioMappings[19].action);
+	writeDoc(doc, "pin20", gpioMappings[20].action);
+	writeDoc(doc, "pin21", gpioMappings[21].action);
+	writeDoc(doc, "pin22", gpioMappings[22].action);
+	writeDoc(doc, "pin23", gpioMappings[23].action);
+	writeDoc(doc, "pin24", gpioMappings[24].action);
+	writeDoc(doc, "pin25", gpioMappings[25].action);
+	writeDoc(doc, "pin26", gpioMappings[26].action);
+	writeDoc(doc, "pin27", gpioMappings[27].action);
+	writeDoc(doc, "pin28", gpioMappings[28].action);
+	writeDoc(doc, "pin29", gpioMappings[29].action);
 
 	return serialize_json(doc);
 }
@@ -966,7 +967,7 @@ std::string setAddonOptions()
 {
 	DynamicJsonDocument doc = get_post_data();
 
-	GpioAction** gpioMappings = Storage::getInstance().getGpioMappingsArray();
+	GpioMappingInfo* gpioMappings = Storage::getInstance().getGpioMappings().pins;
 
     AnalogOptions& analogOptions = Storage::getInstance().getAddonOptions().analogOptions;
 	docToPin(analogOptions.analogAdc1PinX, doc, "analogAdc1PinX");
@@ -1103,10 +1104,10 @@ std::string setAddonOptions()
 	Pin_t oldKbPinDplus = keyboardHostOptions.pinDplus;
 	docToPin(keyboardHostOptions.pinDplus, doc, "keyboardHostPinDplus");
 	if (isValidPin(keyboardHostOptions.pinDplus))
-		*gpioMappings[keyboardHostOptions.pinDplus+1] = GpioAction::ASSIGNED_TO_ADDON;
+		gpioMappings[keyboardHostOptions.pinDplus+1].action = GpioAction::ASSIGNED_TO_ADDON;
 	else if (isValidPin(oldKbPinDplus))
 		// if D+ pin was set, and is no longer, also unset the pin that was used for D-
-		*gpioMappings[oldKbPinDplus+1] = GpioAction::NONE;
+		gpioMappings[oldKbPinDplus+1].action = GpioAction::NONE;
 	docToPin(keyboardHostOptions.pin5V, doc, "keyboardHostPin5V");
 	docToValue(keyboardHostOptions.mapping.keyDpadUp, doc, "keyboardHostMap", "Up");
 	docToValue(keyboardHostOptions.mapping.keyDpadDown, doc, "keyboardHostMap", "Down");
@@ -1132,10 +1133,10 @@ std::string setAddonOptions()
 	Pin_t oldPsPinDplus = psPassthroughOptions.pinDplus;
 	docToPin(psPassthroughOptions.pinDplus, doc, "psPassthroughPinDplus");
 	if (isValidPin(psPassthroughOptions.pinDplus))
-		*gpioMappings[psPassthroughOptions.pinDplus+1] = GpioAction::ASSIGNED_TO_ADDON;
+		gpioMappings[psPassthroughOptions.pinDplus+1].action = GpioAction::ASSIGNED_TO_ADDON;
 	else if (isValidPin(oldPsPinDplus))
 		// if D+ pin was set, and is no longer, also unset the pin that was used for D-
-		*gpioMappings[oldPsPinDplus+1] = GpioAction::NONE;
+		gpioMappings[oldPsPinDplus+1].action = GpioAction::NONE;
 	docToPin(psPassthroughOptions.pin5V, doc, "psPassthroughPin5V");
 
 	Storage::getInstance().save();

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -44,36 +44,6 @@
 Storage::Storage()
 {
 	EEPROM.start();
-	gpioMappingsArray[0] = &config.gpioMappings.pin00;
-	gpioMappingsArray[1] = &config.gpioMappings.pin01;
-	gpioMappingsArray[2] = &config.gpioMappings.pin02;
-	gpioMappingsArray[3] = &config.gpioMappings.pin03;
-	gpioMappingsArray[4] = &config.gpioMappings.pin04;
-	gpioMappingsArray[5] = &config.gpioMappings.pin05;
-	gpioMappingsArray[6] = &config.gpioMappings.pin06;
-	gpioMappingsArray[7] = &config.gpioMappings.pin07;
-	gpioMappingsArray[8] = &config.gpioMappings.pin08;
-	gpioMappingsArray[9] = &config.gpioMappings.pin09;
-	gpioMappingsArray[10] = &config.gpioMappings.pin10;
-	gpioMappingsArray[11] = &config.gpioMappings.pin11;
-	gpioMappingsArray[12] = &config.gpioMappings.pin12;
-	gpioMappingsArray[13] = &config.gpioMappings.pin13;
-	gpioMappingsArray[14] = &config.gpioMappings.pin14;
-	gpioMappingsArray[15] = &config.gpioMappings.pin15;
-	gpioMappingsArray[16] = &config.gpioMappings.pin16;
-	gpioMappingsArray[17] = &config.gpioMappings.pin17;
-	gpioMappingsArray[18] = &config.gpioMappings.pin18;
-	gpioMappingsArray[19] = &config.gpioMappings.pin19;
-	gpioMappingsArray[20] = &config.gpioMappings.pin20;
-	gpioMappingsArray[21] = &config.gpioMappings.pin21;
-	gpioMappingsArray[22] = &config.gpioMappings.pin22;
-	gpioMappingsArray[23] = &config.gpioMappings.pin23;
-	gpioMappingsArray[24] = &config.gpioMappings.pin24;
-	gpioMappingsArray[25] = &config.gpioMappings.pin25;
-	gpioMappingsArray[26] = &config.gpioMappings.pin26;
-	gpioMappingsArray[27] = &config.gpioMappings.pin27;
-	gpioMappingsArray[28] = &config.gpioMappings.pin28;
-	gpioMappingsArray[29] = &config.gpioMappings.pin29;
 	critical_section_init(&animationOptionsCs);
 	ConfigUtils::load(config);
 
@@ -176,7 +146,7 @@ void Storage::setProfile(const uint32_t profileNum)
 void Storage::setFunctionalPinMappings(const uint32_t profileNum)
 {
 	for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++) {
-		functionalPinMappings[pin] = *gpioMappingsArray[pin];
+		functionalPinMappings[pin] = this->config.gpioMappings.pins[pin].action;
 	}
 	if (profileNum < 2 || profileNum > 4) return;
 


### PR DESCRIPTION
! ! ! WARNING ! ! !
Current users of `main` will find their config is wiped by this change. You will have to go into webconfig and redo your config. 0.7.5 users should be unaffected.

My Python-brain wrote `GpioMappings` in a descriptive way that's great for dynamic languages, but it turned out that in our code, I had to quickly treat the dict-like message in protobuf as an array in C, to make it easy to work with. This was fine, but a bit funky, and kept the protobuf descriptive. However, this array pattern would have to have been duplicated for profiles-as-GpioMappings, which would have meant more funky code and more stuff residing in memory for no good reason. This has the mappings as an array in the protobuf, which is slightly less obvious when reading a protobuf config, but this may only matter to me, so making the rest of the code less funky is a good trade-off.