### PR TITLE
Buzzer Speaker enable pin

### DIFF
--- a/headers/addons/buzzerspeaker.h
+++ b/headers/addons/buzzerspeaker.h
@@ -148,6 +148,7 @@ private:
 	uint32_t startedSongMils;
 	Song *currentSong;
 	bool introPlayed;
+    bool isSpeakerOn = false;
 };
 
 #endif

--- a/headers/addons/buzzerspeaker.h
+++ b/headers/addons/buzzerspeaker.h
@@ -13,6 +13,10 @@
 #define BUZZER_PIN -1
 #endif
 
+#ifndef BUZZER_ENABLE_PIN
+#define BUZZER_ENABLE_PIN -1
+#endif
+
 #ifndef BUZZER_VOLUME
 #define BUZZER_VOLUME 100
 #endif
@@ -137,6 +141,7 @@ private:
 	void stop();
 	uint32_t pwmSetFreqDuty(uint slice, uint channel, uint32_t frequency, float duty);
 	uint8_t buzzerPin;
+	uint8_t buzzerEnablePin;
 	uint8_t buzzerPinSlice;
 	uint8_t buzzerPinChannel;
 	uint8_t buzzerVolume;

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -477,6 +477,7 @@ message BuzzerOptions
 	
 	optional int32 pin = 2;
 	optional uint32 volume = 3;
+    optional int32 enablePin = 4;
 }
 
 message ExtraButtonOptions

--- a/src/addons/buzzerspeaker.cpp
+++ b/src/addons/buzzerspeaker.cpp
@@ -19,6 +19,14 @@ void BuzzerSpeakerAddon::setup() {
 	buzzerPinSlice = pwm_gpio_to_slice_num (buzzerPin);
 	buzzerPinChannel = pwm_gpio_to_channel (buzzerPin);
 
+    // enable pin is optional so not required to toggle addon
+    if (isValidPin(options.pin)) {
+        buzzerEnablePin = options.enablePin;
+        gpio_init(buzzerEnablePin);
+        gpio_set_dir(buzzerEnablePin, GPIO_OUT);
+        gpio_put(buzzerEnablePin, 1);
+    }
+
 	buzzerVolume = options.volume;
 	introPlayed = false;
 }

--- a/src/addons/buzzerspeaker.cpp
+++ b/src/addons/buzzerspeaker.cpp
@@ -21,10 +21,11 @@ void BuzzerSpeakerAddon::setup() {
 
     // enable pin is optional so not required to toggle addon
     if (isValidPin(options.pin)) {
+        isSpeakerOn = true;
         buzzerEnablePin = options.enablePin;
         gpio_init(buzzerEnablePin);
         gpio_set_dir(buzzerEnablePin, GPIO_OUT);
-        gpio_put(buzzerEnablePin, 1);
+        gpio_put(buzzerEnablePin, isSpeakerOn);
     }
 
 	buzzerVolume = options.volume;

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -614,6 +614,7 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.addonOptions.buzzerOptions, enabled, !!BUZZER_ENABLED);
     INIT_UNSET_PROPERTY(config.addonOptions.buzzerOptions, pin, BUZZER_PIN);
     INIT_UNSET_PROPERTY(config.addonOptions.buzzerOptions, volume, BUZZER_VOLUME);
+    INIT_UNSET_PROPERTY(config.addonOptions.buzzerOptions, enablePin, BUZZER_ENABLE_PIN);
 
     // addonOptions.inputHistoryOptions
     INIT_UNSET_PROPERTY(config.addonOptions.inputHistoryOptions, enabled, !!INPUT_HISTORY_ENABLED);
@@ -1114,6 +1115,7 @@ void gpioMappingsMigrationCore(Config& config)
     markAddonPinIfUsed(config.addonOptions.analogOptions.analogAdc2PinX);
     markAddonPinIfUsed(config.addonOptions.analogOptions.analogAdc2PinY);
     markAddonPinIfUsed(config.addonOptions.buzzerOptions.pin);
