### PR TITLE
Updated webconfig.cpp to fix flipping display bug

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -491,7 +491,7 @@ std::string getDisplayOptions() // Manually set Document Attributes for the disp
 	writeDoc(doc, "enabled", displayOptions.enabled ? 1 : 0);
 	writeDoc(doc, "i2cAddress", displayOptions.i2cAddress);
 	writeDoc(doc, "i2cBlock", displayOptions.i2cBlock);
-	writeDoc(doc, "flipDisplay", displayOptions.flip ? 1 : 0);
+	writeDoc(doc, "flipDisplay", displayOptions.flip);
 	writeDoc(doc, "invertDisplay", displayOptions.invert ? 1 : 0);
 	writeDoc(doc, "buttonLayout", displayOptions.buttonLayout);
 	writeDoc(doc, "buttonLayoutRight", displayOptions.buttonLayoutRight);


### PR DESCRIPTION
This update fixes a bug in webconfig.cpp which did not allow you to `mirror` or `mirror + flip` a display.  This is because originally we only had two values (`none` and `flip`) and they were set in webconfig.cpp as 0-1.  That has been removed and now all four modes can be used.