### PR TITLE
Fix for Xbox One / USB Host Soft-Reboot

### DIFF
--- a/headers/usbhostmanager.h
+++ b/headers/usbhostmanager.h
@@ -22,8 +22,8 @@ public:
 		static USBHostManager instance; // Guaranteed to be destroyed. // Instantiated on first use.
 		return instance;
 	}
-    void setDataPin(uint8_t); // start USB host (change CPU, setup PIO PICO usb pin)
-    void start();
+    void start();               // Start USB Host
+    void shutdown();            // Called on system reboot
     void pushAddon(USBAddon *); // If anything needs to update in the gpconfig driver
     void process();
     void hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1,5 +1,7 @@
 #include "system.h"
 
+#include "usbhostmanager.h"
+
 #include <hardware/flash.h>
 #include <hardware/sync.h>
 #include <hardware/watchdog.h>
@@ -41,6 +43,9 @@ uint32_t System::getUsedHeap() {
 }
 
 void System::reboot(BootMode bootMode) {
+    // Halt all running USB instances
+    USBHostManager::getInstance().shutdown();
+
     // Make sure that the other core is halted
     // We do not want it to be talking to devices (e.g. OLED display) while we reboot
 	multicore_lockout_start_timeout_us(0xfffffffffffffff);

--- a/src/usbhostmanager.cpp
+++ b/src/usbhostmanager.cpp
@@ -10,10 +10,6 @@
 
 #include "xinput_host.h"
 
-void USBHostManager::setDataPin(uint8_t inPin) {
-    dataPin = inPin;
-}
-
 void USBHostManager::start() {
     // This will happen after Gamepad has initialized
     if ( !addons.empty() ) {
@@ -23,6 +19,15 @@ void USBHostManager::start() {
             tuh_init(BOARD_TUH_RHPORT);
             sleep_us(10); // ensure we are ready
             tuh_ready = true;
+        }
+    }
+}
+
+// Shut down the USB bus if we are running USB right now
+void USBHostManager::shutdown() {
+    if ( !addons.empty() ) {
+        if (PeripheralManager::getInstance().isUSBEnabled(0)) {
+            tuh_rhport_reset_bus(BOARD_TUH_RHPORT, false);
         }
     }
 }


### PR DESCRIPTION
This fixes the first-boot and reboot issues we were seeing on Xbox One with the dongle plugged in. We have to tell TinyUSB Host to shut down the bus/port before we perform the soft reeboot.

Added a shutdown() feature to USB Host Manager to take care of Controller -> Web Config -> Controller bad behavior.