### PR TITLE
update reverse input to work on the dpad state rather than pin masks

### DIFF
--- a/src/addons/reverse.cpp
+++ b/src/addons/reverse.cpp
@@ -62,13 +62,12 @@ void ReverseInput::process()
     update();
 
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
-    Mask_t values = gamepad->debouncedGpio;
 
     gamepad->state.dpad = 0
-        | input(values & mapDpadUp->pinMask,    mapDpadUp->buttonMask,      mapDpadDown->buttonMask,    actionUp,       invertYAxis)
-        | input(values & mapDpadDown->pinMask,  mapDpadDown->buttonMask,    mapDpadUp->buttonMask,      actionDown,     invertYAxis)
-        | input(values & mapDpadLeft->pinMask,  mapDpadLeft->buttonMask,    mapDpadRight->buttonMask,   actionLeft,     invertXAxis)
-        | input(values & mapDpadRight->pinMask, mapDpadRight->buttonMask,   mapDpadLeft->buttonMask,    actionRight,    invertXAxis)
+        | input(gamepad->state.dpad & mapDpadUp->buttonMask,    mapDpadUp->buttonMask,      mapDpadDown->buttonMask,    actionUp,       invertYAxis)
+        | input(gamepad->state.dpad & mapDpadDown->buttonMask,  mapDpadDown->buttonMask,    mapDpadUp->buttonMask,      actionDown,     invertYAxis)
+        | input(gamepad->state.dpad & mapDpadLeft->buttonMask,  mapDpadLeft->buttonMask,    mapDpadRight->buttonMask,   actionLeft,     invertXAxis)
+        | input(gamepad->state.dpad & mapDpadRight->buttonMask, mapDpadRight->buttonMask,   mapDpadLeft->buttonMask,    actionRight,    invertXAxis)
     ;
 
     if (pinLED != 0xff) {


### PR DESCRIPTION
using the core gamepad pin masks meant that anything that was adding to/modifying dpad state was being overwritten because they probably fired before reverse input, and thus their change to the gamepad state was being dropped because the GPIO pins themselves were inactive, so the reverse input logic thought the outputs were inactive and assigned to the dpad e.g. 0 | 0 | 0 | 0 | 0

this fixes reverse input + DDI entirely, and also allows the proper SOCD of the dpad(s) to be inverted rather than dropped.

note that reverse input only works against the dpad, I don't know if that's intended or not, but I'm leaving it as is.

Fixes #822