### PR TITLE
Fix the Turbo LED state

### DIFF
--- a/src/addons/turbo.cpp
+++ b/src/addons/turbo.cpp
@@ -178,11 +178,14 @@ void TurboInput::process()
     // ON: 1 or more turbo buttons enabled
     // BLINK: OFF on turbo shot, ON on turbo flicker
     if (hasLedPin) {
-        if (!turboButtonsPressed) {
-            gpio_put(options.ledPin, 1);
+        if (turboButtonsPressed == 0) {
+            gpio_put(options.ledPin, 0);
+        }
+        else if ((gamepad->state.buttons & turboButtonsPressed) && bTurboFlicker) {
+            gpio_put(options.ledPin, !gpio_get(options.ledPin));
         }
         else {
-            gpio_put(options.ledPin, (gamepad->state.buttons & turboButtonsPressed) && !bTurboFlicker);
+            gpio_put(options.ledPin, 1);
         }
     }
 


### PR DESCRIPTION
The logic didn't match the comments above it or what Feral, Train and I discussed the other day on Discord.

This is now working right, it seems to behave how I'd expect on my stick.