### PR TITLE
New Driver System - Fix bug for Wii/Tilt/few others

### DIFF
--- a/src/addons/board_led.cpp
+++ b/src/addons/board_led.cpp
@@ -24,7 +24,10 @@ void BoardLedAddon::setup() {
 void BoardLedAddon::process() {
     bool state = 0;
     Gamepad * processedGamepad;
-    uint16_t joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+    uint16_t joystickMid = GAMEPAD_JOYSTICK_MID;
+	if ( DriverManager::getInstance().getDriver() != nullptr ) {
+		joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+	}
     switch (onBoardLedMode) {
         case OnBoardLedMode::ON_BOARD_LED_MODE_INPUT_TEST: // Blinks on input
             processedGamepad = Storage::getInstance().GetProcessedGamepad();

--- a/src/addons/board_led.cpp
+++ b/src/addons/board_led.cpp
@@ -25,9 +25,9 @@ void BoardLedAddon::process() {
     bool state = 0;
     Gamepad * processedGamepad;
     uint16_t joystickMid = GAMEPAD_JOYSTICK_MID;
-	if ( DriverManager::getInstance().getDriver() != nullptr ) {
-		joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
-	}
+    if ( DriverManager::getInstance().getDriver() != nullptr ) {
+        joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+    }
     switch (onBoardLedMode) {
         case OnBoardLedMode::ON_BOARD_LED_MODE_INPUT_TEST: // Blinks on input
             processedGamepad = Storage::getInstance().GetProcessedGamepad();

--- a/src/addons/keyboard_host.cpp
+++ b/src/addons/keyboard_host.cpp
@@ -107,7 +107,10 @@ uint8_t KeyboardHostAddon::getKeycodeFromModifier(uint8_t modifier) {
 // convert hid keycode to ascii and print via usb device CDC (ignore non-printable)
 void KeyboardHostAddon::process_kbd_report(uint8_t dev_addr, hid_keyboard_report_t const *report)
 {
-  uint16_t joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+  uint16_t joystickMid = GAMEPAD_JOYSTICK_MID;
+	if ( DriverManager::getInstance().getDriver() != nullptr ) {
+		joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+	}
 
   _keyboard_host_state.dpad = 0;
   _keyboard_host_state.buttons = 0;

--- a/src/addons/snes_input.cpp
+++ b/src/addons/snes_input.cpp
@@ -84,7 +84,10 @@ void SNESpadInput::process() {
     if (nextTimer < getMillis()) {
         snes->poll();
 
-        uint16_t joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+        uint16_t joystickMid = GAMEPAD_JOYSTICK_MID;
+        if ( DriverManager::getInstance().getDriver() != nullptr ) {
+            joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+        }
 
         leftX = joystickMid;
         leftY = joystickMid;

--- a/src/addons/tilt.cpp
+++ b/src/addons/tilt.cpp
@@ -141,7 +141,10 @@ void TiltInput::OverrideGamepad(Gamepad* gamepad, uint8_t dpad1, uint8_t dpad2) 
 	double scaledTilt2FactorRightX = 1.0 - (tilt2FactorRightX / 100.0);
 	double scaledTilt2FactorRightY = 1.0 - (tilt2FactorRightY / 100.0);
 
-	uint16_t midValue = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+	uint16_t midValue = GAMEPAD_JOYSTICK_MID;
+	if ( DriverManager::getInstance().getDriver() != nullptr ) {
+		midValue = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+	}
 
     if (pinTilt1Pressed && pinTilt2Pressed) {
         // inputs act as dpad

--- a/src/addons/wiiext.cpp
+++ b/src/addons/wiiext.cpp
@@ -345,9 +345,9 @@ void WiiExtensionInput::updateAnalogState() {
     gamepad->hasAnalogTriggers = isAnalogTriggers;
 
     uint16_t joystickMid = GAMEPAD_JOYSTICK_MID;
-	if ( DriverManager::getInstance().getDriver() != nullptr ) {
-		joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
-	}
+    if ( DriverManager::getInstance().getDriver() != nullptr ) {
+        joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+    }
 
     uint16_t axisType;
     uint16_t analogInput;

--- a/src/addons/wiiext.cpp
+++ b/src/addons/wiiext.cpp
@@ -102,7 +102,10 @@ uint16_t WiiExtensionInput::bounds(uint16_t x, uint16_t out_min, uint16_t out_ma
 
 void WiiExtensionInput::update() {
     if (wii->extensionType != WII_EXTENSION_NONE) {
-        uint16_t joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+        uint16_t joystickMid = GAMEPAD_JOYSTICK_MID;
+        if ( DriverManager::getInstance().getDriver() != nullptr ) {
+            joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+        }
         currentConfig = &extensionConfigs[wii->extensionType];
 
         //for (const auto& [extensionButton, value] : currentConfig->buttonMap) {
@@ -341,7 +344,10 @@ void WiiExtensionInput::updateAnalogState() {
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
     gamepad->hasAnalogTriggers = isAnalogTriggers;
 
-    uint16_t joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+    uint16_t joystickMid = GAMEPAD_JOYSTICK_MID;
+	if ( DriverManager::getInstance().getDriver() != nullptr ) {
+		joystickMid = DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+	}
 
     uint16_t axisType;
     uint16_t analogInput;

--- a/src/gamepad/GamepadState.cpp
+++ b/src/gamepad/GamepadState.cpp
@@ -13,7 +13,10 @@ uint16_t dpadToAnalogX(uint8_t dpad)
 			return GAMEPAD_JOYSTICK_MAX;
 
 		default:
-			return DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+			if ( DriverManager::getInstance().getDriver() != nullptr )
+				return DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+			else
+				return GAMEPAD_JOYSTICK_MID;
 	}
 }
 
@@ -29,7 +32,10 @@ uint16_t dpadToAnalogY(uint8_t dpad)
 			return GAMEPAD_JOYSTICK_MAX;
 
 		default:
-			return DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+			if ( DriverManager::getInstance().getDriver() != nullptr )
+				return DriverManager::getInstance().getDriver()->GetJoystickMidValue();
+			else
+				return GAMEPAD_JOYSTICK_MID;
 	}
 }
 


### PR DESCRIPTION
This should fix issues with state updates before the driver has been declared. We might want to revisit assigning mid to a Gamepad variable instead of pulling from the driver input, but this will fix crashing issues for now.