### PR TITLE
refactor profile switching to be managed by the GP2040 object

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -42,7 +42,7 @@ public:
 	Gamepad();
 
 	void setup();
-	void teardown_and_reinit(const uint32_t profileNum);
+	void reinit();
 	void process();
 	void read();
 	void save();
@@ -156,6 +156,8 @@ public:
 	GamepadButtonMapping *mapButtonA1;
 	GamepadButtonMapping *mapButtonA2;
 	GamepadButtonMapping *mapButtonFn;
+
+	bool userRequestedReinit = false;
 
 	inline static const SOCDMode resolveSOCDMode(const GamepadOptions& options) {
 		 return (options.socdMode == SOCD_MODE_BYPASS &&

--- a/headers/gp2040.h
+++ b/headers/gp2040.h
@@ -51,6 +51,10 @@ private:
     };
     BootAction getBootAction();
 
+    // GPIO manipulation for setup and profile reinit
+    void initializeStandardGpio();
+    void deinitializeStandardGpio();
+
     // input mask, action
     std::map<uint32_t, int32_t> bootActions;
 };

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -68,7 +68,7 @@ public:
 	uint8_t * GetFeatureData();
 
 	void setProfile(const uint32_t);		// profile support for multiple mappings
-	void setFunctionalPinMappings(const uint32_t);
+	void setFunctionalPinMappings();
 
 	void ResetSettings(); 				// EEPROM Reset Feature
 

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -166,10 +166,8 @@ void Gamepad::setup()
 /**
  * @brief Undo setup().
  */
-void Gamepad::teardown_and_reinit(const uint32_t profileNum)
+void Gamepad::reinit()
 {
-	GpioAction* pinMappings = Storage::getInstance().getProfilePinMappings();
-
 	delete mapDpadUp;
 	delete mapDpadDown;
 	delete mapDpadLeft;
@@ -189,18 +187,6 @@ void Gamepad::teardown_and_reinit(const uint32_t profileNum)
 	delete mapButtonA1;
 	delete mapButtonA2;
 	delete mapButtonFn;
-
-	// deinitialize the GPIO pins so we don't have orphans
-	for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++)
-	{
-		if (pinMappings[pin] > 0)
-		{
-			gpio_deinit(pin);
-		}
-	}
-
-	// set to new profile
-	Storage::getInstance().setProfile(profileNum);
 
 	// reinitialize pin mappings
 	this->setup();
@@ -421,25 +407,29 @@ void Gamepad::processHotkeyIfNewAction(GamepadHotkey action)
 			break;
 		case HOTKEY_LOAD_PROFILE_1:
 			if (action != lastAction) {
-				this->teardown_and_reinit(1);
+				Storage::getInstance().setProfile(1);
+				userRequestedReinit = true;
 				reqSave = true;
 			}
 			break;
 		case HOTKEY_LOAD_PROFILE_2:
 			if (action != lastAction) {
-				this->teardown_and_reinit(2);
+				Storage::getInstance().setProfile(2);
+				userRequestedReinit = true;
 				reqSave = true;
 			}
 			break;
 		case HOTKEY_LOAD_PROFILE_3:
 			if (action != lastAction) {
-				this->teardown_and_reinit(3);
+				Storage::getInstance().setProfile(3);
+				userRequestedReinit = true;
 				reqSave = true;
 			}
 			break;
 		case HOTKEY_LOAD_PROFILE_4:
 			if (action != lastAction) {
-				this->teardown_and_reinit(4);
+				Storage::getInstance().setProfile(4);
+				userRequestedReinit = true;
 				reqSave = true;
 			}
 			break;

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -56,8 +56,9 @@ void GP2040::setup() {
 	}
 
     // Setup Gamepad and Gamepad Storage
-	Gamepad * gamepad = Storage::getInstance().GetGamepad();
-	gamepad->setup();
+    Gamepad * gamepad = Storage::getInstance().GetGamepad();
+    gamepad->setup();
+    this->initializeStandardGpio();
 
     const GamepadOptions& gamepadOptions = Storage::getInstance().getGamepadOptions();
 
@@ -141,6 +142,38 @@ void GP2040::setup() {
 	}
 }
 