+    markAddonPinIfUsed(config.addonOptions.buzzerOptions.enablePin);
     markAddonPinIfUsed(config.addonOptions.focusModeOptions.pin);
     markAddonPinIfUsed(config.addonOptions.turboOptions.ledPin);
     markAddonPinIfUsed(config.addonOptions.turboOptions.shmupDialPin);

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1190,6 +1190,7 @@ std::string setAddonOptions()
 	BuzzerOptions& buzzerOptions = Storage::getInstance().getAddonOptions().buzzerOptions;
 	docToPin(buzzerOptions.pin, doc, "buzzerPin");
 	docToValue(buzzerOptions.volume, doc, "buzzerVolume");
+	docToValue(buzzerOptions.enablePin, doc, "buzzerEnablePin");
 	docToValue(buzzerOptions.enabled, doc, "BuzzerSpeakerAddonEnabled");
 
 	DualDirectionalOptions& dualDirectionalOptions = Storage::getInstance().getAddonOptions().dualDirectionalOptions;
@@ -1598,6 +1599,7 @@ std::string getAddonOptions()
     const BuzzerOptions& buzzerOptions = Storage::getInstance().getAddonOptions().buzzerOptions;
 	writeDoc(doc, "buzzerPin", cleanPin(buzzerOptions.pin));
 	writeDoc(doc, "buzzerVolume", buzzerOptions.volume);
+	writeDoc(doc, "buzzerEnablePin", buzzerOptions.enablePin);
 	writeDoc(doc, "BuzzerSpeakerAddonEnabled", buzzerOptions.enabled);
 
 	const DualDirectionalOptions& dualDirectionalOptions = Storage::getInstance().getAddonOptions().dualDirectionalOptions;

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -426,6 +426,7 @@ app.get('/api/getAddonsOptions', (req, res) => {
 		auto_calibrate: 0,
 		bootselButtonMap: 0,
 		buzzerPin: -1,
+		buzzerEnablePin: -1,
 		buzzerVolume: 100,
 		focusModePin: -1,
 		focusModeButtonLockMask: 0,

--- a/www/src/Addons/Buzzer.tsx
+++ b/www/src/Addons/Buzzer.tsx
@@ -16,6 +16,10 @@ export const buzzerScheme = {
 		.number()
 		.label('Buzzer Pin')
 		.validatePinWhenValue('BuzzerSpeakerAddonEnabled'),
+	buzzerEnablePin: yup
+		.number()
+		.label('Buzzer Enable Pin')
+		.validatePinWhenValue('BuzzerSpeakerAddonEnabled'),
 	buzzerVolume: yup
 		.number()
 		.label('Buzzer Volume')
@@ -25,6 +29,7 @@ export const buzzerScheme = {
 export const buzzerState = {
 	BuzzerSpeakerAddonEnabled: 0,
 	buzzerPin: -1,
+	buzzerEnablePin: -1,
 	buzzerVolume: 100,
 };
 
@@ -46,6 +51,19 @@ const Buzzer = ({ values, errors, handleChange, handleCheckbox }) => {
 						value={values.buzzerPin}
 						error={errors.buzzerPin}
 						isInvalid={errors.buzzerPin}
+						onChange={handleChange}
+						min={-1}
+						max={29}
+					/>
+					<FormControl
+						type="number"
+						label={t('AddonsConfig:buzzer-speaker-enable-pin-label')}
+						name="buzzerEnablePin"
+						className="form-control-sm"
+						groupClassName="col-sm-3 mb-3"
+						value={values.buzzerEnablePin}
+						error={errors.buzzerEnablePin}
+						isInvalid={errors.buzzerEnablePin}
 						onChange={handleChange}
 						min={-1}
 						max={29}

--- a/www/src/Locales/en/AddonsConfig.jsx
+++ b/www/src/Locales/en/AddonsConfig.jsx
@@ -96,6 +96,7 @@ export default {
 	'tilt-socd-mode-label': 'Tilt SOCD Mode',
 	'buzzer-speaker-header-text': 'Buzzer Speaker',
 	'buzzer-speaker-pin-label': 'Buzzer Pin',
+	'buzzer-speaker-enable-pin-label': 'Buzzer Enable Pin',
 	'buzzer-speaker-volume-label': 'Buzzer Volume',
 	'extra-button-header-text': 'Extra Button Configuration',
 	'extra-button-pin-label': 'Extra Button Pin',


### PR DESCRIPTION
Added optional enable pin to to allow toggling the sound on/off when necessary. The enable pin is pulled high on setup() if the pin is defined so it will need to be brought low to disable the speaker during runtime.