### PR TITLE
Tidy up singleton pattern used in Peripheral Manager

### DIFF
--- a/headers/peripheralmanager.h
+++ b/headers/peripheralmanager.h
@@ -9,9 +9,8 @@
 
 class PeripheralManager {
 public:
-    PeripheralManager(){}
 	PeripheralManager(PeripheralManager const&) = delete;
-	void operator=(PeripheralManager const&)  = delete;
+	PeripheralManager& operator=(PeripheralManager const&)  = delete;
 	static PeripheralManager& getInstance() // Thread-safe storage ensures cross-thread talk
 	{
 		static PeripheralManager instance;
@@ -30,6 +29,9 @@ public:
     bool isSPIEnabled(uint8_t block);
     bool isUSBEnabled(uint8_t block);
 private:
+		PeripheralManager() = default;
+    ~PeripheralManager() = default;
+
     PeripheralI2C blockI2C0;
     PeripheralI2C blockI2C1;
 


### PR DESCRIPTION
It appears that the peripheral manager had been converted to use a modern cpp singleton pattern but had a few small issues that this PR addresses

1. The constructor (and implicitly the destructor) was not private, this would allow a developer to construct additional managers which could lead to erroneous behaviour. 
2. The copy assignment was returning void, while it is fine, T& is the recommended return type. (https://en.cppreference.com/w/cpp/language/copy_assignment)

