### PR TITLE
LayoutManager & button layout enhancements/fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ src/display/ui/screens/SplashScreen.cpp
 src/display/GPGFX.cpp
 src/display/GPGFX_UI.cpp
 src/drivermanager.cpp
+src/layoutmanager.cpp
 src/peripheralmanager.cpp
 src/storagemanager.cpp
 src/system.cpp

--- a/headers/display/GPGFX_UI_layouts.h
+++ b/headers/display/GPGFX_UI_layouts.h
@@ -6,11 +6,4 @@
 #include "config.pb.h"
 #include "enums.pb.h"
 
-#define GPELEMENT_PARAM_COUNT 12
-
-typedef struct {
-    GPElement elementType;
-    uint16_t parameters[GPELEMENT_PARAM_COUNT];
-} GPButtonLayout;
-
 #endif

--- a/headers/display/ui/screens/ButtonLayoutScreen.h
+++ b/headers/display/ui/screens/ButtonLayoutScreen.h
@@ -38,6 +38,7 @@
 #define CHAR_SHARE_P  "\x93"
 
 #define INPUT_HISTORY_MAX_INPUTS 22
+#define INPUT_HISTORY_MAX_MODES 11
 
 class ButtonLayoutScreen : public GPScreen {
     public:
@@ -100,7 +101,7 @@ class ButtonLayoutScreen : public GPScreen {
         bool pressedDownLeft();
         bool pressedDownRight();
 
-        const std::vector<std::vector<std::string>> displayNames {
+        const std::string displayNames[INPUT_HISTORY_MAX_MODES][INPUT_HISTORY_MAX_INPUTS] = {
             {		// HID / DINPUT
                     CHAR_UP, CHAR_DOWN, CHAR_LEFT, CHAR_RIGHT,
                     CHAR_UL, CHAR_UR, CHAR_DL, CHAR_DR,

--- a/headers/display/ui/screens/ButtonLayoutScreen.h
+++ b/headers/display/ui/screens/ButtonLayoutScreen.h
@@ -7,6 +7,7 @@
 #include <deque>
 #include <array>
 #include <functional>
+#include "layoutmanager.h"
 #include "GPGFX_UI_widgets.h"
 #include "GPGFX_UI_layouts.h"
 
@@ -40,74 +41,9 @@
 
 class ButtonLayoutScreen : public GPScreen {
     public:
-        typedef std::vector<GPButtonLayout> LayoutList;
-        typedef std::function<LayoutList()> LayoutFunction;
-
         ButtonLayoutScreen() {}
         ButtonLayoutScreen(GPGFX* renderer) { setRenderer(renderer); }
         int8_t update();
-
-        // old layout methods
-        LayoutList drawStickless();
-        LayoutList drawWasdBox();
-        LayoutList drawArcadeStick();
-        LayoutList drawUDLR();
-        LayoutList drawMAMEA();
-        LayoutList drawOpenCore0WASDA();
-        LayoutList drawOpenCore0WASDB();
-        LayoutList drawMAMEB();
-        LayoutList drawMAME8B();
-        LayoutList drawKeyboardAngled();
-        LayoutList drawVewlix();
-        LayoutList drawVewlix7();
-        LayoutList drawSega2p();
-        LayoutList drawNoir8();
-        LayoutList drawCapcom();
-        LayoutList drawCapcom6();
-        LayoutList drawSticklessButtons();
-        LayoutList drawWasdButtons();
-        LayoutList drawArcadeButtons();
-        LayoutList drawDancepadA();
-        LayoutList drawDancepadB();
-        LayoutList drawTwinStickA();
-        LayoutList drawTwinStickB();
-        LayoutList drawBlankA();
-        LayoutList drawBlankB();
-        LayoutList drawVLXA();
-        LayoutList drawVLXB();
-        LayoutList drawFightboard();
-        LayoutList drawFightboardMirrored();
-        LayoutList drawFightboardStick();
-        LayoutList drawFightboardStickMirrored();
-        LayoutList drawStickless13A();
-        LayoutList drawSticklessButtons13B();
-        LayoutList drawStickless16A();
-        LayoutList drawSticklessButtons16B();
-        LayoutList drawStickless14A();
-        LayoutList drawSticklessButtons14B();
-        LayoutList drawButtonLayoutLeft();
-        LayoutList drawButtonLayoutRight();
-        LayoutList drawBoardDefinedA();
-        LayoutList drawBoardDefinedB();
-        LayoutList drawDancepadDDRLeft();
-        LayoutList drawDancepadDDRSolo();
-        LayoutList drawDancepadPIULeft();
-        LayoutList drawPopnA();
-        LayoutList drawTaikoA();
-        LayoutList drawBMTurntableA();
-        LayoutList drawBM5KeyA();
-        LayoutList drawBM7KeyA();
-        LayoutList drawGitadoraFretA();
-        LayoutList drawGitadoraStrumA();
-        LayoutList drawDancepadDDRRight();
-        LayoutList drawDancepadPIURight();
-        LayoutList drawPopnB();
-        LayoutList drawTaikoB();
-        LayoutList drawBMTurntableB();
-        LayoutList drawBM5KeyB();
-        LayoutList drawBM7KeyB();
-        LayoutList drawGitadoraFretB();
-        LayoutList drawGitadoraStrumB();
     protected:
         void drawScreen();
     private:
@@ -117,83 +53,6 @@ class ButtonLayoutScreen : public GPScreen {
         GPSprite* drawSprite(uint16_t startX, uint16_t startY, uint16_t sizeX, uint16_t sizeY);
         GPShape* drawShape(uint16_t startX, uint16_t startY, uint16_t sizeX, uint16_t sizeY, uint16_t strokeColor, uint16_t fillColor);
         GPWidget* drawElement(GPButtonLayout element);
-        LayoutList adjustByCustomSettings(LayoutList layout, ButtonLayoutParamsCommon common, uint16_t originX = 0, uint16_t originY = 0);
-
-        std::map<uint16_t,LayoutFunction> GPButtonLayouts_LeftLayouts = {
-            // levers
-            // parameters: x, y, radiusX/width, radiusY/height, stroke, fill, DpadMode
-            {BUTTON_LAYOUT_STICK,                     [this]() { return this->drawArcadeStick(); }},
-            {BUTTON_LAYOUT_TWINSTICKA,                [this]() { return this->drawTwinStickA(); }},
-            {BUTTON_LAYOUT_VLXA,                      [this]() { return this->drawVLXA(); }},
-            {BUTTON_LAYOUT_FIGHTBOARD_STICK,          [this]() { return this->drawFightboardStick(); }},
-
-            // buttons
-            // parameters: x, y, radiusX/width, radiusY/height, stroke, fill, Gamepad button mask, shape
-            {BUTTON_LAYOUT_STICKLESS,                 [this]() { return this->drawStickless(); }},
-            {BUTTON_LAYOUT_BUTTONS_ANGLED,            [this]() { return this->drawUDLR(); }},
-            {BUTTON_LAYOUT_BUTTONS_BASIC,             [this]() { return this->drawMAMEA(); }},
-            {BUTTON_LAYOUT_KEYBOARD_ANGLED,           [this]() { return this->drawKeyboardAngled(); }},
-            {BUTTON_LAYOUT_KEYBOARDA,                 [this]() { return this->drawWasdBox(); }},
-            {BUTTON_LAYOUT_DANCEPADA,                 [this]() { return this->drawDancepadA(); }},
-            {BUTTON_LAYOUT_BLANKA,                    [this]() { return this->drawBlankA(); }},
-            {BUTTON_LAYOUT_FIGHTBOARD_MIRRORED,       [this]() { return this->drawFightboardMirrored(); }},
-            {BUTTON_LAYOUT_CUSTOMA,                   [this]() { return this->drawButtonLayoutLeft(); }},
-            {BUTTON_LAYOUT_OPENCORE0WASDA,            [this]() { return this->drawOpenCore0WASDA(); }},
-            {BUTTON_LAYOUT_STICKLESS_13,              [this]() { return this->drawStickless13A(); }},
-            {BUTTON_LAYOUT_STICKLESS_16,              [this]() { return this->drawStickless16A(); }},
-            {BUTTON_LAYOUT_STICKLESS_14,              [this]() { return this->drawStickless14A(); }},
-            {BUTTON_LAYOUT_DANCEPADA,                 [this]() { return this->drawDancepadA(); }},
-
-            {BUTTON_LAYOUT_DANCEPAD_DDR_LEFT,         [this]() { return this->drawDancepadDDRLeft(); }},
-            {BUTTON_LAYOUT_DANCEPAD_DDR_SOLO,         [this]() { return this->drawDancepadDDRSolo(); }},
-            {BUTTON_LAYOUT_DANCEPAD_PIU_LEFT,         [this]() { return this->drawDancepadPIULeft(); }},
-            {BUTTON_LAYOUT_POPN_A,                    [this]() { return this->drawPopnA(); }},
-            {BUTTON_LAYOUT_TAIKO_A,                   [this]() { return this->drawTaikoA(); }},
-            {BUTTON_LAYOUT_BM_TURNTABLE_A,            [this]() { return this->drawBMTurntableA(); }},
-            {BUTTON_LAYOUT_BM_5KEY_A,                 [this]() { return this->drawBM5KeyA(); }},
-            {BUTTON_LAYOUT_BM_7KEY_A,                 [this]() { return this->drawBM7KeyA(); }},
-            {BUTTON_LAYOUT_GITADORA_FRET_A,           [this]() { return this->drawGitadoraFretA(); }},
-            {BUTTON_LAYOUT_GITADORA_STRUM_A,          [this]() { return this->drawGitadoraStrumA(); }},
-
-            {BUTTON_LAYOUT_BOARD_DEFINED_A,           [this]() { return this->drawBoardDefinedA(); }},
-        };
-
-        std::map<uint16_t,LayoutFunction> GPButtonLayouts_RightLayouts = {
-            {BUTTON_LAYOUT_ARCADE,                    [this]() { return this->drawArcadeButtons(); }},
-            {BUTTON_LAYOUT_STICKLESSB,                [this]() { return this->drawSticklessButtons(); }},
-            {BUTTON_LAYOUT_BUTTONS_ANGLEDB,           [this]() { return this->drawMAMEB(); }},
-            {BUTTON_LAYOUT_VEWLIX,                    [this]() { return this->drawVewlix(); }},
-            {BUTTON_LAYOUT_VEWLIX7,                   [this]() { return this->drawVewlix7(); }},
-            {BUTTON_LAYOUT_CAPCOM,                    [this]() { return this->drawCapcom(); }},
-            {BUTTON_LAYOUT_CAPCOM6,                   [this]() { return this->drawCapcom6(); }},
-            {BUTTON_LAYOUT_SEGA2P,                    [this]() { return this->drawSega2p(); }},
-            {BUTTON_LAYOUT_NOIR8,                     [this]() { return this->drawNoir8(); }},
-            {BUTTON_LAYOUT_KEYBOARDB,                 [this]() { return this->drawMAMEB(); }},
-            {BUTTON_LAYOUT_TWINSTICKB,                [this]() { return this->drawTwinStickB(); }},
-            {BUTTON_LAYOUT_BLANKB,                    [this]() { return this->drawBlankB(); }},
-            {BUTTON_LAYOUT_VLXB,                      [this]() { return this->drawVLXB(); }},
-            {BUTTON_LAYOUT_FIGHTBOARD,                [this]() { return this->drawFightboard(); }},
-            {BUTTON_LAYOUT_FIGHTBOARD_STICK_MIRRORED, [this]() { return this->drawFightboardStickMirrored(); }},
-            {BUTTON_LAYOUT_CUSTOMB,                   [this]() { return this->drawButtonLayoutRight(); }},
-            {BUTTON_LAYOUT_KEYBOARD8B,                [this]() { return this->drawMAME8B(); }},
-            {BUTTON_LAYOUT_OPENCORE0WASDB,            [this]() { return this->drawOpenCore0WASDB(); }},
-            {BUTTON_LAYOUT_STICKLESS_13B,             [this]() { return this->drawSticklessButtons13B(); }},
-            {BUTTON_LAYOUT_STICKLESS_16B,             [this]() { return this->drawSticklessButtons16B(); }},
-            {BUTTON_LAYOUT_STICKLESS_14B,             [this]() { return this->drawSticklessButtons14B(); }},
-            {BUTTON_LAYOUT_DANCEPADB,                 [this]() { return this->drawDancepadB(); }},
-
-            {BUTTON_LAYOUT_DANCEPAD_DDR_RIGHT,        [this]() { return this->drawDancepadDDRRight(); }},
-            {BUTTON_LAYOUT_DANCEPAD_PIU_RIGHT,        [this]() { return this->drawDancepadPIURight(); }},
-            {BUTTON_LAYOUT_POPN_B,                    [this]() { return this->drawPopnB(); }},
-            {BUTTON_LAYOUT_TAIKO_B,                   [this]() { return this->drawTaikoB(); }},
-            {BUTTON_LAYOUT_BM_TURNTABLE_B,            [this]() { return this->drawBMTurntableB(); }},
-            {BUTTON_LAYOUT_BM_5KEY_B,                 [this]() { return this->drawBM5KeyB(); }},
-            {BUTTON_LAYOUT_BM_7KEY_B,                 [this]() { return this->drawBM7KeyB(); }},
-            {BUTTON_LAYOUT_GITADORA_FRET_B,           [this]() { return this->drawGitadoraFretB(); }},
-            {BUTTON_LAYOUT_GITADORA_STRUM_B,          [this]() { return this->drawGitadoraStrumB(); }},
-
-            {BUTTON_LAYOUT_BOARD_DEFINED_B,           [this]() { return this->drawBoardDefinedB(); }},
-        };
 
         const std::map<uint16_t, uint16_t> displayModeLookup = {
             {INPUT_MODE_HID, 0},

--- a/headers/layoutmanager.h
+++ b/headers/layoutmanager.h
@@ -1,0 +1,201 @@
+#ifndef _LAYOUTMANAGER_H_
+#define _LAYOUTMANAGER_H_
+
+#include <map>
+#include <vector>
+#include <string>
+#include <deque>
+#include <array>
+#include <functional>
+#include "config.pb.h"
+#include "enums.pb.h"
+
+typedef struct {
+    uint16_t x1;
+    uint16_t y1;
+    uint16_t x2;
+    uint16_t y2;
+    uint16_t stroke;
+    uint16_t fill;
+    uint16_t value;
+    uint16_t shape;
+    uint16_t angleStart;
+    uint16_t angleEnd;
+    uint16_t closed;
+} GPButtonParameters;
+
+typedef struct {
+    GPElement elementType;
+    GPButtonParameters parameters;
+} GPButtonLayout;
+
+#define LAYOUTMGR LayoutManager::getInstance()
+
+class LayoutManager {
+    public:
+        typedef std::vector<GPButtonLayout> LayoutList;
+        typedef std::function<LayoutList()> LayoutFunction;
+
+        LayoutManager(LayoutManager const&) = delete;
+        void operator=(LayoutManager const&)  = delete;
+        static LayoutManager& getInstance() // Thread-safe storage ensures cross-thread talk
+        {
+            static LayoutManager instance;
+            return instance;
+        }
+
+        LayoutList getLayoutA();
+        LayoutList getLayoutB();
+
+        std::string getLayoutAName();
+        std::string getLayoutBName();
+
+        std::string getButtonLayoutName(ButtonLayout layout);
+        std::string getButtonLayoutRightName(ButtonLayoutRight layout);
+
+        LayoutList adjustByCustomSettings(LayoutList layout, ButtonLayoutParamsCommon common, uint16_t originX = 0, uint16_t originY = 0);
+
+        // old layout methods
+        LayoutList drawStickless();
+        LayoutList drawWasdBox();
+        LayoutList drawArcadeStick();
+        LayoutList drawUDLR();
+        LayoutList drawMAMEA();
+        LayoutList drawOpenCore0WASDA();
+        LayoutList drawOpenCore0WASDB();
+        LayoutList drawMAMEB();
+        LayoutList drawMAME8B();
+        LayoutList drawKeyboardAngled();
+        LayoutList drawVewlix();
+        LayoutList drawVewlix7();
+        LayoutList drawSega2p();
+        LayoutList drawNoir8();
+        LayoutList drawCapcom();
+        LayoutList drawCapcom6();
+        LayoutList drawSticklessButtons();
+        LayoutList drawWasdButtons();
+        LayoutList drawArcadeButtons();
+        LayoutList drawDancepadA();
+        LayoutList drawDancepadB();
+        LayoutList drawTwinStickA();
+        LayoutList drawTwinStickB();
+        LayoutList drawBlankA();
+        LayoutList drawBlankB();
+        LayoutList drawVLXA();
+        LayoutList drawVLXB();
+        LayoutList drawFightboard();
+        LayoutList drawFightboardMirrored();
+        LayoutList drawFightboardStick();
+        LayoutList drawFightboardStickMirrored();
+        LayoutList drawStickless13A();
+        LayoutList drawSticklessButtons13B();
+        LayoutList drawStickless16A();
+        LayoutList drawSticklessButtons16B();
+        LayoutList drawStickless14A();
+        LayoutList drawSticklessButtons14B();
+        LayoutList drawButtonLayoutLeft();
+        LayoutList drawButtonLayoutRight();
+        LayoutList drawBoardDefinedA();
+        LayoutList drawBoardDefinedB();
+        LayoutList drawDancepadDDRLeft();
+        LayoutList drawDancepadDDRSolo();
+        LayoutList drawDancepadPIULeft();
+        LayoutList drawPopnA();
+        LayoutList drawTaikoA();
+        LayoutList drawBMTurntableA();
+        LayoutList drawBM5KeyA();
+        LayoutList drawBM7KeyA();
+        LayoutList drawGitadoraFretA();
+        LayoutList drawGitadoraStrumA();
+        LayoutList drawDancepadDDRRight();
+        LayoutList drawDancepadPIURight();
+        LayoutList drawPopnB();
+        LayoutList drawTaikoB();
+        LayoutList drawBMTurntableB();
+        LayoutList drawBM5KeyB();
+        LayoutList drawBM7KeyB();
+        LayoutList drawGitadoraFretB();
+        LayoutList drawGitadoraStrumB();
+    private:
+        LayoutManager(){}
+
+        std::string getLayoutNameByID();
+
+        std::map<uint16_t,LayoutFunction> GPButtonLayouts_LeftLayouts = {
+            // levers
+            // parameters: x, y, radiusX/width, radiusY/height, stroke, fill, DpadMode
+            {BUTTON_LAYOUT_STICK,                     [this]() { return this->drawArcadeStick(); }},
+            {BUTTON_LAYOUT_TWINSTICKA,                [this]() { return this->drawTwinStickA(); }},
+            {BUTTON_LAYOUT_VLXA,                      [this]() { return this->drawVLXA(); }},
+            {BUTTON_LAYOUT_FIGHTBOARD_STICK,          [this]() { return this->drawFightboardStick(); }},
+
+            // buttons
+            // parameters: x, y, radiusX/width, radiusY/height, stroke, fill, Gamepad button mask, shape
+            {BUTTON_LAYOUT_STICKLESS,                 [this]() { return this->drawStickless(); }},
+            {BUTTON_LAYOUT_BUTTONS_ANGLED,            [this]() { return this->drawUDLR(); }},
+            {BUTTON_LAYOUT_BUTTONS_BASIC,             [this]() { return this->drawMAMEA(); }},
+            {BUTTON_LAYOUT_KEYBOARD_ANGLED,           [this]() { return this->drawKeyboardAngled(); }},
+            {BUTTON_LAYOUT_KEYBOARDA,                 [this]() { return this->drawWasdBox(); }},
+            {BUTTON_LAYOUT_DANCEPADA,                 [this]() { return this->drawDancepadA(); }},
+            {BUTTON_LAYOUT_BLANKA,                    [this]() { return this->drawBlankA(); }},
+            {BUTTON_LAYOUT_FIGHTBOARD_MIRRORED,       [this]() { return this->drawFightboardMirrored(); }},
+            {BUTTON_LAYOUT_CUSTOMA,                   [this]() { return this->drawButtonLayoutLeft(); }},
+            {BUTTON_LAYOUT_OPENCORE0WASDA,            [this]() { return this->drawOpenCore0WASDA(); }},
+            {BUTTON_LAYOUT_STICKLESS_13,              [this]() { return this->drawStickless13A(); }},
+            {BUTTON_LAYOUT_STICKLESS_16,              [this]() { return this->drawStickless16A(); }},
+            {BUTTON_LAYOUT_STICKLESS_14,              [this]() { return this->drawStickless14A(); }},
+            {BUTTON_LAYOUT_DANCEPADA,                 [this]() { return this->drawDancepadA(); }},
+
+            {BUTTON_LAYOUT_DANCEPAD_DDR_LEFT,         [this]() { return this->drawDancepadDDRLeft(); }},
+            {BUTTON_LAYOUT_DANCEPAD_DDR_SOLO,         [this]() { return this->drawDancepadDDRSolo(); }},
+            {BUTTON_LAYOUT_DANCEPAD_PIU_LEFT,         [this]() { return this->drawDancepadPIULeft(); }},
+            {BUTTON_LAYOUT_POPN_A,                    [this]() { return this->drawPopnA(); }},
+            {BUTTON_LAYOUT_TAIKO_A,                   [this]() { return this->drawTaikoA(); }},
+            {BUTTON_LAYOUT_BM_TURNTABLE_A,            [this]() { return this->drawBMTurntableA(); }},
+            {BUTTON_LAYOUT_BM_5KEY_A,                 [this]() { return this->drawBM5KeyA(); }},
+            {BUTTON_LAYOUT_BM_7KEY_A,                 [this]() { return this->drawBM7KeyA(); }},
+            {BUTTON_LAYOUT_GITADORA_FRET_A,           [this]() { return this->drawGitadoraFretA(); }},
+            {BUTTON_LAYOUT_GITADORA_STRUM_A,          [this]() { return this->drawGitadoraStrumA(); }},
+
+            {BUTTON_LAYOUT_BOARD_DEFINED_A,           [this]() { return this->drawBoardDefinedA(); }},
+        };
+
+        std::map<uint16_t,LayoutFunction> GPButtonLayouts_RightLayouts = {
+            {BUTTON_LAYOUT_ARCADE,                    [this]() { return this->drawArcadeButtons(); }},
+            {BUTTON_LAYOUT_STICKLESSB,                [this]() { return this->drawSticklessButtons(); }},
+            {BUTTON_LAYOUT_BUTTONS_ANGLEDB,           [this]() { return this->drawMAMEB(); }},
+            {BUTTON_LAYOUT_VEWLIX,                    [this]() { return this->drawVewlix(); }},
+            {BUTTON_LAYOUT_VEWLIX7,                   [this]() { return this->drawVewlix7(); }},
+            {BUTTON_LAYOUT_CAPCOM,                    [this]() { return this->drawCapcom(); }},
+            {BUTTON_LAYOUT_CAPCOM6,                   [this]() { return this->drawCapcom6(); }},
+            {BUTTON_LAYOUT_SEGA2P,                    [this]() { return this->drawSega2p(); }},
+            {BUTTON_LAYOUT_NOIR8,                     [this]() { return this->drawNoir8(); }},
+            {BUTTON_LAYOUT_KEYBOARDB,                 [this]() { return this->drawMAMEB(); }},
+            {BUTTON_LAYOUT_TWINSTICKB,                [this]() { return this->drawTwinStickB(); }},
+            {BUTTON_LAYOUT_BLANKB,                    [this]() { return this->drawBlankB(); }},
+            {BUTTON_LAYOUT_VLXB,                      [this]() { return this->drawVLXB(); }},
+            {BUTTON_LAYOUT_FIGHTBOARD,                [this]() { return this->drawFightboard(); }},
+            {BUTTON_LAYOUT_FIGHTBOARD_STICK_MIRRORED, [this]() { return this->drawFightboardStickMirrored(); }},
+            {BUTTON_LAYOUT_CUSTOMB,                   [this]() { return this->drawButtonLayoutRight(); }},
+            {BUTTON_LAYOUT_KEYBOARD8B,                [this]() { return this->drawMAME8B(); }},
+            {BUTTON_LAYOUT_OPENCORE0WASDB,            [this]() { return this->drawOpenCore0WASDB(); }},
+            {BUTTON_LAYOUT_STICKLESS_13B,             [this]() { return this->drawSticklessButtons13B(); }},
+            {BUTTON_LAYOUT_STICKLESS_16B,             [this]() { return this->drawSticklessButtons16B(); }},
+            {BUTTON_LAYOUT_STICKLESS_14B,             [this]() { return this->drawSticklessButtons14B(); }},
+            {BUTTON_LAYOUT_DANCEPADB,                 [this]() { return this->drawDancepadB(); }},
+
+            {BUTTON_LAYOUT_DANCEPAD_DDR_RIGHT,        [this]() { return this->drawDancepadDDRRight(); }},
+            {BUTTON_LAYOUT_DANCEPAD_PIU_RIGHT,        [this]() { return this->drawDancepadPIURight(); }},
+            {BUTTON_LAYOUT_POPN_B,                    [this]() { return this->drawPopnB(); }},
+            {BUTTON_LAYOUT_TAIKO_B,                   [this]() { return this->drawTaikoB(); }},
+            {BUTTON_LAYOUT_BM_TURNTABLE_B,            [this]() { return this->drawBMTurntableB(); }},
+            {BUTTON_LAYOUT_BM_5KEY_B,                 [this]() { return this->drawBM5KeyB(); }},
+            {BUTTON_LAYOUT_BM_7KEY_B,                 [this]() { return this->drawBM7KeyB(); }},
+            {BUTTON_LAYOUT_GITADORA_FRET_B,           [this]() { return this->drawGitadoraFretB(); }},
+            {BUTTON_LAYOUT_GITADORA_STRUM_B,          [this]() { return this->drawGitadoraStrumB(); }},
+
+            {BUTTON_LAYOUT_BOARD_DEFINED_B,           [this]() { return this->drawBoardDefinedB(); }},
+        };
+};
+
+#endif

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -4,6 +4,7 @@
 
 #include "storagemanager.h"
 #include "configmanager.h"
+#include "layoutmanager.h"
 #include "AnimationStorage.hpp"
 #include "system.h"
 #include "config_utils.h"
@@ -810,6 +811,93 @@ std::string getLedOptions()
 	writeDoc(doc, "pledColor", ((RGB)ledOptions.pledColor).value(LED_FORMAT_RGB));
 
 	return serialize_json(doc);
+}
+
+std::string getButtonLayoutDefs()
+{
+    DynamicJsonDocument doc(LWIP_HTTPD_POST_MAX_PAYLOAD_LEN);
+    uint16_t layoutCtr = 0;
+
+    for (layoutCtr = _ButtonLayout_MIN; layoutCtr < _ButtonLayout_ARRAYSIZE; layoutCtr++) {
+        writeDoc(doc, "buttonLayout", LayoutManager::getInstance().getButtonLayoutName((ButtonLayout)layoutCtr), layoutCtr);
+    }
+    
+    for (layoutCtr = _ButtonLayoutRight_MIN; layoutCtr < _ButtonLayoutRight_ARRAYSIZE; layoutCtr++) {
+        writeDoc(doc, "buttonLayoutRight", LayoutManager::getInstance().getButtonLayoutRightName((ButtonLayoutRight)layoutCtr), layoutCtr);
+    }
+
+    return serialize_json(doc);
+}
+
+std::string getButtonLayouts()
+{
+    DynamicJsonDocument doc(LWIP_HTTPD_POST_MAX_PAYLOAD_LEN);
+    const LEDOptions& ledOptions = Storage::getInstance().getLedOptions();
+    const DisplayOptions& displayOptions = Storage::getInstance().getDisplayOptions();
+    uint16_t elementCtr = 0;
+    
+    LayoutManager::LayoutList layoutA = LayoutManager::getInstance().getLayoutA();
+    LayoutManager::LayoutList layoutB = LayoutManager::getInstance().getLayoutB();
+
+    writeDoc(doc, "ledLayout", "id", ledOptions.ledLayout);
+	writeDoc(doc, "ledLayout", "indexUp", ledOptions.indexUp);
+	writeDoc(doc, "ledLayout", "indexDown", ledOptions.indexDown);
+	writeDoc(doc, "ledLayout", "indexLeft", ledOptions.indexLeft);
+	writeDoc(doc, "ledLayout", "indexRight", ledOptions.indexRight);
+	writeDoc(doc, "ledLayout", "indexB1", ledOptions.indexB1);
+	writeDoc(doc, "ledLayout", "indexB2", ledOptions.indexB2);
+	writeDoc(doc, "ledLayout", "indexB3", ledOptions.indexB3);
+	writeDoc(doc, "ledLayout", "indexB4", ledOptions.indexB4);
+	writeDoc(doc, "ledLayout", "indexL1", ledOptions.indexL1);
+	writeDoc(doc, "ledLayout", "indexR1", ledOptions.indexR1);
+	writeDoc(doc, "ledLayout", "indexL2", ledOptions.indexL2);
+	writeDoc(doc, "ledLayout", "indexR2", ledOptions.indexR2);
+	writeDoc(doc, "ledLayout", "indexS1", ledOptions.indexS1);
+	writeDoc(doc, "ledLayout", "indexS2", ledOptions.indexS2);
+	writeDoc(doc, "ledLayout", "indexL3", ledOptions.indexL3);
+	writeDoc(doc, "ledLayout", "indexR3", ledOptions.indexR3);
+	writeDoc(doc, "ledLayout", "indexA1", ledOptions.indexA1);
+	writeDoc(doc, "ledLayout", "indexA2", ledOptions.indexA2);
+
+    writeDoc(doc, "displayLayouts", "buttonLayoutId", displayOptions.buttonLayout);
+    for (elementCtr = 0; elementCtr < layoutA.size(); elementCtr++) {
+        DynamicJsonDocument ele(LWIP_HTTPD_POST_MAX_PAYLOAD_LEN);
+
+        writeDoc(ele, "elementType", layoutA[elementCtr].elementType);
+        writeDoc(ele, "parameters", "x1", layoutA[elementCtr].parameters.x1);
+        writeDoc(ele, "parameters", "y1", layoutA[elementCtr].parameters.y1);
+        writeDoc(ele, "parameters", "x2", layoutA[elementCtr].parameters.x2);
+        writeDoc(ele, "parameters", "y2", layoutA[elementCtr].parameters.y2);
+        writeDoc(ele, "parameters", "stroke", layoutA[elementCtr].parameters.stroke);
+        writeDoc(ele, "parameters", "fill", layoutA[elementCtr].parameters.fill);
+        writeDoc(ele, "parameters", "value", layoutA[elementCtr].parameters.value);
+        writeDoc(ele, "parameters", "shape", layoutA[elementCtr].parameters.shape);
+        writeDoc(ele, "parameters", "angleStart", layoutA[elementCtr].parameters.angleStart);
+        writeDoc(ele, "parameters", "angleEnd", layoutA[elementCtr].parameters.angleEnd);
+        writeDoc(ele, "parameters", "closed", layoutA[elementCtr].parameters.closed);
+        writeDoc(doc, "displayLayouts", "buttonLayout", std::to_string(elementCtr), ele);
+    }
+
+    writeDoc(doc, "displayLayouts", "buttonLayoutRightId", displayOptions.buttonLayoutRight);
+    for (elementCtr = 0; elementCtr < layoutB.size(); elementCtr++) {
+        DynamicJsonDocument ele(LWIP_HTTPD_POST_MAX_PAYLOAD_LEN);
+
+        writeDoc(ele, "elementType", layoutB[elementCtr].elementType);
+        writeDoc(ele, "parameters", "x1", layoutB[elementCtr].parameters.x1);
+        writeDoc(ele, "parameters", "y1", layoutB[elementCtr].parameters.y1);
+        writeDoc(ele, "parameters", "x2", layoutB[elementCtr].parameters.x2);
+        writeDoc(ele, "parameters", "y2", layoutB[elementCtr].parameters.y2);
+        writeDoc(ele, "parameters", "stroke", layoutB[elementCtr].parameters.stroke);
+        writeDoc(ele, "parameters", "fill", layoutB[elementCtr].parameters.fill);
+        writeDoc(ele, "parameters", "value", layoutB[elementCtr].parameters.value);
+        writeDoc(ele, "parameters", "shape", layoutB[elementCtr].parameters.shape);
+        writeDoc(ele, "parameters", "angleStart", layoutB[elementCtr].parameters.angleStart);
+        writeDoc(ele, "parameters", "angleEnd", layoutB[elementCtr].parameters.angleEnd);
+        writeDoc(ele, "parameters", "closed", layoutB[elementCtr].parameters.closed);
+        writeDoc(doc, "displayLayouts", "buttonLayoutRight", std::to_string(elementCtr), ele);
+    }
+    
+    return serialize_json(doc);
 }
 
 std::string setCustomTheme()
@@ -1989,6 +2077,8 @@ static const std::pair<const char*, HandlerFuncPtr> handlerFuncs[] =
 	{ "/api/reboot", reboot },
 	{ "/api/getDisplayOptions", getDisplayOptions },
 	{ "/api/getGamepadOptions", getGamepadOptions },
+	{ "/api/getButtonLayoutDefs", getButtonLayoutDefs },
+	{ "/api/getButtonLayouts", getButtonLayouts },
 	{ "/api/getLedOptions", getLedOptions },
 	{ "/api/getPinMappings", getPinMappings },
 	{ "/api/getProfileOptions", getProfileOptions },

--- a/src/display/ui/screens/ButtonLayoutScreen.cpp
+++ b/src/display/ui/screens/ButtonLayoutScreen.cpp
@@ -7,345 +7,6 @@ void ButtonLayoutScreen::drawScreen() {
     getRenderer()->drawText(0, 7, footer);
 }
 
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawButtonLayoutLeft()
-{
-    const DisplayOptions& options = Storage::getInstance().getDisplayOptions();
-    ButtonLayoutCustomOptions buttonLayoutCustomOptions = options.buttonLayoutCustomOptions;
-    ButtonLayoutParamsLeft leftOptions = buttonLayoutCustomOptions.paramsLeft;
-    return adjustByCustomSettings(GPButtonLayouts_LeftLayouts.at(leftOptions.layout)(), leftOptions.common);
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawButtonLayoutRight()
-{
-    const DisplayOptions& options = Storage::getInstance().getDisplayOptions();
-    ButtonLayoutCustomOptions buttonLayoutCustomOptions = options.buttonLayoutCustomOptions;
-    ButtonLayoutParamsRight rightOptions = buttonLayoutCustomOptions.paramsRight;
-    return adjustByCustomSettings(GPButtonLayouts_RightLayouts.at(rightOptions.layout)(), rightOptions.common, 64);
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::adjustByCustomSettings(ButtonLayoutScreen::LayoutList layout, ButtonLayoutParamsCommon common, uint16_t originX, uint16_t originY) {
-    if (layout.size() > 0) {
-        int32_t startX = layout[0].parameters[0];
-        int32_t startY = layout[0].parameters[1];
-        int32_t customX = common.startX;
-        int32_t customY = common.startY;
-        int32_t offsetX = customX-startX;
-        int32_t offsetY = customY-startY;
-        for (uint16_t elementCtr = 0; elementCtr < layout.size(); elementCtr++) {
-            if (layout[elementCtr].elementType == GP_ELEMENT_BTN_BUTTON) {
-                layout[elementCtr].parameters[0] += originX+(offsetX+common.buttonPadding);
-                layout[elementCtr].parameters[1] += originY+(offsetY+common.buttonPadding);
-            } else {
-                layout[elementCtr].parameters[0] += originX+offsetX;
-                layout[elementCtr].parameters[1] += originY+offsetY;
-            }
-
-            if (((GPShape_Type)layout[elementCtr].parameters[7] == GP_SHAPE_ELLIPSE) || ((GPShape_Type)layout[elementCtr].parameters[7] == GP_SHAPE_POLYGON)) {
-                // radius
-                layout[elementCtr].parameters[2] = common.buttonRadius;
-                layout[elementCtr].parameters[3] = common.buttonRadius;
-            }
-        }
-    }
-    return layout;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawStickless()
-{
-	return BUTTON_GROUP_STICKLESS;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawWasdBox()
-{
-    return BUTTON_GROUP_WASD_BOX;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawUDLR()
-{
-    return BUTTON_GROUP_UDLR;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawArcadeStick()
-{
-    return BUTTON_GROUP_ARCADE_STICK;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawVLXA()
-{
-    return BUTTON_GROUP_VLXA;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawFightboardMirrored()
-{
-    return BUTTON_GROUP_FIGHTBOARD_MIRRORED;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawFightboardStick()
-{
-    return BUTTON_GROUP_FIGHTBOARD_STICK;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawFightboardStickMirrored()
-{
-    return BUTTON_GROUP_FIGHTBOARD_STICK_MIRRORED;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawTwinStickA()
-{
-    return BUTTON_GROUP_TWINSTICK_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawTwinStickB()
-{
-    return BUTTON_GROUP_TWINSTICK_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawMAMEA()
-{
-    return BUTTON_GROUP_MAME_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawOpenCore0WASDA()
-{
-    return BUTTON_GROUP_OPEN_CORE_WASD_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawMAMEB()
-{
-    return BUTTON_GROUP_MAME_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawMAME8B()
-{
-    return BUTTON_GROUP_MAME_8B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawOpenCore0WASDB()
-{
-    return BUTTON_GROUP_OPEN_CORE_WASD_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawKeyboardAngled()
-{
-    return BUTTON_GROUP_KEYBOARD_ANGLED;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawVewlix()
-{
-    return BUTTON_GROUP_VEWLIX;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawVLXB()
-{
-    return BUTTON_GROUP_VLXB;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawFightboard()
-{
-    return BUTTON_GROUP_FIGHTBOARD;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawVewlix7()
-{
-    return BUTTON_GROUP_VEWLIX7;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawSega2p()
-{
-    return BUTTON_GROUP_SEGA_2P;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawNoir8()
-{
-    return BUTTON_GROUP_NOIR8;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawCapcom()
-{
-    return BUTTON_GROUP_CAPCOM;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawCapcom6()
-{
-    return BUTTON_GROUP_CAPCOM6;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawSticklessButtons()
-{
-    return BUTTON_GROUP_STICKLESS_BUTTONS;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawWasdButtons()
-{
-    return BUTTON_GROUP_WASD_BUTTONS;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawArcadeButtons()
-{
-    return BUTTON_GROUP_ARCADE_BUTTONS;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawStickless13A()
-{
-    return BUTTON_GROUP_STICKLESS13A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawSticklessButtons13B()
-{
-    return BUTTON_GROUP_STICKLESS_BUTTONS13B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawStickless16A()
-{
-    return BUTTON_GROUP_STICKLESS16A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawSticklessButtons16B()
-{
-    return BUTTON_GROUP_STICKLESS_BUTTONS16B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawStickless14A()
-{
-    return BUTTON_GROUP_STICKLESS14A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawSticklessButtons14B()
-{
-    return BUTTON_GROUP_STICKLESS_BUTTONS14B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawDancepadA()
-{
-    return BUTTON_GROUP_DANCEPAD_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawDancepadB()
-{
-    return BUTTON_GROUP_DANCEPAD_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawDancepadDDRLeft()
-{
-    return BUTTON_GROUP_DANCEPAD_DDR_LEFT;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawDancepadDDRSolo()
-{
-    return BUTTON_GROUP_DANCEPAD_DDR_SOLO;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawDancepadPIULeft()
-{
-    return BUTTON_GROUP_DANCEPAD_PIU_LEFT;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawPopnA()
-{
-    return BUTTON_GROUP_POPN_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawTaikoA()
-{
-    return BUTTON_GROUP_TAIKO_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBMTurntableA()
-{
-    return BUTTON_GROUP_BM_TURNTABLE_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBM5KeyA()
-{
-    return BUTTON_GROUP_BM_5KEY_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBM7KeyA()
-{
-    return BUTTON_GROUP_BM_7KEY_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawGitadoraFretA()
-{
-    return BUTTON_GROUP_GITADORA_FRET_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawGitadoraStrumA()
-{
-    return BUTTON_GROUP_GITADORA_STRUM_A;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawDancepadDDRRight()
-{
-    return BUTTON_GROUP_DANCEPAD_DDR_RIGHT;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawDancepadPIURight()
-{
-    return BUTTON_GROUP_DANCEPAD_PIU_RIGHT;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawPopnB()
-{
-    return BUTTON_GROUP_POPN_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawTaikoB()
-{
-    return BUTTON_GROUP_TAIKO_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBMTurntableB()
-{
-    return BUTTON_GROUP_BM_TURNTABLE_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBM5KeyB()
-{
-    return BUTTON_GROUP_BM_5KEY_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBM7KeyB()
-{
-    return BUTTON_GROUP_BM_7KEY_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawGitadoraFretB()
-{
-    return BUTTON_GROUP_GITADORA_FRET_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawGitadoraStrumB()
-{
-    return BUTTON_GROUP_GITADORA_STRUM_B;
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBlankA()
-{
-    return {};
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBlankB()
-{
-    return {};
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBoardDefinedA() {
-#ifdef DEFAULT_BOARD_LAYOUT_A
-    return DEFAULT_BOARD_LAYOUT_A;
-#else
-    return drawBlankA();
-#endif
-}
-
-ButtonLayoutScreen::LayoutList ButtonLayoutScreen::drawBoardDefinedB() {
-#ifdef DEFAULT_BOARD_LAYOUT_B
-    return DEFAULT_BOARD_LAYOUT_B;
-#else
-    return drawBlankA();
-#endif
-}
-
 GPLever* ButtonLayoutScreen::drawLever(uint16_t startX, uint16_t startY, uint16_t sizeX, uint16_t sizeY, uint16_t strokeColor, uint16_t fillColor, uint16_t inputType) {
     GPLever* lever = new GPLever();
     lever->setRenderer(getRenderer());
@@ -405,29 +66,29 @@ GPWidget* ButtonLayoutScreen::drawElement(GPButtonLayout element) {
     }
 
     if (element.elementType == GP_ELEMENT_LEVER) {
-        return drawLever(element.parameters[0], element.parameters[1]-yOffset, element.parameters[2], element.parameters[3], element.parameters[4], element.parameters[5], element.parameters[6]);
+        return drawLever(element.parameters.x1, element.parameters.y1-yOffset, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill, element.parameters.value);
     } else if ((element.elementType == GP_ELEMENT_BTN_BUTTON) || (element.elementType == GP_ELEMENT_DIR_BUTTON) || (element.elementType == GP_ELEMENT_PIN_BUTTON)) {
-        GPButton* button = drawButton(element.parameters[0], element.parameters[1]-yOffset, element.parameters[2], element.parameters[3], element.parameters[4], element.parameters[5], element.parameters[6]);
+        GPButton* button = drawButton(element.parameters.x1, element.parameters.y1-yOffset, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill, element.parameters.value);
 
         // set type of button
         button->setInputType(element.elementType);
         button->setInputDirection(false);
-        button->setShape((GPShape_Type)element.parameters[7]);
-        button->setAngle(element.parameters[8]);
-        button->setAngleEnd(element.parameters[9]);
-        button->setClosed(element.parameters[10]);
+        button->setShape((GPShape_Type)element.parameters.shape);
+        button->setAngle(element.parameters.angleStart);
+        button->setAngleEnd(element.parameters.angleEnd);
+        button->setClosed(element.parameters.closed);
 
         if (element.elementType == GP_ELEMENT_DIR_BUTTON) button->setInputDirection(true);
 
         return (GPWidget*)button;
     } else if (element.elementType == GP_ELEMENT_SPRITE) {
-        return drawSprite(element.parameters[0], element.parameters[1]-yOffset, element.parameters[2], element.parameters[3]);
+        return drawSprite(element.parameters.x1, element.parameters.y1-yOffset, element.parameters.x2, element.parameters.y2);
     } else if (element.elementType == GP_ELEMENT_SHAPE) {
-        GPShape* shape = drawShape(element.parameters[0], element.parameters[1]-yOffset, element.parameters[2], element.parameters[3], element.parameters[4], element.parameters[5]);
-        shape->setShape((GPShape_Type)element.parameters[7]);
-        shape->setAngle(element.parameters[8]);
-        shape->setAngleEnd(element.parameters[9]);
-        shape->setClosed(element.parameters[10]);
+        GPShape* shape = drawShape(element.parameters.x1, element.parameters.y1-yOffset, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill);
+        shape->setShape((GPShape_Type)element.parameters.shape);
+        shape->setAngle(element.parameters.angleStart);
+        shape->setAngleEnd(element.parameters.angleEnd);
+        shape->setClosed(element.parameters.closed);
         return shape;
     }
     return NULL;
@@ -446,10 +107,8 @@ int8_t ButtonLayoutScreen::update() {
 
         // load layout
         uint16_t elementCtr = 0;
-        uint16_t layoutLeft = Storage::getInstance().getDisplayOptions().buttonLayout;
-        uint16_t layoutRight = Storage::getInstance().getDisplayOptions().buttonLayoutRight;
-        LayoutList currLayoutLeft = GPButtonLayouts_LeftLayouts.at(layoutLeft)();
-        LayoutList currLayoutRight = GPButtonLayouts_RightLayouts.at(layoutRight)();
+        LayoutManager::LayoutList currLayoutLeft = LayoutManager::getInstance().getLayoutA();
+        LayoutManager::LayoutList currLayoutRight = LayoutManager::getInstance().getLayoutB();
         for (elementCtr = 0; elementCtr < currLayoutLeft.size(); elementCtr++) {
             drawElement(currLayoutLeft[elementCtr]);
         }

--- a/src/layoutmanager.cpp
+++ b/src/layoutmanager.cpp
@@ -1,0 +1,381 @@
+#include "layoutmanager.h"
+#include "storagemanager.h"
+#include "buttonlayouts.h"
+#include "enums.pb.h"
+
+LayoutManager::LayoutList LayoutManager::getLayoutA() {
+    uint16_t layoutLeft = Storage::getInstance().getDisplayOptions().buttonLayout;
+    return GPButtonLayouts_LeftLayouts.at(layoutLeft)();
+}
+
+LayoutManager::LayoutList LayoutManager::getLayoutB() {
+    uint16_t layoutRight = Storage::getInstance().getDisplayOptions().buttonLayoutRight;
+    return GPButtonLayouts_RightLayouts.at(layoutRight)();
+}
+
+std::string LayoutManager::getLayoutAName() {
+    uint16_t layoutLeft = Storage::getInstance().getDisplayOptions().buttonLayout;
+    return getButtonLayoutName((ButtonLayout)layoutLeft);
+}
+
+std::string LayoutManager::getLayoutBName() {
+    uint16_t layoutRight = Storage::getInstance().getDisplayOptions().buttonLayoutRight;
+    return getButtonLayoutRightName((ButtonLayoutRight)layoutRight);
+}
+
+std::string LayoutManager::getButtonLayoutName(ButtonLayout layout) {
+    #define ENUM_CASE(name, value) case name: return #name;
+    switch (layout) {
+        ButtonLayout_VALUELIST(ENUM_CASE)
+        default: return "BUTTON_LAYOUT_UNKNOWN";
+    }
+    #undef ENUM_CASE
+}
+
+std::string LayoutManager::getButtonLayoutRightName(ButtonLayoutRight layout) {
+    #define ENUM_CASE(name, value) case name: return #name;
+    switch (layout) {
+        ButtonLayoutRight_VALUELIST(ENUM_CASE)
+        default: return "BUTTON_LAYOUT_UNKNOWN";
+    }
+    #undef ENUM_CASE
+}
+
+LayoutManager::LayoutList LayoutManager::drawButtonLayoutLeft()
+{
+    const DisplayOptions& options = Storage::getInstance().getDisplayOptions();
+    ButtonLayoutCustomOptions buttonLayoutCustomOptions = options.buttonLayoutCustomOptions;
+    ButtonLayoutParamsLeft leftOptions = buttonLayoutCustomOptions.paramsLeft;
+    return adjustByCustomSettings(GPButtonLayouts_LeftLayouts.at(leftOptions.layout)(), leftOptions.common);
+}
+
+LayoutManager::LayoutList LayoutManager::drawButtonLayoutRight()
+{
+    const DisplayOptions& options = Storage::getInstance().getDisplayOptions();
+    ButtonLayoutCustomOptions buttonLayoutCustomOptions = options.buttonLayoutCustomOptions;
+    ButtonLayoutParamsRight rightOptions = buttonLayoutCustomOptions.paramsRight;
+    return adjustByCustomSettings(GPButtonLayouts_RightLayouts.at(rightOptions.layout)(), rightOptions.common, 64);
+}
+
+LayoutManager::LayoutList LayoutManager::adjustByCustomSettings(LayoutManager::LayoutList layout, ButtonLayoutParamsCommon common, uint16_t originX, uint16_t originY) {
+    if (layout.size() > 0) {
+        int32_t startX = layout[0].parameters.x1;
+        int32_t startY = layout[0].parameters.y1;
+        int32_t customX = common.startX;
+        int32_t customY = common.startY;
+        int32_t offsetX = customX-startX;
+        int32_t offsetY = customY-startY;
+        for (uint16_t elementCtr = 0; elementCtr < layout.size(); elementCtr++) {
+            if (layout[elementCtr].elementType == GP_ELEMENT_BTN_BUTTON) {
+                layout[elementCtr].parameters.x1 += originX+(offsetX+common.buttonPadding);
+                layout[elementCtr].parameters.y1 += originY+(offsetY+common.buttonPadding);
+            } else {
+                layout[elementCtr].parameters.x1 += originX+offsetX;
+                layout[elementCtr].parameters.y1 += originY+offsetY;
+            }
+
+            if (((GPShape_Type)layout[elementCtr].parameters.shape == GP_SHAPE_ELLIPSE) || ((GPShape_Type)layout[elementCtr].parameters.shape == GP_SHAPE_POLYGON)) {
+                // radius
+                layout[elementCtr].parameters.x2 = common.buttonRadius;
+                layout[elementCtr].parameters.y2 = common.buttonRadius;
+            }
+        }
+    }
+    return layout;
+}
+
+LayoutManager::LayoutList LayoutManager::drawStickless()
+{
+	return BUTTON_GROUP_STICKLESS;
+}
+
+LayoutManager::LayoutList LayoutManager::drawWasdBox()
+{
+    return BUTTON_GROUP_WASD_BOX;
+}
+
+LayoutManager::LayoutList LayoutManager::drawUDLR()
+{
+    return BUTTON_GROUP_UDLR;
+}
+
+LayoutManager::LayoutList LayoutManager::drawArcadeStick()
+{
+    return BUTTON_GROUP_ARCADE_STICK;
+}
+
+LayoutManager::LayoutList LayoutManager::drawVLXA()
+{
+    return BUTTON_GROUP_VLXA;
+}
+
+LayoutManager::LayoutList LayoutManager::drawFightboardMirrored()
+{
+    return BUTTON_GROUP_FIGHTBOARD_MIRRORED;
+}
+
+LayoutManager::LayoutList LayoutManager::drawFightboardStick()
+{
+    return BUTTON_GROUP_FIGHTBOARD_STICK;
+}
+
+LayoutManager::LayoutList LayoutManager::drawFightboardStickMirrored()
+{
+    return BUTTON_GROUP_FIGHTBOARD_STICK_MIRRORED;
+}
+
+LayoutManager::LayoutList LayoutManager::drawTwinStickA()
+{
+    return BUTTON_GROUP_TWINSTICK_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawTwinStickB()
+{
+    return BUTTON_GROUP_TWINSTICK_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawMAMEA()
+{
+    return BUTTON_GROUP_MAME_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawOpenCore0WASDA()
+{
+    return BUTTON_GROUP_OPEN_CORE_WASD_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawMAMEB()
+{
+    return BUTTON_GROUP_MAME_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawMAME8B()
+{
+    return BUTTON_GROUP_MAME_8B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawOpenCore0WASDB()
+{
+    return BUTTON_GROUP_OPEN_CORE_WASD_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawKeyboardAngled()
+{
+    return BUTTON_GROUP_KEYBOARD_ANGLED;
+}
+
+LayoutManager::LayoutList LayoutManager::drawVewlix()
+{
+    return BUTTON_GROUP_VEWLIX;
+}
+
+LayoutManager::LayoutList LayoutManager::drawVLXB()
+{
+    return BUTTON_GROUP_VLXB;
+}
+
+LayoutManager::LayoutList LayoutManager::drawFightboard()
+{
+    return BUTTON_GROUP_FIGHTBOARD;
+}
+
+LayoutManager::LayoutList LayoutManager::drawVewlix7()
+{
+    return BUTTON_GROUP_VEWLIX7;
+}
+
+LayoutManager::LayoutList LayoutManager::drawSega2p()
+{
+    return BUTTON_GROUP_SEGA_2P;
+}
+
+LayoutManager::LayoutList LayoutManager::drawNoir8()
+{
+    return BUTTON_GROUP_NOIR8;
+}
+
+LayoutManager::LayoutList LayoutManager::drawCapcom()
+{
+    return BUTTON_GROUP_CAPCOM;
+}
+
+LayoutManager::LayoutList LayoutManager::drawCapcom6()
+{
+    return BUTTON_GROUP_CAPCOM6;
+}
+
+LayoutManager::LayoutList LayoutManager::drawSticklessButtons()
+{
+    return BUTTON_GROUP_STICKLESS_BUTTONS;
+}
+
+LayoutManager::LayoutList LayoutManager::drawWasdButtons()
+{
+    return BUTTON_GROUP_WASD_BUTTONS;
+}
+
+LayoutManager::LayoutList LayoutManager::drawArcadeButtons()
+{
+    return BUTTON_GROUP_ARCADE_BUTTONS;
+}
+
+LayoutManager::LayoutList LayoutManager::drawStickless13A()
+{
+    return BUTTON_GROUP_STICKLESS13A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawSticklessButtons13B()
+{
+    return BUTTON_GROUP_STICKLESS_BUTTONS13B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawStickless16A()
+{
+    return BUTTON_GROUP_STICKLESS16A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawSticklessButtons16B()
+{
+    return BUTTON_GROUP_STICKLESS_BUTTONS16B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawStickless14A()
+{
+    return BUTTON_GROUP_STICKLESS14A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawSticklessButtons14B()
+{
+    return BUTTON_GROUP_STICKLESS_BUTTONS14B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawDancepadA()
+{
+    return BUTTON_GROUP_DANCEPAD_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawDancepadB()
+{
+    return BUTTON_GROUP_DANCEPAD_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawDancepadDDRLeft()
+{
+    return BUTTON_GROUP_DANCEPAD_DDR_LEFT;
+}
+
+LayoutManager::LayoutList LayoutManager::drawDancepadDDRSolo()
+{
+    return BUTTON_GROUP_DANCEPAD_DDR_SOLO;
+}
+
+LayoutManager::LayoutList LayoutManager::drawDancepadPIULeft()
+{
+    return BUTTON_GROUP_DANCEPAD_PIU_LEFT;
+}
+
+LayoutManager::LayoutList LayoutManager::drawPopnA()
+{
+    return BUTTON_GROUP_POPN_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawTaikoA()
+{
+    return BUTTON_GROUP_TAIKO_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawBMTurntableA()
+{
+    return BUTTON_GROUP_BM_TURNTABLE_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawBM5KeyA()
+{
+    return BUTTON_GROUP_BM_5KEY_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawBM7KeyA()
+{
+    return BUTTON_GROUP_BM_7KEY_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawGitadoraFretA()
+{
+    return BUTTON_GROUP_GITADORA_FRET_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawGitadoraStrumA()
+{
+    return BUTTON_GROUP_GITADORA_STRUM_A;
+}
+
+LayoutManager::LayoutList LayoutManager::drawDancepadDDRRight()
+{
+    return BUTTON_GROUP_DANCEPAD_DDR_RIGHT;
+}
+
+LayoutManager::LayoutList LayoutManager::drawDancepadPIURight()
+{
+    return BUTTON_GROUP_DANCEPAD_PIU_RIGHT;
+}
+
+LayoutManager::LayoutList LayoutManager::drawPopnB()
+{
+    return BUTTON_GROUP_POPN_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawTaikoB()
+{
+    return BUTTON_GROUP_TAIKO_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawBMTurntableB()
+{
+    return BUTTON_GROUP_BM_TURNTABLE_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawBM5KeyB()
+{
+    return BUTTON_GROUP_BM_5KEY_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawBM7KeyB()
+{
+    return BUTTON_GROUP_BM_7KEY_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawGitadoraFretB()
+{
+    return BUTTON_GROUP_GITADORA_FRET_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawGitadoraStrumB()
+{
+    return BUTTON_GROUP_GITADORA_STRUM_B;
+}
+
+LayoutManager::LayoutList LayoutManager::drawBlankA()
+{
+    return {};
+}
+
+LayoutManager::LayoutList LayoutManager::drawBlankB()
+{
+    return {};
+}
+
+LayoutManager::LayoutList LayoutManager::drawBoardDefinedA() {
+#ifdef DEFAULT_BOARD_LAYOUT_A
+    return DEFAULT_BOARD_LAYOUT_A;
+#else
+    return drawBlankA();
+#endif
+}
+
+LayoutManager::LayoutList LayoutManager::drawBoardDefinedB() {
+#ifdef DEFAULT_BOARD_LAYOUT_B
+    return DEFAULT_BOARD_LAYOUT_B;
+#else
+    return drawBlankA();
+#endif
+}


### PR DESCRIPTION
Fixes:
Addresses a bug with the Input History button glyph LUT that would cause the firmware to crash when run from a Debug build state.

Enhancements:
LayoutManager was created to allow sharing of built-in and custom layouts beyond the use of the OLED Display. This also includes two new API routes for the WebConfig:

* /api/getButtonLayoutDefs
  * Returns the list of ButtonLayout and ButtonLayoutRight definitions and their values.
* /api/getButtonLayouts
  * Returns the layouts for the current ButtonLayout and ButtonLayoutRight definitions, as well as the LED layout indexes.

This also includes enhancements to the button layouts to change from an unnamed array of parameters to named properties.  The defined button layouts will still use the previous structure for brevity, but the names exist to make the layout generation code easier to use.