### PR TITLE
Added PS4 report speed hack to web config

### DIFF
--- a/headers/gamepad/GamepadConfig.h
+++ b/headers/gamepad/GamepadConfig.h
@@ -21,6 +21,10 @@
 #define DEFAULT_PS4CONTROLLER_TYPE PS4_CONTROLLER
 #endif
 
+#ifndef DEFAULT_PS4_REPORTHACK
+#define DEFAULT_PS4_REPORTHACK false
+#endif 
+
 /* hotkeys */
 #ifndef HOTKEY_01_AUX_MASK
 #define HOTKEY_01_AUX_MASK 0

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -24,6 +24,7 @@ message GamepadOptions
     optional int32 inputModeL2 = 17;
     optional int32 inputModeR1 = 18;
     optional int32 inputModeR2 = 19;
+	optional bool ps4ReportHack = 20;
 }
 
 message KeyboardMapping

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -147,6 +147,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.gamepadOptions, inputModeL2, DEFAULT_INPUT_MODE_L2);
     INIT_UNSET_PROPERTY(config.gamepadOptions, inputModeR1, DEFAULT_INPUT_MODE_R1);
     INIT_UNSET_PROPERTY(config.gamepadOptions, inputModeR2, DEFAULT_INPUT_MODE_R2);
+    INIT_UNSET_PROPERTY(config.gamepadOptions, ps4ReportHack, DEFAULT_PS4_REPORTHACK);
 
     // hotkeyOptions
     HotkeyOptions& hotkeyOptions = config.hotkeyOptions;

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -652,6 +652,7 @@ std::string setGamepadOptions()
     readDoc(gamepadOptions.inputModeL2, doc, "inputModeL2");
     readDoc(gamepadOptions.inputModeR1, doc, "inputModeR1");
     readDoc(gamepadOptions.inputModeR2, doc, "inputModeR2");
+	readDoc(gamepadOptions.ps4ReportHack, doc, "ps4ReportHack");
 
 	HotkeyOptions& hotkeyOptions = Storage::getInstance().getHotkeyOptions();
 	save_hotkey(&hotkeyOptions.hotkey01, doc, "hotkey01");
@@ -701,6 +702,7 @@ std::string getGamepadOptions()
     writeDoc(doc, "inputModeL2", gamepadOptions.inputModeL2);
     writeDoc(doc, "inputModeR1", gamepadOptions.inputModeR1);
     writeDoc(doc, "inputModeR2", gamepadOptions.inputModeR2);
+	writeDoc(doc, "ps4ReportHack", gamepadOptions.ps4ReportHack ? 1 : 0);
 
 	writeDoc(doc, "fnButtonPin", -1);
 	GpioMappingInfo* gpioMappings = Storage::getInstance().getGpioMappings().pins;

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -938,7 +938,9 @@ PS4Report *Gamepad::getPS4Report()
 	ps4Report.button_touchpad = options.switchTpShareForDs4 ? pressedS1() : pressedA2();
 
 	// report counter is 6 bits
-	ps4Report.report_counter = last_report_counter;
+	if ( !options.ps4ReportHack ) {
+		ps4Report.report_counter = last_report_counter;
+	}
 
 	ps4Report.left_stick_x = static_cast<uint8_t>(state.lx >> 8);
 	ps4Report.left_stick_y = static_cast<uint8_t>(state.ly >> 8);
@@ -957,7 +959,9 @@ PS4Report *Gamepad::getPS4Report()
 	}
 
 	// axis counter is 16 bits
-	ps4Report.axis_timing = last_axis_counter;
+	if ( !options.ps4ReportHack ) {
+		ps4Report.axis_timing = last_axis_counter;
+	}
 
 	// set touchpad to nothing
 	touchpadData.p1.unpressed = 1;

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -937,9 +937,10 @@ PS4Report *Gamepad::getPS4Report()
 	ps4Report.button_home     = pressedA1();
 	ps4Report.button_touchpad = options.switchTpShareForDs4 ? pressedS1() : pressedA2();
 
-	// report counter is 6 bits
+	
 	if ( !options.ps4ReportHack ) {
-		ps4Report.report_counter = last_report_counter;
+		ps4Report.report_counter = last_report_counter; 	// report counter is 6 bits
+		ps4Report.axis_timing = last_axis_counter; 			// axis counter is 16 bits
 	}
 
 	ps4Report.left_stick_x = static_cast<uint8_t>(state.lx >> 8);
@@ -958,10 +959,7 @@ PS4Report *Gamepad::getPS4Report()
 		ps4Report.right_trigger = pressedR2() ? 0xFF : 0;
 	}
 