+/**
+ * @brief Initialize standard input button GPIOs that are present in the currently loaded profile.
+ */
+void GP2040::initializeStandardGpio() {
+	GpioAction* pinMappings = Storage::getInstance().getProfilePinMappings();
+	for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++)
+	{
+		// (NONE=-10, RESERVED=-5, ASSIGNED_TO_ADDON=0, everything else is ours)
+		if (pinMappings[pin] > 0)
+		{
+			gpio_init(pin);             // Initialize pin
+			gpio_set_dir(pin, GPIO_IN); // Set as INPUT
+			gpio_pull_up(pin);          // Set as PULLUP
+		}
+	}
+}
+
+/**
+ * @brief Deinitialize standard input button GPIOs that are present in the currently loaded profile.
+ */
+void GP2040::deinitializeStandardGpio() {
+	GpioAction* pinMappings = Storage::getInstance().getProfilePinMappings();
+	for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++)
+	{
+		// (NONE=-10, RESERVED=-5, ASSIGNED_TO_ADDON=0, everything else is ours)
+		if (pinMappings[pin] > 0)
+		{
+			gpio_deinit(pin);
+		}
+	}
+}
+
 void GP2040::run() {
 	Gamepad * gamepad = Storage::getInstance().GetGamepad();
 	Gamepad * processedGamepad = Storage::getInstance().GetProcessedGamepad();
@@ -148,6 +181,29 @@ void GP2040::run() {
 	uint8_t * featureData = Storage::getInstance().GetFeatureData();
 	memset(featureData, 0, 32); // X-Input is the only feature data currently supported
 	while (1) { // LOOP
+		// check if we should reinitialize the gamepad
+		if (gamepad->userRequestedReinit) {
+			// deinitialize the ordinary (non-reserved, non-addon) GPIO pins, since
+			// we are moving off of them and onto potentially different pin assignments
+			// we currently don't support ASSIGNED_TO_ADDON pins being reinitialized,
+			// but if they were to be, that'd be the addon's duty, not ours
+			this->deinitializeStandardGpio();
+
+			// now we can load the latest configured profile, which will map the
+			// new set of GPIOs to use...
+			Storage::getInstance().setFunctionalPinMappings();
+
+			// ...and initialize the pins again
+			this->initializeStandardGpio();
+
+			// now we can tell the gamepad that the new mappings are in place
+			// and ready to use, and the pins are ready, so it should reinitialize itself
+			gamepad->reinit();
+
+			// and we're done
+			gamepad->userRequestedReinit = false;
+		}
+
 		Storage::getInstance().performEnqueuedSaves();
 		// Config Loop (Web-Config does not require gamepad)
 		if (configMode == true) {

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -47,7 +47,7 @@ Storage::Storage()
 	critical_section_init(&animationOptionsCs);
 	ConfigUtils::load(config);
 
-	setFunctionalPinMappings(config.gamepadOptions.profileNumber);
+	setFunctionalPinMappings();
 }
 
 bool Storage::save()
@@ -138,19 +138,17 @@ void Storage::ResetSettings()
 
 void Storage::setProfile(const uint32_t profileNum)
 {
-	if (profileNum < 1 || profileNum > 4) return;
-	setFunctionalPinMappings(profileNum);
-	this->config.gamepadOptions.profileNumber = profileNum;
+	this->config.gamepadOptions.profileNumber = (profileNum < 1 || profileNum > 4) ? 1 : profileNum;
 }
 
-void Storage::setFunctionalPinMappings(const uint32_t profileNum)
+void Storage::setFunctionalPinMappings()
 {
 	for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++) {
 		functionalPinMappings[pin] = this->config.gpioMappings.pins[pin].action;
 	}
-	if (profileNum < 2 || profileNum > 4) return;
+	if (config.gamepadOptions.profileNumber < 2 || config.gamepadOptions.profileNumber > 4) return;
 
-	AlternativePinMappings alts = this->config.profileOptions.alternativePinMappings[profileNum-2];
+	AlternativePinMappings alts = this->config.profileOptions.alternativePinMappings[config.gamepadOptions.profileNumber-2];
 
 	const auto reassignProfilePin = [&](Pin_t targetPin, GpioAction newAction) -> void {
 		// reassign the functional pin if:


### PR DESCRIPTION
GPIO fiddling was in the Gamepad object, which was fine, but it's going to make more sense in the future for the GP2040 object to manage it, since it has references to addons which will be affected by profile changes, pending another refactor.

this has us essentially initialize/deinitialize "normal" GPIO pins in the higher object and then gamepad and addons just need to worry about button masks or whatever, regardless of the pin initialization itself