### PR TITLE
Update to i2cdisplay defined values

### DIFF
--- a/headers/addons/i2cdisplay.h
+++ b/headers/addons/i2cdisplay.h
@@ -19,7 +19,7 @@
 #include "addons/inputhistory.h"
 
 #ifndef HAS_I2C_DISPLAY
-#define HAS_I2C_DISPLAY -1
+#define HAS_I2C_DISPLAY 0
 #endif
 
 #ifndef DISPLAY_I2C_ADDR


### PR DESCRIPTION
This PR updates i2cdisplay.h's `HAS_I2C_DISPLAY` to 0 which was current set as -1 and causing issues.

This was only discovered now that we are stripping unused instances of `HAS_I2C_DISPLAY` out of configs where not used.