### PR TITLE
Buzzer Speaker off-by-one fix

### DIFF
--- a/src/addons/buzzerspeaker.cpp
+++ b/src/addons/buzzerspeaker.cpp
@@ -56,7 +56,7 @@ void BuzzerSpeakerAddon::processBuzzer() {
 	uint16_t currentTonePosition = floor((currentTimeSong * currentSong->song.size()) / totalTimeSong);
 	Tone currentTone = currentSong->song[currentTonePosition];
 
-	if (currentTonePosition > currentSong->song.size()) {
+	if (currentTonePosition >= currentSong->song.size()) {
 		stop();
 		return;
 	}


### PR DESCRIPTION
Buzzer speaker had an off-by-one issue. So the last note would read from memory, and in some cases cause a "fart" noise