### PR TITLE
Tweak PS4 non-hack report timer

### DIFF
--- a/src/drivers/ps4/PS4Driver.cpp
+++ b/src/drivers/ps4/PS4Driver.cpp
@@ -14,7 +14,7 @@
 #include "enums.pb.h"
 
 // force a report to be sent every X ms
-#define PS4_KEEPALIVE_TIMER 250
+#define PS4_KEEPALIVE_TIMER 2
 
 void PS4Driver::initialize() {
     //touchpadData = {

--- a/src/drivers/ps4/PS4Driver.cpp
+++ b/src/drivers/ps4/PS4Driver.cpp
@@ -14,7 +14,7 @@
 #include "enums.pb.h"
 
 // force a report to be sent every X ms
-#define PS4_KEEPALIVE_TIMER 2
+#define PS4_KEEPALIVE_TIMER 5
 
 void PS4Driver::initialize() {
     //touchpadData = {


### PR DESCRIPTION
The old keepalive timer of 250ms (four forced reports when idle, per second) functioned, but was far longer than a single frame, meaning that stuck inputs could still definitely happen, just for short periods of time. This was fine when the only game we knew about was Ultimate Chicken Horse, which, while being a platformer, is not exactly the most precision-heavy game. However, we learned in beta testing 0.7.8 that the Hamster Arcade Archives also often exhibit this problem, especially games like Tetris: the Grand Master, where precision *is absolutely* important.

Turning the timer down to sub-frame (assuming 60 Hz input mechanisms) means we have a couple opportunities to force the correct input down to the PS4 within one frame, which in my testing to this point has eliminated any stuck/missed inputs in TGM.