### PR TITLE
PS4 latency improvement: force occasional reports (with new counters) in PS4 mode to reduce the need for the PS4 Hack

### DIFF
--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -974,7 +974,8 @@ PS4Report *Gamepad::getPS4Report()
 	if ( !options.ps4ReportHack ) {
 		uint32_t now = to_ms_since_boot(get_absolute_time());
 		if ((now - keep_alive_timer) > PS4_KEEPALIVE_TIMER) {
-			ps4Report.report_counter = last_report_counter++;	// report counter is 6 bits
+			last_report_counter = (last_report_counter+1) & 0x3F;
+			ps4Report.report_counter = last_report_counter;		// report counter is 6 bits
 			ps4Report.axis_timing = now;		 		// axis counter is 16 bits
 			keep_alive_timer = now;
 		}

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -47,7 +47,7 @@ static HIDReport hidReport
 };
 
 // force a report to be sent every X ms
-#define PS4_KEEPALIVE_TIMER 17
+#define PS4_KEEPALIVE_TIMER 1000
 
 static PS4Report ps4Report
 {


### PR DESCRIPTION
~~This does some trickery with the report increments to use them to force a PS4 report roughly every 7ms (there's no particular design behind this value, it's just the result after I looked at some docs)~~ This puts a forced report with new counter values on a ~~17~~ 1000 ms timer, which fixes games that expect occasional reports, meaning we may not need the PS4 Hack anymore.

Shoutout to @TheTrainGoes for doing some quick latency testing. See the last comment for updated timer-based latency results, they are better than the old methodology anyway.

The latest results are virtually no increase over the measured 0.86 ms (in the README) for PS4 Hack mode, and considerably better than the 1.72 ms measured without the hack. A game thinking the inputs are stuck will have a new report every second to potentially correct itself, so this is converging on a sweet spot of game accuracy + low latency.