### PR TITLE
Validate addon settings when enabled

### DIFF
--- a/www/src/Contexts/AppContext.jsx
+++ b/www/src/Contexts/AppContext.jsx
@@ -15,16 +15,12 @@ yup.addMethod(yup.string, 'validateColor', function () {
 	);
 });
 
-const isEnabledValue = (value) => {
-	return Number.isInteger(value) && value > -1;
-}
-
 yup.addMethod(
 	yup.NumberSchema,
 	'validateSelectionWhenValue',
 	function (name, choices) {
 		return this.when(name, {
-			is: isEnabledValue,
+			is: 1,
 			then: () => this.required().oneOf(choices.map((o) => o.value)),
 			otherwise: () => yup.mixed().notRequired(),
 		});
@@ -33,7 +29,7 @@ yup.addMethod(
 
 yup.addMethod(yup.NumberSchema, 'validateNumberWhenValue', function (name) {
 	return this.when(name, {
-		is: isEnabledValue,
+		is: 1,
 		then: () => this.required(),
 		otherwise: () => yup.mixed().notRequired().strip(),
 	});
@@ -56,7 +52,7 @@ yup.addMethod(
 	'validateRangeWhenValue',
 	function (name, min, max) {
 		return this.when(name, {
-			is: isEnabledValue,
+			is: 1,
 			then: () => this.required().min(min).max(max),
 			otherwise: () => yup.mixed().notRequired().strip(),
 		});
@@ -77,7 +73,7 @@ yup.addMethod(
 
 yup.addMethod(yup.NumberSchema, 'validatePinWhenValue', function (name) {
 	return this.when(name, {
-		is: isEnabledValue,
+		is: 1,
 		then: () => this.checkUsedPins(),
 		otherwise: () => yup.mixed().notRequired().strip(),
 	})


### PR DESCRIPTION
Solves the issue of the addons page thinking all addons are enabled even when disabled.
Current we have this issue: 
<img width="404" alt="Skärmavbild 2024-01-02 kl  00 40 03" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/5345892/24d9dcff-8de2-43ef-84aa-09274bce3311">

The `is` check is always compared against the [checkbox/toggle](https://github.com/OpenStickCommunity/GP2040-CE/blob/aa48d716c654b55da66d0e955576d3844c832e5d/www/src/Pages/AddonsConfigPage.jsx#L204) value for the addon section, meaning it's either `1` or `0`
Yup validation for `is` does a strict equal hence not being able to do `is: true`

This change is equivalent to 
```javascript
is: (value) => value === 1
```
If we feel that is more explicit

More info: https://github.com/jquense/yup?tab=readme-ov-file#schemawhenkeys-string--string-builder-object--values-any-schema--schema-schema