### PR TITLE
Added button masks for Neo Geo ASP extended buttons

### DIFF
--- a/headers/drivers/neogeo/NeoGeoDescriptors.h
+++ b/headers/drivers/neogeo/NeoGeoDescriptors.h
@@ -23,11 +23,15 @@
 // Button report (16 bits)
 #define NEOGEO_MASK_A       (1U <<  0)
 #define NEOGEO_MASK_B       (1U <<  1)
+#define NEOGEO_MASK_R1      (1U <<  2)
 #define NEOGEO_MASK_C       (1U <<  3)
 #define NEOGEO_MASK_D       (1U <<  4)
+#define NEOGEO_MASK_R2      (1U <<  5)
+#define NEOGEO_MASK_L1      (1U <<  6)
+#define NEOGEO_MASK_L2      (1U <<  7)
+#define NEOGEO_MASK_OPTIONS (1U <<  9)
 #define NEOGEO_MASK_SELECT  (1U <<  10)
 #define NEOGEO_MASK_START   (1U <<  11)
-
 #define NEOGEO_JOYSTICK_MID  0x7f
 
 typedef struct __attribute((packed, aligned(1)))

--- a/src/drivers/neogeo/NeoGeoDriver.cpp
+++ b/src/drivers/neogeo/NeoGeoDriver.cpp
@@ -59,6 +59,11 @@ void NeoGeoDriver::process(Gamepad * gamepad, uint8_t * outBuffer) {
 		| (gamepad->pressedB2() ? NEOGEO_MASK_D       : 0)
 		| (gamepad->pressedS1() ? NEOGEO_MASK_SELECT  : 0)
 		| (gamepad->pressedS2() ? NEOGEO_MASK_START   : 0)
+		| (gamepad->pressedA1() ? NEOGEO_MASK_OPTIONS : 0)
+		| (gamepad->pressedL1() ? NEOGEO_MASK_L1      : 0)
+		| (gamepad->pressedL2() ? NEOGEO_MASK_L2      : 0)
+		| (gamepad->pressedR1() ? NEOGEO_MASK_R1      : 0)
+		| (gamepad->pressedR2() ? NEOGEO_MASK_R2      : 0)
 	;
 
 	// Wake up TinyUSB device


### PR DESCRIPTION
This should allow the side panel Options button and 4 extra action buttons to be included where used.

Assume the following mapping, as the remaining 4 buttons are unlabeled (using L1/L2/R1/R2 naming).
```
A C R1 L1
B D R2 L2

B3=A
B1=B
B4=C
B2=D
S1=Select
S2=Start
A1=Options
L1=L1
L2=L2
R1=R1
R2=R2
```
This should help to resolve #844 .