### PR TITLE
Combine enums and config proto generation

### DIFF
--- a/compile_proto.cmake
+++ b/compile_proto.cmake
@@ -23,20 +23,6 @@ function (compile_proto)
 	set(PROTO_OUTPUT_DIR ${PROTO_OUTPUT_DIR} PARENT_SCOPE)
 
 	add_custom_command(
-		DEPENDS ${VENV_FILE} ${NANOPB_GENERATOR} ${CMAKE_SOURCE_DIR}/proto/enums.proto ${CMAKE_SOURCE_DIR}/lib/nanopb/generator/proto/nanopb.proto
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-		COMMAND ${CMAKE_COMMAND} -E make_directory ${PROTO_OUTPUT_DIR}
-		COMMAND ${VENV_BIN_DIR}/python ${NANOPB_GENERATOR}
-			-q
-			-D ${PROTO_OUTPUT_DIR}
-			-I ${CMAKE_SOURCE_DIR}/proto
-			-I ${CMAKE_SOURCE_DIR}/lib/nanopb/generator/proto
-			${CMAKE_SOURCE_DIR}/proto/enums.proto
-		OUTPUT ${PROTO_OUTPUT_DIR}/enums.pb.c ${PROTO_OUTPUT_DIR}/enums.pb.h
-		COMMENT "Compiling enums.proto"
-	)
-
-	add_custom_command(
 		DEPENDS ${VENV_FILE} ${NANOPB_GENERATOR} ${CMAKE_SOURCE_DIR}/proto/enums.proto ${CMAKE_SOURCE_DIR}/proto/config.proto ${CMAKE_SOURCE_DIR}/lib/nanopb/generator/proto/nanopb.proto
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		COMMAND ${CMAKE_COMMAND} -E make_directory ${PROTO_OUTPUT_DIR}
@@ -45,8 +31,14 @@ function (compile_proto)
 			-D ${PROTO_OUTPUT_DIR}
 			-I ${CMAKE_SOURCE_DIR}/proto
 			-I ${CMAKE_SOURCE_DIR}/lib/nanopb/generator/proto
+			${CMAKE_SOURCE_DIR}/proto/enums.proto
+		COMMAND ${VENV_BIN_DIR}/python ${NANOPB_GENERATOR}
+			-q
+			-D ${PROTO_OUTPUT_DIR}
+			-I ${CMAKE_SOURCE_DIR}/proto
+			-I ${CMAKE_SOURCE_DIR}/lib/nanopb/generator/proto
 			${CMAKE_SOURCE_DIR}/proto/config.proto
-		OUTPUT ${PROTO_OUTPUT_DIR}/config.pb.c ${PROTO_OUTPUT_DIR}/config.pb.h
-		COMMENT "Compiling config.proto"
+		OUTPUT ${PROTO_OUTPUT_DIR}/config.pb.c ${PROTO_OUTPUT_DIR}/config.pb.h ${PROTO_OUTPUT_DIR}/enums.pb.c ${PROTO_OUTPUT_DIR}/enums.pb.h
+		COMMENT "Compiling enums.proto and config.proto"
 	)
 endfunction()


### PR DESCRIPTION
It looks like the cmake generation of enums and config proto could run out of order and cause a strange race condition on Github runners.

Combining these two into a single custom command fixes the ordering and no longer fails.