-	// axis counter is 16 bits
-	if ( !options.ps4ReportHack ) {
-		ps4Report.axis_timing = last_axis_counter;
-	}
+
 
 	// set touchpad to nothing
 	touchpadData.p1.unpressed = 1;

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -104,6 +104,7 @@ app.get('/api/getGamepadOptions', (req, res) => {
         inputModeL2: -1,
         inputModeR1: -1,
         inputModeR2: 3,
+		ps4ReportHack: 0,
 		hotkey01: {
 			auxMask: 32768,
 			buttonsMask: 66304,

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -2,6 +2,7 @@ export default {
 	'settings-header-text': 'Settings',
 	'input-mode-label': 'Input Mode',
 	'input-mode-extra-label': 'Switch Touchpad and Share',
+	'ps4-report-hack': 'PS4 Report Speed Hack',
 	'input-mode-options': {
         none: 'No Mode Selected',
 		xinput: 'XInput',

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -168,6 +168,10 @@ const schema = yup.object().shape({
 		.number()
 		.required()
 		.label('Switch Touchpad and Share'),
+	ps4ReportHack: yup
+		.number()
+		.required()
+		.label('PS4 Report Speed Hack'),
 	forcedSetupMode: yup
 		.number()
 		.required()
@@ -246,6 +250,8 @@ const FormContext = ({ setButtonLabels }) => {
 		if (!!values.socdMode) values.socdMode = parseInt(values.socdMode);
 		if (!!values.switchTpShareForDs4)
 			values.switchTpShareForDs4 = parseInt(values.switchTpShareForDs4);
+		if (!!values.ps4ReportHack)
+			values.ps4ReportHack = parseInt(values.ps4ReportHack);
 		if (!!values.forcedSetupMode)
 			values.forcedSetupMode = parseInt(values.forcedSetupMode);
 		if (!!values.lockHotkeys) values.lockHotkeys = parseInt(values.lockHotkeys);
@@ -413,55 +419,68 @@ export default function SettingsPage() {
 										</Form.Control.Feedback>
 									</div>
 									{values.inputMode === PS4Mode && (
-										<div className="col-sm-3">
-											<Form.Check
-												label={t('SettingsPage:input-mode-extra-label')}
-												type="switch"
-												name="switchTpShareForDs4"
-												isInvalid={false}
-												checked={Boolean(values.switchTpShareForDs4)}
-												onChange={(e) => {
-													setFieldValue(
-														'switchTpShareForDs4',
-														e.target.checked ? 1 : 0,
-													);
-												}}
-											/>
-										</div>
-									)}
-									{values.inputMode === PS4Mode && (
-										<div className="col-sm-3">
-											<Form.Select
-												name="ps4ControllerType"
-												className="form-select-sm"
-												value={values.ps4ControllerType}
-												onChange={handleChange}
-												isInvalid={errors.ps4ControllerType}
-											>
-												{translatedPS4ControllerTypeModes.map((o, i) => (
-													<option
-														key={`button-ps4ControllerType-option-${i}`}
-														value={o.value}
-													>
-														{o.label}
-													</option>
-												))}
-											</Form.Select>
-										</div>
-									)}
-									{values.inputMode === PS4Mode && (
-										<div className="mb-3">
-											<Trans
-												ns="SettingsPage"
-												i18nKey="ps4-compatibility-label"
-											>
-												For <strong>PS5 compatibility</strong>, use "Arcade
-												Stick" and enable PS Passthrough add-on
-												<br />
-												For <strong>PS4 support</strong>, use "Controller" and
-												enable PS4 Mode add-on if you have the necessary files
-											</Trans>
-										</div>
+										<Form className="row mb-3">
+											<div className="col-sm-3">
+												<Form.Check
+													label={t('SettingsPage:input-mode-extra-label')}
+													type="switch"
+													name="switchTpShareForDs4"
+													isInvalid={false}
+													checked={Boolean(values.switchTpShareForDs4)}
+													onChange={(e) => {
+														setFieldValue(
+															'switchTpShareForDs4',
+															e.target.checked ? 1 : 0,
+														);
+													}}
+												/>
+											</div>
+											<div className="col-sm-3">
+												<Form.Check
+													label={t('SettingsPage:ps4-report-hack')}
+													type="switch"
+													name="ps4ReportHack"
+													isInvalid={false}
+													checked={Boolean(values.ps4ReportHack)}
+													onChange={(e) => {
+														setFieldValue(
+															'ps4ReportHack',
+															e.target.checked ? 1 : 0,
+														);
+													}}
+												/>
+											</div>
+											<div className="col-sm-3">
+												<Form.Select
+													name="ps4ControllerType"
+													className="form-select-sm"
+													value={values.ps4ControllerType}
+													onChange={handleChange}
+													isInvalid={errors.ps4ControllerType}
+												>
+													{translatedPS4ControllerTypeModes.map((o, i) => (
+														<option
+															key={`button-ps4ControllerType-option-${i}`}
+															value={o.value}
+														>
+															{o.label}
+														</option>
+													))}
+												</Form.Select>
+											</div>
+											<div className="mb-3">
+												<Trans
+													ns="SettingsPage"
+													i18nKey="ps4-compatibility-label"
+												>
+													For <strong>PS5 compatibility</strong>, use "Arcade
+													Stick" and enable PS Passthrough add-on
+													<br />
+													For <strong>PS4 support</strong>, use "Controller" and
+													enable PS4 Mode add-on if you have the necessary files
+												</Trans>
+											</div>
+										</Form>
 									)}
 								</Form.Group>
 								<Form.Group className="row mb-3">


### PR DESCRIPTION
PS4 reporting is a hot topic.

This adds a switch to our web config so you can turn on a hack that disables report counters in the PS4/PS5 reports. This brings PS4/PS5 latency down to around 0.8ms, but could have potential instability in certain games.