### PR TITLE
Updated copyrights to 2024, moved copyrights for MIT over from feral …

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 OpenStickCommunity (gp2040-ce.info)
+Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
 Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/configs/BentoBox/BoardConfig.h
+++ b/configs/BentoBox/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/FightboardV3/BoardConfig.h
+++ b/configs/FightboardV3/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/FightboardV3Mirrored/BoardConfig.h
+++ b/configs/FightboardV3Mirrored/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/FlatboxRev4/BoardConfig.h
+++ b/configs/FlatboxRev4/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef FLATBOX_REV4_CONFIG_H_

--- a/configs/FlatboxRev5/BoardConfig.h
+++ b/configs/FlatboxRev5/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef FLATBOX_REV5_CONFIG_H_

--- a/configs/FlatboxRev5RGB/BoardConfig.h
+++ b/configs/FlatboxRev5RGB/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef FLATBOX_REV5_RGB_CONFIG_H_

--- a/configs/FlatboxRev5Southpaw/BoardConfig.h
+++ b/configs/FlatboxRev5Southpaw/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef FLATBOX_REV5_CONFIG_H_

--- a/configs/Haute42/BoardConfig.h
+++ b/configs/Haute42/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/KB2040/BoardConfig.h
+++ b/configs/KB2040/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/KeyboardConverter/BoardConfig.h
+++ b/configs/KeyboardConverter/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/Mavercade/BoardConfig.h
+++ b/configs/Mavercade/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef MAVERCADE_CONFIG_H_

--- a/configs/OpenCore0/BoardConfig.h
+++ b/configs/OpenCore0/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/OpenCore0WASD/BoardConfig.h
+++ b/configs/OpenCore0WASD/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/PicoFightingBoard/BoardConfig.h
+++ b/configs/PicoFightingBoard/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/PicoW/BoardConfig.h
+++ b/configs/PicoW/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICOW_BOARD_CONFIG_H_

--- a/configs/RP2040AdvancedBreakoutBoard/BoardConfig.h
+++ b/configs/RP2040AdvancedBreakoutBoard/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/RP2040AdvancedBreakoutBoardUSBPassthrough/BoardConfig.h
+++ b/configs/RP2040AdvancedBreakoutBoardUSBPassthrough/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/RP2040MiniBreakoutBoard/BoardConfig.h
+++ b/configs/RP2040MiniBreakoutBoard/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/RanaTadpole/BoardConfig.h
+++ b/configs/RanaTadpole/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/ReflexCtrlSNES/BoardConfig.h
+++ b/configs/ReflexCtrlSNES/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/ReflexEncodeV1.2/BoardConfig.h
+++ b/configs/ReflexEncodeV1.2/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/ReflexEncodeV2.0/BoardConfig.h
+++ b/configs/ReflexEncodeV2.0/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/SGFBridget/BoardConfig.h
+++ b/configs/SGFBridget/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef SGF_DEVICES_CONFIG_H_

--- a/configs/SGFFaust/BoardConfig.h
+++ b/configs/SGFFaust/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef SGF_FAUST_CONFIG_H_

--- a/configs/Stress/BoardConfig.h
+++ b/configs/Stress/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/configs/WaveshareZero/BoardConfig.h
+++ b/configs/WaveshareZero/BoardConfig.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef PICO_BOARD_CONFIG_H_

--- a/headers/addons/i2cdisplay.h
+++ b/headers/addons/i2cdisplay.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef DISPLAY_H_

--- a/headers/gamepad/descriptors/AstroDescriptors.h
+++ b/headers/gamepad/descriptors/AstroDescriptors.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/headers/gamepad/descriptors/EgretDescriptors.h
+++ b/headers/gamepad/descriptors/EgretDescriptors.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/headers/gamepad/descriptors/NeogeoDescriptors.h
+++ b/headers/gamepad/descriptors/NeogeoDescriptors.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/headers/gamepad/descriptors/PCEngineDescriptors.h
+++ b/headers/gamepad/descriptors/PCEngineDescriptors.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/headers/gamepad/descriptors/PS4Descriptors.h
+++ b/headers/gamepad/descriptors/PS4Descriptors.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/headers/gamepad/descriptors/PSClassicDescriptors.h
+++ b/headers/gamepad/descriptors/PSClassicDescriptors.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/headers/gamepad/descriptors/XBOneDescriptors.h
+++ b/headers/gamepad/descriptors/XBOneDescriptors.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2023 OpenStickCommunity (gp2040-ce.info)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/headers/gp2040.h
+++ b/headers/gp2040.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef GP2040_H_

--- a/headers/gp2040aux.h
+++ b/headers/gp2040aux.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef GP2040CORE1_H_

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -1,6 +1,6 @@
  /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #ifndef STORAGE_H_

--- a/lib/TinyUSB_Gamepad/src/ps4_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/ps4_driver.cpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #include "ps4_driver.h"

--- a/lib/TinyUSB_Gamepad/src/ps4_driver.h
+++ b/lib/TinyUSB_Gamepad/src/ps4_driver.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/lib/TinyUSB_Gamepad/src/xbone_driver.cpp
+++ b/lib/TinyUSB_Gamepad/src/xbone_driver.cpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #include "xbone_driver.h"

--- a/lib/TinyUSB_Gamepad/src/xbone_driver.h
+++ b/lib/TinyUSB_Gamepad/src/xbone_driver.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #pragma once

--- a/lib/TinyUSB_Gamepad/src/xgip_protocol.cpp
+++ b/lib/TinyUSB_Gamepad/src/xgip_protocol.cpp
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 OpenStickCommunity (gp2040-ce.info)
+ * Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/TinyUSB_Gamepad/src/xgip_protocol.h
+++ b/lib/TinyUSB_Gamepad/src/xgip_protocol.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 OpenStickCommunity (gp2040-ce.info)
+ * Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/TinyUSB_Gamepad/src/xinput_host.h
+++ b/lib/TinyUSB_Gamepad/src/xinput_host.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 OpenStickCommunity (gp2040-ce.info)
+ * Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/addons/i2cdisplay.cpp
+++ b/src/addons/i2cdisplay.cpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #include "addons/i2cdisplay.h"

--- a/src/addons/ps4mode.cpp
+++ b/src/addons/ps4mode.cpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #include "addons/ps4mode.h"

--- a/src/gamepad/GamepadDebouncer.cpp
+++ b/src/gamepad/GamepadDebouncer.cpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #include "gamepad/GamepadDebouncer.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 // Pi Pico includes

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: MIT
- * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
  */
 
 #include "storagemanager.h"


### PR DESCRIPTION
Moved copyrights for MIT over from feral to OpenStickCommunity for files we know we created (legacy from copy-paste of old project).