### PR TITLE
use if-else block logic instead of switch in jslider debouncer

### DIFF
--- a/src/addons/jslider.cpp
+++ b/src/addons/jslider.cpp
@@ -58,21 +58,14 @@ void JSliderInput::debounce()
     }
 
     uint32_t uNowTime = getMillis();
-
     if ((uNowTime - uDebTime) > JSLIDER_DEBOUNCE_MILLIS) {
-        switch (dpadState ^ dDebState)
-        {
-            // Bounce Right Analog
-            case DPAD_MODE_RIGHT_ANALOG:
-                dDebState = (DpadMode)(dDebState ^ DPAD_MODE_RIGHT_ANALOG);
-
-            // Bounce Left Analog
-            case DPAD_MODE_LEFT_ANALOG:
-                dDebState = (DpadMode)(dDebState ^ DPAD_MODE_LEFT_ANALOG);
-        }
+        if ( (dpadState ^ dDebState) == DPAD_MODE_RIGHT_ANALOG )
+            dDebState = (DpadMode)(dDebState ^ DPAD_MODE_RIGHT_ANALOG); // Bounce Right Analog
+        else if ( (dpadState ^ dDebState) & DPAD_MODE_LEFT_ANALOG )
+            dDebState = (DpadMode)(dDebState ^ DPAD_MODE_LEFT_ANALOG); // Bounce Left Analog
         uDebTime = uNowTime;
-        dpadState = dDebState;
     }
+    dpadState = dDebState;
 }
 
 void JSliderInput::process()


### PR DESCRIPTION
I'm not going to say we *understand* why this fixes #790, but it appears to.