### PR TITLE
Fix 4-way mode when enabled for both core gamepad and DDI

### DIFF
--- a/headers/addons/dualdirectional.h
+++ b/headers/addons/dualdirectional.h
@@ -56,6 +56,8 @@ public:
 private:
     void debounce();
     uint8_t gpadToBinary(DpadMode, GamepadState);
+    uint8_t updateDpadDDI(uint8_t dpad, DpadDirection direction);
+    uint8_t filterToFourWayModeDDI(uint8_t dpad);
     void SOCDDualClean(SOCDMode);
     uint8_t SOCDCombine(SOCDMode, uint8_t);
     uint8_t SOCDGamepadClean(uint8_t, bool isLastWin);


### PR DESCRIPTION
This fixes the misbehavior described in #559 item 3, where 4-way didn't work properly if it was enabled for both the core gamepad and DDI at the same time. @sirrow is the author, I have just pulled, reviewed, and tested it.

Fixes #559.