### PR TITLE
Allow some hotkeys to be held again

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -89,7 +89,7 @@ public:
 	}
 
 	/**
-	 * @brief Remote hotkey bits from the state bitmask and provide pressed action.
+	 * @brief Remove hotkey bits from the state bitmask and provide pressed action.
 	 */
 	inline GamepadHotkey __attribute__((always_inline)) selectHotkey(const HotkeyEntry hotkey) {
 		state.buttons &= ~(hotkey.buttonsMask);

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -284,16 +284,22 @@ void Gamepad::processHotkeyAction(GamepadHotkey action) {
 	bool reqSave = false;
 	switch (action) {
 		case HOTKEY_DPAD_DIGITAL:
-			options.dpadMode = DPAD_MODE_DIGITAL;
-			reqSave = true;
+			if (action != lastAction) {
+				options.dpadMode = DPAD_MODE_DIGITAL;
+				reqSave = true;
+			}
 			break;
 		case HOTKEY_DPAD_LEFT_ANALOG:
-			options.dpadMode = DPAD_MODE_LEFT_ANALOG;
-			reqSave = true;
+			if (action != lastAction) {
+				options.dpadMode = DPAD_MODE_LEFT_ANALOG;
+				reqSave = true;
+			}
 			break;
 		case HOTKEY_DPAD_RIGHT_ANALOG:
-			options.dpadMode = DPAD_MODE_RIGHT_ANALOG;
-			reqSave = true;
+			if (action != lastAction) {
+				options.dpadMode = DPAD_MODE_RIGHT_ANALOG;
+				reqSave = true;
+			}
 			break;
 		case HOTKEY_HOME_BUTTON:
 			state.buttons |= GAMEPAD_MASK_A1;
@@ -341,24 +347,34 @@ void Gamepad::processHotkeyAction(GamepadHotkey action) {
 			state.buttons |= GAMEPAD_MASK_A2;
 			break;
 		case HOTKEY_SOCD_UP_PRIORITY:
-			options.socdMode = SOCD_MODE_UP_PRIORITY;
-			reqSave = true;
+			if (action != lastAction) {
+				options.socdMode = SOCD_MODE_UP_PRIORITY;
+				reqSave = true;
+			}
 			break;
 		case HOTKEY_SOCD_NEUTRAL:
-			options.socdMode = SOCD_MODE_NEUTRAL;
-			reqSave = true;
+			if (action != lastAction) {
+				options.socdMode = SOCD_MODE_NEUTRAL;
+				reqSave = true;
+			}
 			break;
 		case HOTKEY_SOCD_LAST_INPUT:
-			options.socdMode = SOCD_MODE_SECOND_INPUT_PRIORITY;
-			reqSave = true;
+			if (action != lastAction) {
+				options.socdMode = SOCD_MODE_SECOND_INPUT_PRIORITY;
+				reqSave = true;
+			}
 			break;
 		case HOTKEY_SOCD_FIRST_INPUT:
-			options.socdMode = SOCD_MODE_FIRST_INPUT_PRIORITY;
-			reqSave = true;
+			if (action != lastAction) {
+				options.socdMode = SOCD_MODE_FIRST_INPUT_PRIORITY;
+				reqSave = true;
+			}
 			break;
 		case HOTKEY_SOCD_BYPASS:
-			options.socdMode = SOCD_MODE_BYPASS;
-			reqSave = true;
+			if (action != lastAction) {
+				options.socdMode = SOCD_MODE_BYPASS;
+				reqSave = true;
+			}
 			break;
 		case HOTKEY_REBOOT_DEFAULT:
 			System::reboot(System::BootMode::DEFAULT);

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -258,10 +258,11 @@ void Gamepad::hotkey()
 	else if (pressedHotkey(hotkeyOptions.hotkey14))	action = selectHotkey(hotkeyOptions.hotkey14);
 	else if (pressedHotkey(hotkeyOptions.hotkey15))	action = selectHotkey(hotkeyOptions.hotkey15);
 	else if (pressedHotkey(hotkeyOptions.hotkey16))	action = selectHotkey(hotkeyOptions.hotkey16);
-	if ( lastAction != action ) {
+	if ( action != HOTKEY_NONE ) {
+		// processHotkeyAction checks lastAction to determine if the action is repeatable or not
 		processHotkeyAction(action);
-		lastAction = action;
 	}
+	lastAction = action;
 }
 
 void Gamepad::clearState() {
@@ -425,7 +426,7 @@ void Gamepad::processHotkeyAction(GamepadHotkey action) {
 			return;
 	}
 
-	// only save if we did something different (except NONE because NONE doesn't get here)
+	// only save if requested
 	if (reqSave) {
 		save();
 	}


### PR DESCRIPTION
Some hotkeys are just chords of a sort for normal button outputs, and should be allowed to be held. Some refactoring accidentally undid that and had all hotkeys be checked against the previously run hotkey, such that they all only ran once until the hotkey was let go. This restores the old functionality and also guards some additional hotkeys that don't need to be held and should only run once because they are toggles and/or they save to flash.

Fixes #876 