### PR TITLE
Custom theme pressed color variable fade

### DIFF
--- a/lib/AnimationStation/src/Animation.cpp
+++ b/lib/AnimationStation/src/Animation.cpp
@@ -5,8 +5,8 @@ LEDFormat Animation::format;
 Animation::Animation(PixelMatrix &matrix) : matrix(&matrix) {
 }
 
-void Animation::UpdatePixels(std::vector<Pixel> pixels) {
-  this->pixels = pixels;
+void Animation::UpdatePixels(std::vector<Pixel> inpixels) {
+  this->pixels = inpixels;
 }
 
 void Animation::ClearPixels() {

--- a/lib/AnimationStation/src/Animation.hpp
+++ b/lib/AnimationStation/src/Animation.hpp
@@ -105,7 +105,7 @@ inline const std::vector<RGB> colors {
 class Animation {
 public:
   Animation(PixelMatrix &matrix);
-  void UpdatePixels(std::vector<Pixel> pixels);
+  virtual void UpdatePixels(std::vector<Pixel> pixels);
   void ClearPixels();
   virtual ~Animation(){};
 

--- a/lib/AnimationStation/src/AnimationStation.cpp
+++ b/lib/AnimationStation/src/AnimationStation.cpp
@@ -89,6 +89,7 @@ uint16_t AnimationStation::AdjustIndex(int changeSize) {
 
 void AnimationStation::HandlePressed(std::vector<Pixel> pressed) {
   this->lastPressed = pressed;
+  this->baseAnimation->UpdatePixels(pressed);  
   this->buttonAnimation->UpdatePixels(pressed);
 }
 
@@ -96,6 +97,10 @@ void AnimationStation::ClearPressed() {
   if (this->buttonAnimation != nullptr) {
     this->buttonAnimation->ClearPixels();
   }
+  if (this->baseAnimation != nullptr) {
+    this->baseAnimation->ClearPixels();
+  }
+
   this->lastPressed.clear();
 }
 

--- a/lib/AnimationStation/src/AnimationStation.hpp
+++ b/lib/AnimationStation/src/AnimationStation.hpp
@@ -88,6 +88,7 @@ struct __attribute__ ((__packed__)) AnimationOptions
   uint32_t customThemeR3Pressed;
   uint32_t customThemeA1Pressed;
   uint32_t customThemeA2Pressed;
+  uint32_t customThemeCooldownTimeInMs;  
 };
 
 class AnimationStation

--- a/lib/AnimationStation/src/Effects/CustomTheme.cpp
+++ b/lib/AnimationStation/src/Effects/CustomTheme.cpp
@@ -1,41 +1,106 @@
 #include "CustomTheme.hpp"
 
 std::map<uint32_t, RGB> CustomTheme::theme;
+std::map<uint32_t, int32_t> CustomTheme::times = {};
+std::map<uint32_t, RGB> CustomTheme::hitColor = {};
 
 CustomTheme::CustomTheme(PixelMatrix &matrix) : Animation(matrix) {
+    for (size_t r = 0; r != matrix.pixels.size(); r++) {
+        for (size_t c = 0; c != matrix.pixels[r].size(); c++) {
+            if (matrix.pixels[r][c].index == NO_PIXEL.index)
+                continue;
+            times.insert_or_assign(matrix.pixels[r][c].index, 0);
+        }
+    }
+}
 
+void CustomTheme::UpdatePixels(std::vector<Pixel> inpixels) {
+  this->pixels = inpixels;
 }
 
 void CustomTheme::Animate(RGB (&frame)[100]) {
-  for (size_t r = 0; r != matrix->pixels.size(); r++) {
-    for (size_t c = 0; c != matrix->pixels[r].size(); c++) {
-      if (matrix->pixels[r][c].index == NO_PIXEL.index)
-        continue;
 
-      auto itr = theme.find(matrix->pixels[r][c].mask);
-      if (itr != theme.end())
-        for (size_t p = 0; p != matrix->pixels[r][c].positions.size(); p++)
-          frame[matrix->pixels[r][c].positions[p]] = itr->second;
-      else
-        for (size_t p = 0; p != matrix->pixels[r][c].positions.size(); p++)
-          frame[matrix->pixels[r][c].positions[p]] = defaultColor;
+    coolDownTimeInMs = AnimationStation::options.customThemeCooldownTimeInMs;
+
+    for (size_t p = 0; p < pixels.size(); p++) {
+        if (pixels[p].index != NO_PIXEL.index) {
+            hitColor[pixels[p].index] = frame[pixels[p].positions[0]];
+            times[pixels[p].index] = coolDownTimeInMs;            
+        }
     }
-  }
+
+    if (!time_reached(this->nextRunTime)) {
+        return;
+    }
+
+
+    for (size_t r = 0; r != matrix->pixels.size(); r++) {
+        for (size_t c = 0; c != matrix->pixels[r].size(); c++) {
+            if (matrix->pixels[r][c].index == NO_PIXEL.index)
+                continue;
+
+            auto itr = theme.find(matrix->pixels[r][c].mask);
+            if (itr != theme.end()) {
+                for (size_t p = 0; p != matrix->pixels[r][c].positions.size(); p++) {
+                    
+                    // Count down the timer
+                    times[matrix->pixels[r][c].index]-=updateTimeInms;
+                    if (times[matrix->pixels[r][c].index] < 0) {
+                        times[matrix->pixels[r][c].index] = 0;
+                    };
+
+                    // Interpolate from hitColor (color the button was assigned when pressed) back to the theme color
+                    frame[matrix->pixels[r][c].positions[p]] = BlendColor(hitColor[matrix->pixels[r][c].index], itr->second, times[matrix->pixels[r][c].index]);
+                }
+            } else {
+                for (size_t p = 0; p != matrix->pixels[r][c].positions.size(); p++) {
+                    frame[matrix->pixels[r][c].positions[p]] = defaultColor;
+                }
+            }
+        }
+    }
+
+    this->nextRunTime = make_timeout_time_ms(updateTimeInms);
 }
 
 bool CustomTheme::HasTheme() {
-  return CustomTheme::theme.size() > 0;
+    return CustomTheme::theme.size() > 0;
 }
 
 void CustomTheme::SetCustomTheme(std::map<uint32_t, RGB> customTheme) {
-  CustomTheme::theme = customTheme;
-  AnimationStation::effectCount = TOTAL_EFFECTS + 1;
+    CustomTheme::theme = customTheme;
+    AnimationStation::effectCount = TOTAL_EFFECTS + 1;
 }
 
+#define PRESS_COOLDOWN_INCREMENT   500
+#define PRESS_COOLDOWN_MAX         10000
+#define PRESS_COOLDOWN_MIN         10
+ 
 void CustomTheme::ParameterUp() {
-
+    if (AnimationStation::options.customThemeCooldownTimeInMs + PRESS_COOLDOWN_INCREMENT < PRESS_COOLDOWN_MAX) {
+        AnimationStation::options.customThemeCooldownTimeInMs = AnimationStation::options.customThemeCooldownTimeInMs + PRESS_COOLDOWN_INCREMENT;
+    } else {
+        AnimationStation::options.customThemeCooldownTimeInMs = PRESS_COOLDOWN_MAX;
+    }
 }
 
 void CustomTheme::ParameterDown() {
+    if (AnimationStation::options.customThemeCooldownTimeInMs - PRESS_COOLDOWN_INCREMENT > PRESS_COOLDOWN_MIN) {
+        AnimationStation::options.customThemeCooldownTimeInMs = AnimationStation::options.customThemeCooldownTimeInMs - PRESS_COOLDOWN_INCREMENT;
+    } else {
+        AnimationStation::options.customThemeCooldownTimeInMs = PRESS_COOLDOWN_MIN;
+    }
+}
 
+RGB CustomTheme::BlendColor(RGB start, RGB end, uint32_t frame) {
+    RGB result = ColorBlack;
+    float progress = 1.0f - (static_cast<float>(frame) / static_cast<float>(coolDownTimeInMs));
+    if (progress < 0.0f) progress = 0.0f;
+    if (progress > 1.0f) progress = 1.0f;
+
+    result.r = static_cast<uint32_t>(static_cast<float>(start.r + (end.r - start.r) * progress));
+    result.g = static_cast<uint32_t>(static_cast<float>(start.g + (end.g - start.g) * progress));
+    result.b = static_cast<uint32_t>(static_cast<float>(start.b + (end.b - start.b) * progress));
+
+    return result;
 }

--- a/lib/AnimationStation/src/Effects/CustomTheme.cpp
+++ b/lib/AnimationStation/src/Effects/CustomTheme.cpp
@@ -1,5 +1,9 @@
 #include "CustomTheme.hpp"
 
+#define PRESS_COOLDOWN_INCREMENT   500
+#define PRESS_COOLDOWN_MAX         5000
+#define PRESS_COOLDOWN_MIN         0
+
 std::map<uint32_t, RGB> CustomTheme::theme;
 std::map<uint32_t, int32_t> CustomTheme::times = {};
 std::map<uint32_t, RGB> CustomTheme::hitColor = {};
@@ -20,8 +24,11 @@ void CustomTheme::UpdatePixels(std::vector<Pixel> inpixels) {
 }
 
 void CustomTheme::Animate(RGB (&frame)[100]) {
-
     coolDownTimeInMs = AnimationStation::options.customThemeCooldownTimeInMs;
+
+    absolute_time_t currentTime = get_absolute_time();
+    int64_t updateTimeInMs = absolute_time_diff_us(lastUpdateTime, currentTime) / 1000;
+    lastUpdateTime = currentTime;
 
     for (size_t p = 0; p < pixels.size(); p++) {
         if (pixels[p].index != NO_PIXEL.index) {
@@ -30,15 +37,13 @@ void CustomTheme::Animate(RGB (&frame)[100]) {
         }
     }
 
-    updateTimeInms = absolute_time_diff_us(lastUpdateTime, get_absolute_time()) / 1000;
-
     for (size_t r = 0; r != matrix->pixels.size(); r++) {
         for (size_t c = 0; c != matrix->pixels[r].size(); c++) {
             if (matrix->pixels[r][c].index == NO_PIXEL.index)
                 continue;
 
             // Count down the timer
-            times[matrix->pixels[r][c].index] -= updateTimeInms;
+            times[matrix->pixels[r][c].index] -= updateTimeInMs;
             if (times[matrix->pixels[r][c].index] < 0) {
                 times[matrix->pixels[r][c].index] = 0;
             };
@@ -56,8 +61,6 @@ void CustomTheme::Animate(RGB (&frame)[100]) {
             }
         }
     }
-
-    lastUpdateTime = get_absolute_time();
 }
 
 bool CustomTheme::HasTheme() {
@@ -68,10 +71,6 @@ void CustomTheme::SetCustomTheme(std::map<uint32_t, RGB> customTheme) {
     CustomTheme::theme = customTheme;
     AnimationStation::effectCount = TOTAL_EFFECTS + 1;
 }
-
-#define PRESS_COOLDOWN_INCREMENT   500
-#define PRESS_COOLDOWN_MAX         5000
-#define PRESS_COOLDOWN_MIN         0
 
 void CustomTheme::ParameterUp() {
     AnimationStation::options.customThemeCooldownTimeInMs = AnimationStation::options.customThemeCooldownTimeInMs + PRESS_COOLDOWN_INCREMENT;

--- a/lib/AnimationStation/src/Effects/CustomTheme.hpp
+++ b/lib/AnimationStation/src/Effects/CustomTheme.hpp
@@ -26,8 +26,9 @@ protected:
 
   RGB BlendColor(RGB start, RGB end, uint32_t frame);
 
-  absolute_time_t nextRunTime = nil_time;
-  uint32_t updateTimeInms = 20;
+  absolute_time_t lastUpdateTime = nil_time;
+
+  uint32_t updateTimeInms = 10;
   uint32_t coolDownTimeInMs = 1000;
 
 };

--- a/lib/AnimationStation/src/Effects/CustomTheme.hpp
+++ b/lib/AnimationStation/src/Effects/CustomTheme.hpp
@@ -8,16 +8,28 @@
 class CustomTheme : public Animation {
 public:
   CustomTheme(PixelMatrix &matrix);
-  ~CustomTheme() {};
+  ~CustomTheme() {  };
 
   static bool HasTheme();
   static void SetCustomTheme(std::map<uint32_t, RGB> customTheme);
+  virtual void UpdatePixels(std::vector<Pixel> pixels);
   void Animate(RGB (&frame)[100]);
   void ParameterUp();
   void ParameterDown();
 protected:
   RGB defaultColor = ColorBlack;
   static std::map<uint32_t, RGB> theme;
+  
+  // timers per button
+  static std::map<uint32_t, int32_t> times;
+  static std::map<uint32_t, RGB> hitColor;    
+
+  RGB BlendColor(RGB start, RGB end, uint32_t frame);
+
+  absolute_time_t nextRunTime = nil_time;
+  uint32_t updateTimeInms = 20;
+  uint32_t coolDownTimeInMs = 1000;
+
 };
 
 #endif

--- a/lib/AnimationStation/src/Effects/CustomTheme.hpp
+++ b/lib/AnimationStation/src/Effects/CustomTheme.hpp
@@ -28,7 +28,6 @@ protected:
 
   absolute_time_t lastUpdateTime = nil_time;
 
-  uint32_t updateTimeInms = 10;
   uint32_t coolDownTimeInMs = 1000;
 
 };

--- a/lib/AnimationStation/src/Effects/CustomThemePressed.hpp
+++ b/lib/AnimationStation/src/Effects/CustomThemePressed.hpp
@@ -14,7 +14,6 @@ public:
 
   static bool HasTheme();
   static void SetCustomTheme(std::map<uint32_t, RGB> customTheme);
-  void UpdatePixels(std::vector<Pixel> pixels);
   void Animate(RGB (&frame)[100]);
   void ParameterUp() { }
   void ParameterDown() { }

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -314,6 +314,7 @@ message AnimationOptions_Proto
 	optional uint32 customThemeR3Pressed = 42;
 	optional uint32 customThemeA1Pressed = 43;
 	optional uint32 customThemeA2Pressed = 44;
+	optional uint32 customThemeCooldownTimeInMs = 45;  	
 }
 
 message BootselButtonOptions

--- a/src/config_legacy.cpp
+++ b/src/config_legacy.cpp
@@ -398,6 +398,7 @@ namespace ConfigLegacy
         uint32_t customThemeR3Pressed;
         uint32_t customThemeA1Pressed;
         uint32_t customThemeA2Pressed;
+        uint32_t customThemeCooldownTimeInMs;        
     };
 
     struct BoardOptions
@@ -936,6 +937,7 @@ bool ConfigUtils::fromLegacyStorage(Config& config)
         SET_PROPERTY(animationOptions, customThemeR3Pressed, legacyAnimationOptions.customThemeR3Pressed);
         SET_PROPERTY(animationOptions, customThemeA1Pressed, legacyAnimationOptions.customThemeA1Pressed);
         SET_PROPERTY(animationOptions, customThemeA2Pressed, legacyAnimationOptions.customThemeA2Pressed);
+        SET_PROPERTY(animationOptions, customThemeCooldownTimeInMs, legacyAnimationOptions.customThemeCooldownTimeInMs);        
     }
 
     const ConfigLegacy::AddonOptions& legacyAddonOptions = *reinterpret_cast<ConfigLegacy::AddonOptions*>(EEPROM_ADDRESS_START + ADDON_STORAGE_INDEX);

--- a/src/config_legacy.cpp
+++ b/src/config_legacy.cpp
@@ -397,8 +397,7 @@ namespace ConfigLegacy
         uint32_t customThemeL3Pressed;
         uint32_t customThemeR3Pressed;
         uint32_t customThemeA1Pressed;
-        uint32_t customThemeA2Pressed;
-        uint32_t customThemeCooldownTimeInMs;        
+        uint32_t customThemeA2Pressed;    
     };
 
     struct BoardOptions
@@ -936,8 +935,7 @@ bool ConfigUtils::fromLegacyStorage(Config& config)
         SET_PROPERTY(animationOptions, customThemeL3Pressed, legacyAnimationOptions.customThemeL3Pressed);
         SET_PROPERTY(animationOptions, customThemeR3Pressed, legacyAnimationOptions.customThemeR3Pressed);
         SET_PROPERTY(animationOptions, customThemeA1Pressed, legacyAnimationOptions.customThemeA1Pressed);
-        SET_PROPERTY(animationOptions, customThemeA2Pressed, legacyAnimationOptions.customThemeA2Pressed);
-        SET_PROPERTY(animationOptions, customThemeCooldownTimeInMs, legacyAnimationOptions.customThemeCooldownTimeInMs);        
+        SET_PROPERTY(animationOptions, customThemeA2Pressed, legacyAnimationOptions.customThemeA2Pressed);    
     }
 
     const ConfigLegacy::AddonOptions& legacyAddonOptions = *reinterpret_cast<ConfigLegacy::AddonOptions*>(EEPROM_ADDRESS_START + ADDON_STORAGE_INDEX);

--- a/src/config_legacy.cpp
+++ b/src/config_legacy.cpp
@@ -397,7 +397,7 @@ namespace ConfigLegacy
         uint32_t customThemeL3Pressed;
         uint32_t customThemeR3Pressed;
         uint32_t customThemeA1Pressed;
-        uint32_t customThemeA2Pressed;    
+        uint32_t customThemeA2Pressed;
     };
 
     struct BoardOptions

