### PR TITLE
Debouncing fix

### DIFF
--- a/headers/addons/dualdirectional.h
+++ b/headers/addons/dualdirectional.h
@@ -49,6 +49,7 @@ private:
     const SOCDMode getSOCDMode(const GamepadOptions&);
     uint8_t dDebState;          // Debounce State (stored)
     uint8_t dualState;          // Dual Directional State
+    GamepadDebouncer ddiDebouncer;
     DpadDirection lastGPUD; // Gamepad Last Up-Down
 	DpadDirection lastGPLR; // Gamepad Last Left-Right
     DpadDirection lastDualUD; // Dual Last Up-Down

--- a/headers/addons/tilt.h
+++ b/headers/addons/tilt.h
@@ -105,6 +105,7 @@ private:
 	uint8_t dDebRightState;          // Debounce State (stored)
 	uint8_t tiltLeftState;          // Tilt State
 	uint8_t tiltRightState;          // Tilt Right Analog State
+	GamepadDebouncer tiltDebouncer;
 	DpadDirection lastGPUD; // Gamepad Last Up-Down
 	DpadDirection lastGPLR; // Gamepad Last Left-Right
 	DpadDirection leftLastTiltUD; // Tilt Last Up-Down

--- a/headers/gamepad/GamepadDebouncer.h
+++ b/headers/gamepad/GamepadDebouncer.h
@@ -19,8 +19,8 @@ class GamepadDebouncer
 		GamepadDebouncer() { }
 
 		void debounce(GamepadState *state);
-		uint8_t debounceDpad(uint8_t dpadState, uint8_t changedDpad, uint32_t now);
-		uint16_t debounceButtons(uint16_t buttonState, uint16_t changedButtons, uint32_t now);
+		uint8_t debounceDpad(uint8_t oldDpad, uint8_t newDpad, uint32_t now);
+		uint16_t debounceButtons(uint16_t oldButtons, uint16_t newButtons, uint32_t now);
 
 		GamepadState debounceState;
 		uint32_t dpadTime[4];

--- a/headers/gamepad/GamepadDebouncer.h
+++ b/headers/gamepad/GamepadDebouncer.h
@@ -19,8 +19,8 @@ class GamepadDebouncer
 		GamepadDebouncer() { }
 
 		void debounce(GamepadState *state);
-		uint8_t debounceDpad(uint8_t dpadState, uint32_t changedDpad);
-		uint16_t debounceButtons(uint16_t buttonState, uint32_t changedButtons);
+		uint8_t debounceDpad(uint8_t dpadState, uint8_t changedDpad, uint32_t now);
+		uint16_t debounceButtons(uint16_t buttonState, uint16_t changedButtons, uint32_t now);
 
 		GamepadState debounceState;
 		uint32_t dpadTime[4];

