### PR TITLE
Tidy up last of Perpherial Manager

### DIFF
--- a/headers/peripheralmanager.h
+++ b/headers/peripheralmanager.h
@@ -9,9 +9,8 @@
 
 class PeripheralManager {
 public:
-    PeripheralManager(){}
 	PeripheralManager(PeripheralManager const&) = delete;
-	void operator=(PeripheralManager const&)  = delete;
+	PeripheralManager& operator=(PeripheralManager const&)  = delete;
 	static PeripheralManager& getInstance() // Thread-safe storage ensures cross-thread talk
 	{
 		static PeripheralManager instance;
@@ -30,6 +29,9 @@ public:
     bool isSPIEnabled(uint8_t block);
     bool isUSBEnabled(uint8_t block);
 private:
+		PeripheralManager() = default;
+    ~PeripheralManager() = default;
+
     PeripheralI2C blockI2C0;
     PeripheralI2C blockI2C1;
 

--- a/headers/peripheralmanager.h
+++ b/headers/peripheralmanager.h
@@ -29,7 +29,7 @@ public:
     bool isSPIEnabled(uint8_t block);
     bool isUSBEnabled(uint8_t block);
 private:
-	PeripheralManager() = default;
+    PeripheralManager() = default;
     ~PeripheralManager() = default;
 
     PeripheralI2C blockI2C0;

--- a/headers/peripheralmanager.h
+++ b/headers/peripheralmanager.h
@@ -11,7 +11,7 @@ class PeripheralManager {
 public:
 	PeripheralManager(PeripheralManager const&) = delete;
 	PeripheralManager& operator=(PeripheralManager const&)  = delete;
-	static PeripheralManager& getInstance() // Thread-safe storage ensures cross-thread talk
+	static PeripheralManager& getInstance()
 	{
 		static PeripheralManager instance;
 		return instance;


### PR DESCRIPTION
- Made destructor explicitly private
- Fix return type on copy constructor
- Remove comment about thread safety (As far as I can tell, there is nothing here that guarantees thread safety. A singleton just gives the variable a static location but its still prone to race conditions)
