### PR TITLE
populate the PS3 analog values for buttons

### DIFF
--- a/headers/drivers/hid/HIDDescriptors.h
+++ b/headers/drivers/hid/HIDDescriptors.h
@@ -102,8 +102,7 @@ typedef struct __attribute((packed, aligned(1)))
 	uint8_t r_x_axis;
 	uint8_t r_y_axis;
 
-	// Gonna assume these are button analog values for the d-pad.
-	// NOTE: NOT EVEN SURE THIS IS RIGHT, OR IN THE CORRECT ORDER
+	// button analog values for the d-pad.
 	uint8_t right_axis;
 	uint8_t left_axis;
 	uint8_t up_axis;

--- a/src/drivers/hid/HIDDriver.cpp
+++ b/src/drivers/hid/HIDDriver.cpp
@@ -93,6 +93,16 @@ void HIDDriver::process(Gamepad * gamepad, uint8_t * outBuffer) {
 		hidReport.r2_axis = gamepad->pressedR2() ? 0xFF : 0;
 	}
 
+	hidReport.triangle_axis =	gamepad->pressedB4() ? 0xFF : 0;
+	hidReport.circle_axis =		gamepad->pressedB2() ? 0xFF : 0;
+	hidReport.cross_axis =		gamepad->pressedB1() ? 0xFF : 0;
+	hidReport.square_axis =		gamepad->pressedB3() ? 0xFF : 0;
+	hidReport.l1_axis =		gamepad->pressedL1() ? 0xFF : 0;
+	hidReport.r1_axis =		gamepad->pressedR1() ? 0xFF : 0;
+	hidReport.right_axis =		gamepad->state.dpad & GAMEPAD_MASK_RIGHT ? 0xFF : 0;
+	hidReport.left_axis =		gamepad->state.dpad & GAMEPAD_MASK_LEFT ? 0xFF : 0;
+	hidReport.up_axis =		gamepad->state.dpad & GAMEPAD_MASK_UP ? 0xFF : 0;
+	hidReport.down_axis =		gamepad->state.dpad & GAMEPAD_MASK_DOWN ? 0xFF : 0;
 
 	// Wake up TinyUSB device
 	if (tud_suspended())


### PR DESCRIPTION
PS3 face buttons are technically analogs like L2/R2. they were declared in the payload but never used, but apparently Marvel vs. Capcom 2 uses the analog values, so use the digital button state to populate the fake "analog" values and get the game working.

this also confirms the order of the axes declared in HIDDescriptors.h, which is nice.

this *ALSO* means MvC2 (and who knows what else) has a predefined notion of what's in the payload bytes despite the interface descriptor, so that's interesting, but whatever

I WANNA TAKE YOU FOR A RIDE

Fixes #785