--- a/src/config_legacy.cpp
+++ b/src/config_legacy.cpp
@@ -935,7 +935,7 @@ bool ConfigUtils::fromLegacyStorage(Config& config)
         SET_PROPERTY(animationOptions, customThemeL3Pressed, legacyAnimationOptions.customThemeL3Pressed);
         SET_PROPERTY(animationOptions, customThemeR3Pressed, legacyAnimationOptions.customThemeR3Pressed);
         SET_PROPERTY(animationOptions, customThemeA1Pressed, legacyAnimationOptions.customThemeA1Pressed);
-        SET_PROPERTY(animationOptions, customThemeA2Pressed, legacyAnimationOptions.customThemeA2Pressed);    
+        SET_PROPERTY(animationOptions, customThemeA2Pressed, legacyAnimationOptions.customThemeA2Pressed);
     }
 
     const ConfigLegacy::AddonOptions& legacyAddonOptions = *reinterpret_cast<ConfigLegacy::AddonOptions*>(EEPROM_ADDRESS_START + ADDON_STORAGE_INDEX);

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -485,6 +485,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.animationOptions, customThemeR3Pressed, 0);
     INIT_UNSET_PROPERTY(config.animationOptions, customThemeA1Pressed, 0);
     INIT_UNSET_PROPERTY(config.animationOptions, customThemeA2Pressed, 0);