--- a/src/addons/dualdirectional.cpp
+++ b/src/addons/dualdirectional.cpp
@@ -61,9 +61,9 @@ void DualDirectionalInput::reinit()
 void DualDirectionalInput::debounce()
 {
     GamepadDebouncer gamepadDebouncer;
-		uint32_t now = getMillis();
 
     if (dDebState != dualState) {
+        uint32_t now = getMillis();
         dualState = gamepadDebouncer.debounceDpad(dDebState, dualState, now);
         dDebState = dualState;
     }
@@ -308,7 +308,7 @@ uint8_t DualDirectionalInput::SOCDCombine(SOCDMode mode, uint8_t gamepadState) {
     return outState;
 }
 
-void DualDirectionalInput::SOCDDualClean(SOCDMode socdMode) { 
+void DualDirectionalInput::SOCDDualClean(SOCDMode socdMode) {
     if (socdMode == SOCD_MODE_BYPASS) {
         return;
     }

--- a/src/addons/dualdirectional.cpp
+++ b/src/addons/dualdirectional.cpp
@@ -61,11 +61,10 @@ void DualDirectionalInput::reinit()
 void DualDirectionalInput::debounce()
 {
     GamepadDebouncer gamepadDebouncer;
+		uint32_t now = getMillis();
 
-    if (dDebState != dualState) {	    
-        uint32_t changedDpad = dDebState ^ dualState;
-	
-        dualState = gamepadDebouncer.debounceDpad(dDebState, changedDpad);
+    if (dDebState != dualState) {
+        dualState = gamepadDebouncer.debounceDpad(dDebState, dualState, now);
         dDebState = dualState;
     }
 }

--- a/src/addons/dualdirectional.cpp
+++ b/src/addons/dualdirectional.cpp
@@ -60,11 +60,11 @@ void DualDirectionalInput::reinit()
 
 void DualDirectionalInput::debounce()
 {
-    GamepadDebouncer gamepadDebouncer;
+    static GamepadDebouncer ddiDebouncer;
 
     if (dDebState != dualState) {
         uint32_t now = getMillis();
-        dualState = gamepadDebouncer.debounceDpad(dDebState, dualState, now);
+        dualState = ddiDebouncer.debounceDpad(dDebState, dualState, now);
         dDebState = dualState;
     }
 }

--- a/src/addons/dualdirectional.cpp
+++ b/src/addons/dualdirectional.cpp
@@ -60,8 +60,6 @@ void DualDirectionalInput::reinit()
 
 void DualDirectionalInput::debounce()
 {
-    static GamepadDebouncer ddiDebouncer;
-
     if (dDebState != dualState) {
         uint32_t now = getMillis();
         dualState = ddiDebouncer.debounceDpad(dDebState, dualState, now);

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -77,7 +77,7 @@ void TiltInput::setup() {
 
 void TiltInput::debounce()
 {
-	GamepadDebouncer gamepadDebouncer;
+	static GamepadDebouncer tiltDebouncer;
 
 	// Return if the states haven't changed
 	if ((dDebLeftState == tiltLeftState) && (dDebRightState == tiltRightState))
@@ -87,13 +87,13 @@ void TiltInput::debounce()
 
 	// Debounce the tilt left state
 	if (dDebLeftState != tiltLeftState) {
-		tiltLeftState = gamepadDebouncer.debounceDpad(dDebLeftState, tiltLeftState, now);
+		tiltLeftState = tiltDebouncer.debounceDpad(dDebLeftState, tiltLeftState, now);
 		dDebLeftState = tiltLeftState;
 	}
 
 	// Debounce the tilt right state
 	if (dDebRightState != tiltRightState) {
-		tiltRightState = gamepadDebouncer.debounceDpad(dDebRightState, tiltRightState, now);
+		tiltRightState = tiltDebouncer.debounceDpad(dDebRightState, tiltRightState, now);
 		dDebRightState = tiltRightState;
 	}
 }

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -77,8 +77,6 @@ void TiltInput::setup() {
 
 void TiltInput::debounce()
 {
-	static GamepadDebouncer tiltDebouncer;
-
 	// Return if the states haven't changed
 	if ((dDebLeftState == tiltLeftState) && (dDebRightState == tiltRightState))
 		return;
@@ -276,7 +274,7 @@ void TiltInput::SOCDTiltClean(SOCDMode socdMode) {
 		rightLastTiltUD = DIRECTION_NONE;
 		break;
 	}
-    
+
 	switch (tiltRightState & (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT)) {
 	case (GAMEPAD_MASK_LEFT | GAMEPAD_MASK_RIGHT):
 		if (socdMode == SOCD_MODE_UP_PRIORITY || socdMode == SOCD_MODE_NEUTRAL) {

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -80,24 +80,22 @@ void TiltInput::debounce()
 	GamepadDebouncer gamepadDebouncer;
 
 	// Return if the states haven't changed
-    if ((dDebLeftState == tiltLeftState) && (dDebRightState == tiltRightState))
-        return;
+	if ((dDebLeftState == tiltLeftState) && (dDebRightState == tiltRightState))
+		return;
+
+	uint32_t now = getMillis();
 
 	// Debounce the tilt left state
-    if (dDebLeftState != tiltLeftState) {
-        uint32_t changedDpad = dDebLeftState ^ tiltLeftState;
-
-        tiltLeftState = gamepadDebouncer.debounceDpad(dDebLeftState, changedDpad);
+	if (dDebLeftState != tiltLeftState) {
+		tiltLeftState = gamepadDebouncer.debounceDpad(dDebLeftState, tiltLeftState, now);
 		dDebLeftState = tiltLeftState;
-    }
-	
+	}
+
 	// Debounce the tilt right state
 	if (dDebRightState != tiltRightState) {
-        uint32_t changedDpad = dDebRightState ^ tiltRightState;
-
-        tiltRightState = gamepadDebouncer.debounceDpad(dDebRightState, changedDpad);
+		tiltRightState = gamepadDebouncer.debounceDpad(dDebRightState, tiltRightState, now);
 		dDebRightState = tiltRightState;
-    }
+	}
 }
 
 void TiltInput::preprocess()

--- a/src/gamepad/GamepadDebouncer.cpp
+++ b/src/gamepad/GamepadDebouncer.cpp
@@ -16,14 +16,14 @@ void GamepadDebouncer::debounce(GamepadState *state) {
 
 	// Debounce the Dpad
 	if (debounceState.dpad != state->dpad) {
-		debounceState.dpad = debounceDpad(debounceState.dpad, state->dpad, now);
-		state->dpad = debounceState.dpad;
+		state->dpad = debounceDpad(debounceState.dpad, state->dpad, now);
+		debounceState.dpad = state->dpad;
 	}
 
 	// Debounce the buttons
 	if (debounceState.buttons != state->buttons) {
-		debounceState.buttons = debounceButtons(debounceState.buttons, state->buttons, now);
-		state->buttons = debounceState.buttons;
+		state->buttons = debounceButtons(debounceState.buttons, state->buttons, now);
+		debounceState.buttons = state->buttons;
 	}
 }
 


### PR DESCRIPTION
This is a fix for the debouncing bug discovered in the 0.7.6 refactor. I've reverted the logic for checking debounce time but kept the method separation so the debounce functions can be used in the DDI and Tilt addons.

This addresses https://github.com/OpenStickCommunity/GP2040-CE/issues/850 and possibly some other issues.