### PR TITLE
Update BoardConfig.h for Pico config

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -53,4 +53,38 @@
 #define KEY_BUTTON_A2   HID_KEY_F2            // A2     | ~      | Capture | ~        | 14     | ~      |
 #define KEY_BUTTON_FN   -1                    // Hotkey Function                                        |
 
+#define TURBO_ENABLED 1
+#define GPIO_PIN_14 GpioAction::BUTTON_PRESS_TURBO
+#define TURBO_LED_PIN 15
+
+#define BOARD_LEDS_PIN 28
+#define LED_BRIGHTNESS_MAXIMUM 100
+#define LED_BRIGHTNESS_STEPS 5
+#define LED_FORMAT LED_FORMAT_GRB
+#define LEDS_PER_PIXEL 1
+
+#define LEDS_DPAD_LEFT   0
+#define LEDS_DPAD_DOWN   1
+#define LEDS_DPAD_RIGHT  2
+#define LEDS_DPAD_UP     3
+#define LEDS_BUTTON_B3   4
+#define LEDS_BUTTON_B4   5
+#define LEDS_BUTTON_R1   6
+#define LEDS_BUTTON_L1   7
+#define LEDS_BUTTON_B1   8
+#define LEDS_BUTTON_B2   9
+#define LEDS_BUTTON_R2   10
+#define LEDS_BUTTON_L2   11
+#define LEDS_BUTTON_A1   12
+#define LEDS_BUTTON_L3   13
+#define LEDS_BUTTON_R3   14
+#define LEDS_BUTTON_A2   15
+
+#define HAS_I2C_DISPLAY 1
+#define I2C0_ENABLED 1
+#define I2C0_PIN_SDA 0
+#define I2C0_PIN_SCL 1
+#define BUTTON_LAYOUT BUTTON_LAYOUT_STICKLESS
+#define BUTTON_LAYOUT_RIGHT BUTTON_LAYOUT_STICKLESSB
+
 #endif


### PR DESCRIPTION
Tihs PR reverts the Pico config to its original state which had  Turbo, Turbo LED, board LED and the OLED display on by default.

This was originally removed because of conflicts that could occure but we have a more robust web-config setup now.

This will address a number of issues for people that have purchased generic devices on AliExpress which were designed around the original configuration.