+    INIT_UNSET_PROPERTY(config.animationOptions, customThemeCooldownTimeInMs, 0);
 
     // addonOptions.bootselButtonOptions
     INIT_UNSET_PROPERTY(config.addonOptions.bootselButtonOptions, enabled, !!BOOTSEL_BUTTON_ENABLED);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -889,7 +889,12 @@ std::string setCustomTheme()
 	options.customThemeR3Pressed	= readDocDefaultToZero("R3", "d");
 	options.customThemeA1Pressed	= readDocDefaultToZero("A1", "d");
 	options.customThemeA2Pressed	= readDocDefaultToZero("A2", "d");
+	
+	uint32_t pressCooldown = 0;
+	readDoc(pressCooldown, doc, "customThemeCooldownTimeInMs");
+	options.customThemeCooldownTimeInMs = pressCooldown;
 
+	 
 	AnimationStation::SetOptions(options);
 	AnimationStore.save();
 
@@ -938,6 +943,7 @@ std::string getCustomTheme()
 	writeDoc(doc, "L3", "d", options.customThemeL3Pressed);
 	writeDoc(doc, "R3", "u", options.customThemeR3);
 	writeDoc(doc, "R3", "d", options.customThemeR3Pressed);
+	writeDoc(doc, "customThemeCooldownTimeInMs", options.customThemeCooldownTimeInMs);
 
 	return serialize_json(doc);
 }

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -894,7 +894,6 @@ std::string setCustomTheme()
 	readDoc(pressCooldown, doc, "customThemeCooldownTimeInMs");
 	options.customThemeCooldownTimeInMs = pressCooldown;
 
