### PR TITLE
v0.7.6 FIX: deduplicate the PLED PWM GPIOs vs. RGB indexes

### DIFF
--- a/proto/config.proto
+++ b/proto/config.proto
@@ -259,6 +259,11 @@ message LEDOptions
 	optional uint32 pledColor = 30;
 
 	optional bool turnOffWhenSuspended = 31;
+
+	optional int32 pledIndex1 = 32;
+	optional int32 pledIndex2 = 33;
+	optional int32 pledIndex3 = 34;
+	optional int32 pledIndex4 = 35;
 };
 
 // This has to be kept in sync with AnimationOptions in AnimationStation.hpp

--- a/src/addons/neopicoleds.cpp
+++ b/src/addons/neopicoleds.cpp
@@ -177,15 +177,15 @@ void NeoPicoLEDAddon::process()
 	if (ledOptions.pledType == PLED_TYPE_RGB) {
 		if (inputMode == INPUT_MODE_XINPUT) { // HACK
 			LEDOptions & ledOptions = Storage::getInstance().getLedOptions();
-			int32_t pledPins[] = { ledOptions.pledPin1, ledOptions.pledPin2, ledOptions.pledPin3, ledOptions.pledPin4 };
+			int32_t pledIndexes[] = { ledOptions.pledIndex1, ledOptions.pledIndex2, ledOptions.pledIndex3, ledOptions.pledIndex4 };
 			for (int i = 0; i < PLED_COUNT; i++) {
-				if (pledPins[i] < 0)
+				if (pledIndexes[i] < 0)
 					continue;
 
 				float level = (static_cast<float>(PLED_MAX_LEVEL - neoPLEDs->getLedLevels()[i]) / static_cast<float>(PLED_MAX_LEVEL));
 				float brightness = as.GetBrightnessX() * level;
 				rgbPLEDValues[i] = ((RGB)ledOptions.pledColor).value(neopico->GetFormat(), brightness);
-				frame[pledPins[i]] = rgbPLEDValues[i];
+				frame[pledIndexes[i]] = rgbPLEDValues[i];
 			}
 		}
 	}

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -771,6 +771,10 @@ std::string setLedOptions()
 	docToPin(ledOptions.pledPin2, doc, "pledPin2");
 	docToPin(ledOptions.pledPin3, doc, "pledPin3");
 	docToPin(ledOptions.pledPin4, doc, "pledPin4");
+	readDoc(ledOptions.pledIndex1, doc, "pledIndex1");
+	readDoc(ledOptions.pledIndex2, doc, "pledIndex2");
+	readDoc(ledOptions.pledIndex3, doc, "pledIndex3");
+	readDoc(ledOptions.pledIndex4, doc, "pledIndex4");
 	readDoc(ledOptions.pledColor, doc, "pledColor");
 
 	Storage::getInstance().save();
@@ -823,6 +827,10 @@ std::string getLedOptions()
 	writeDoc(doc, "pledPin2", ledOptions.pledPin2);
 	writeDoc(doc, "pledPin3", ledOptions.pledPin3);
 	writeDoc(doc, "pledPin4", ledOptions.pledPin4);
+	writeDoc(doc, "pledIndex1", ledOptions.pledIndex1);
+	writeDoc(doc, "pledIndex2", ledOptions.pledIndex2);
+	writeDoc(doc, "pledIndex3", ledOptions.pledIndex3);
+	writeDoc(doc, "pledIndex4", ledOptions.pledIndex4);
 	writeDoc(doc, "pledColor", ((RGB)ledOptions.pledColor).value(LED_FORMAT_RGB));
 
 	return serialize_json(doc);

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -219,6 +219,10 @@ app.get('/api/getLedOptions', (req, res) => {
 		pledPin2: 13,
 		pledPin3: 14,
 		pledPin4: 15,
+		pledIndex1: 12,
+		pledIndex2: 13,
+		pledIndex3: 14,
+		pledIndex4: 15,
 		pledColor: 65280,
 		turnOffWhenSuspended: 0,
 	});

--- a/www/src/Pages/LEDConfigPage.jsx
+++ b/www/src/Pages/LEDConfigPage.jsx
@@ -205,10 +205,6 @@ const FormContext = ({
 				getLedButtons(buttonLabels, assigned, true, swapTpShareLabels),
 			];
 
-			data.pledIndex1 = data.pledType === 1 ? data.pledPin1 : -1;
-			data.pledIndex2 = data.pledType === 1 ? data.pledPin2 : -1;
-			data.pledIndex3 = data.pledType === 1 ? data.pledPin3 : -1;
-			data.pledIndex4 = data.pledType === 1 ? data.pledPin4 : -1;
 
 			setDataSources(dataSources);
 			setValues(data);
@@ -330,27 +326,6 @@ export default function LEDConfigPage() {
 		e.preventDefault();
 
 		values.pledType = parseInt(values.pledType);
-
-		// Consolidate PLED fields based on selected type
-		switch (values.pledType) {
-			case 0:
-				// PLED pin already set
-				break;
-
-			case 1:
-				values.pledPin1 = values.pledIndex1;
-				values.pledPin2 = values.pledIndex2;
-				values.pledPin3 = values.pledIndex3;
-				values.pledPin4 = values.pledIndex4;
-				break;
-
-			default:
-				values.pledPin1 = -1;
-				values.pledPin2 = -1;
-				values.pledPin3 = -1;
-				values.pledPin4 = -1;
-				break;
-		}
 
 		setValues(values);
 		handleSubmit();

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -297,12 +297,6 @@ async function getLedOptions(setLoading) {
 		setLoading(false);
 
 		response.data.pledColor = rgbIntToHex(response.data.pledColor) || '#ffffff';
-		if (response.data.pledType === 1) {
-			response.data.pledIndex1 = response.data.pledPin1;
-			response.data.pledIndex2 = response.data.pledPin2;
-			response.data.pledIndex3 = response.data.pledPin3;
-			response.data.pledIndex4 = response.data.pledPin4;
-		}
 
 		return response.data;
 	} catch (error) {
@@ -644,10 +638,6 @@ async function reboot(bootMode) {
 
 function sanitizeRequest(request) {
 	const newRequest = { ...request };
-	delete newRequest.pledIndex1;
-	delete newRequest.pledIndex2;
-	delete newRequest.pledIndex3;
-	delete newRequest.pledIndex4;
 	delete newRequest.usedPins;
 	return newRequest;
 }


### PR DESCRIPTION
I missed/lost track of the fact that pledPin1-4 are only true GPIOs in PWM mode, and RGB mode uses the same fields as generic indexes instead. this is of course a wreck for tracking in GpioMappings, so I added new pledIndex1-4 fields for use in RGB mode, letting pledPin1-4 be truly just for GPIO pin assignments in PWM mode (or set to -1 otherwise).

furthering the confusion, the web UI *already* referred to pledIndex1-4, just it copied the value of those states back and forth to/from pledPin1-4, so now that the API has those fields as real fields, I just had to remove the copying.

I don't have PLEDs so all I was able to test is that protobuf does what it should now, and only when PWM pins are set do they get reserved in GpioMappings. tested on a nuked board, with webconfig allowing for getting out of a bad state.