### PR TITLE
Corrected fix for PeripheralManager as a singleton

### DIFF
--- a/headers/gp2040.h
+++ b/headers/gp2040.h
@@ -11,7 +11,6 @@
 // GP2040 Classes
 #include "gamepad.h"
 #include "addonmanager.h"
-#include "peripheralmanager.h"
 #include "gpdriver.h"
 
 #include "pico/types.h"
@@ -25,7 +24,6 @@ public:
 private:
     Gamepad snapshot;
     AddonManager addons;
-    PeripheralManager peripherals;
 
     struct RebootHotkeys {
         RebootHotkeys();

--- a/headers/peripheralmanager.h
+++ b/headers/peripheralmanager.h
@@ -9,7 +9,6 @@
 
 class PeripheralManager {
 public:
-    PeripheralManager(){}
 	PeripheralManager(PeripheralManager const&) = delete;
 	void operator=(PeripheralManager const&)  = delete;
 	static PeripheralManager& getInstance() // Thread-safe storage ensures cross-thread talk
@@ -30,6 +29,8 @@ public:
     bool isSPIEnabled(uint8_t block);
     bool isUSBEnabled(uint8_t block);
 private:
+    PeripheralManager(){}
+
     PeripheralI2C blockI2C0;
     PeripheralI2C blockI2C1;
 

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -6,6 +6,7 @@
 
 #include "build_info.h"
 #include "configmanager.h" // Global Managers
+#include "peripheralmanager.h"
 #include "storagemanager.h"
 #include "addonmanager.h"
 #include "usbhostmanager.h"


### PR DESCRIPTION
This is the correct fix for PeripheralManager as a singleton