-	 
 	AnimationStation::SetOptions(options);
 	AnimationStore.save();
 

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -103,6 +103,7 @@ static void updateAnimationOptionsProto(const AnimationOptions& options)
 	optionsProto.customThemeA2Pressed		= options.customThemeA2Pressed;
 	optionsProto.customThemeL3Pressed		= options.customThemeL3Pressed;
 	optionsProto.customThemeR3Pressed		= options.customThemeR3Pressed;
+	optionsProto.customThemeCooldownTimeInMs = options.customThemeCooldownTimeInMs;	
 }
 
 void Storage::performEnqueuedSaves()
@@ -261,6 +262,7 @@ AnimationOptions AnimationStorage::getAnimationOptions()
 	options.customThemeA2Pressed	= optionsProto.customThemeA2Pressed;
 	options.customThemeL3Pressed	= optionsProto.customThemeL3Pressed;
 	options.customThemeR3Pressed	= optionsProto.customThemeR3Pressed;
+	options.customThemeCooldownTimeInMs = optionsProto.customThemeCooldownTimeInMs;		
 
 	return options;
 }


### PR DESCRIPTION
The Custom theme now supports blending the pressed color back into the regular color.  
https://discord.com/channels/1049366310389289001/1049370387563163731/1197730363015962844

Use parameter up/down (S1+S1+(R1/R2)) to increase or decrease the fade.   Defaults to 0ms blend which is the current behaviour.