### PR TITLE
Enables scroll for color picker when out of view

### DIFF
--- a/www/src/Pages/CustomThemePage.scss
+++ b/www/src/Pages/CustomThemePage.scss
@@ -1,7 +1,3 @@
-.popover {
-	position: fixed !important;
-}
-
 .led-color-picker {
 	user-select: none;
 	padding-bottom: 10px;

--- a/www/src/index.scss
+++ b/www/src/index.scss
@@ -68,7 +68,6 @@ button {
 }
 
 .popover {
-	position: fixed !important;
 	z-index: 2;
 
 	.cover {


### PR DESCRIPTION
This should also solve the same issue in led config page.
A quick fix for #897

https://github.com/OpenStickCommunity/GP2040-CE/assets/5345892/15742081-a597-4979-88e8-ec2f56895e2f

