### PR TITLE
Added information about hotkey access to webconfig and bootsel while controller is plugged in

### DIFF
--- a/site/docs/usage.mdx
+++ b/site/docs/usage.mdx
@@ -50,13 +50,13 @@ Unlike other controllers, Keyboard gets different keys for directional buttons. 
 
 Bootsel Mode is the state of the board where firmware can be flashed onto the board. You will need to use this whenever there is an update or as part of the troubleshooting process.
 
-You can boot into Bootsel Mode by either holding <Hotkey buttons={["S1", "S2", "Up"]}/> buttons while plugging in the controller or by booting into the Web Configurator and then restarting in Bootsel Mode.
+You can boot into Bootsel Mode by either holding <Hotkey buttons={["S1", "S2", "Up"]}/> buttons while plugging in the controller, by booting into the Web Configurator and then restarting in Bootsel Mode, or by holding <Hotkey buttons={["S2"]}/>, <Hotkey buttons={["B3"]}/>, and <Hotkey buttons={["B4"]}/> together for five seconds while the controller is plugged in. There is no way to leave Bootsel mode once activated other than by flashing new firmware or by unplugging the device.
 
 ## WebConfig Mode
 
 WebConfig Mode is the state of the board where built-in web browser-based configuration application is launched. From here, you can customize and configure your controller as needed. For more information, click [here](./web-configurator/web-configurator.mdx) for more information.
 
-You can boot into WebConfig Mode by holding the <Hotkey buttons={["S2"]}/> button while plugging in the controller.
+You can boot into WebConfig Mode by holding the <Hotkey buttons={["S2"]}/> button while plugging in the controller or by holding <Hotkey buttons={["S2"]}/>, <Hotkey buttons={["B3"]}/>, and <Hotkey buttons={["B4"]}/> together for five seconds while the controller is plugged in. Holding this same combination again for five seconds while in webconfig mode will swap the device back to the previously used controller mode.
 
 ## Input Modes
 

--- a/site/docs/web-configurator/web-configurator.mdx
+++ b/site/docs/web-configurator/web-configurator.mdx
@@ -18,7 +18,7 @@ Select the button labels to be displayed in the usage guide:
 <InputLabelSelector />
 <br />
 
-GP2040-CE contains a built-in web-based configuration application which can be started up by holding <Hotkey buttons={["S2"]}/> when plugging your controller into a PC. Then access <http://192.168.7.1> in a web browser to begin configuration.
+GP2040-CE contains a built-in web-based configuration application which can be started by holding <Hotkey buttons={["S2"]}/> when plugging your controller into a PC or by holding <Hotkey buttons={["S2"]}/>, <Hotkey buttons={["B3"]}/>, and <Hotkey buttons={["B4"]}/> together for five seconds while the controller is plugged in. Then access <http://192.168.7.1> in a web browser to begin configuration.
 
 This mode is compatible with Windows, Mac, Linux and SteamOS. Android and iOS devices are not supported at this time.
 


### PR DESCRIPTION
Made changes to documentation describing the hotkey combinations to access webconfig and bootsel while the controller is plugged in.