### PR TITLE
v0.7.6-RC2 FIX: Xbox One input-fix

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -90,6 +90,8 @@ public:
     PSClassicReport *getPSClassicReport();
     XboxOriginalReport *getXboxOriginalReport();
 
+	uint8_t last_report[CFG_TUD_ENDPOINT0_SIZE] = { };
+
 	/**
 	 * @brief Check for a button press. Used by `pressed[Button]` helper methods.
 	 */

--- a/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/tusb_driver.cpp
@@ -132,8 +132,8 @@ const usbd_class_driver_t *usbd_app_driver_get_cb(uint8_t *driver_count)
 			case INPUT_MODE_PS4:
 				return &ps4_driver;
 
-      case INPUT_MODE_XBOXORIGINAL:
-        return xid_get_driver();
+			case INPUT_MODE_XBOXORIGINAL:
+				return xid_get_driver();
 
 			case INPUT_MODE_XBONE:
 				return &xbone_driver;


### PR DESCRIPTION
In order to increment sequence on key press in Xbox One, we have to keep track of last report sent.

This is slightly tricky because report generation does not guarantee a report is sent.
- So, if our last report sent input != current report sent, set sequence for this report to +1 but don't increment.
- ON SUCCESS, increment report by 1 and update our last sent report.