### PR TITLE
I2C peripheral device fixes

### DIFF
--- a/headers/display/GPGFX_UI.h
+++ b/headers/display/GPGFX_UI.h
@@ -6,6 +6,7 @@
 
 #include "GPGFX_core.h"
 #include "GPGFX.h"
+#include "GPGFX_UI_types.h"
 #include "config.pb.h"
 #include "GamepadState.h"
 #include "storagemanager.h"

--- a/headers/display/GPGFX_UI_types.h
+++ b/headers/display/GPGFX_UI_types.h
@@ -11,4 +11,11 @@ typedef struct {
     std::function<void()> action;
 } MenuEntry;
 
+typedef struct {
+    uint16_t top = 0;
+    uint16_t left = 0;
+    uint16_t bottom = 0;
+    uint16_t right = 0;
+} GPViewport;
+
 #endif

--- a/headers/display/ui/elements/GPWidget.h
+++ b/headers/display/ui/elements/GPWidget.h
@@ -21,6 +21,13 @@ class GPWidget : public GPGFX_UI {
         
         void setPriority(uint16_t priority) { this->_priority = priority; }
         uint16_t getPriority() { return this->_priority; }
+
+        void setViewport(uint16_t top, uint16_t left, uint16_t bottom, uint16_t right) { this->_viewport.top = top; this->_viewport.left = left; this->_viewport.bottom = bottom; this->_viewport.right = right; }
+        void setViewport(GPViewport viewport) { this->_viewport = viewport; }
+        GPViewport getViewport() { return this->_viewport; }
+
+        double getScaleX() { return ((double)(this->getViewport().right - this->getViewport().left) / (double)getRenderer()->getDriver()->getMetrics()->width); }
+        double getScaleY() { return ((double)(this->getViewport().bottom - this->getViewport().top) / (double)(getRenderer()->getDriver()->getMetrics()->height)); }
     protected:
         uint16_t x = 0;
         uint16_t y = 0;
@@ -29,6 +36,8 @@ class GPWidget : public GPGFX_UI {
         uint16_t fillColor = 0;
         uint16_t _ID;
         uint16_t _priority = 0;
+
+        GPViewport _viewport;
 };
 
 #endif

--- a/headers/display/ui/elements/GPWidget.h
+++ b/headers/display/ui/elements/GPWidget.h
@@ -26,7 +26,7 @@ class GPWidget : public GPGFX_UI {
         void setViewport(GPViewport viewport) { this->_viewport = viewport; }
         GPViewport getViewport() { return this->_viewport; }
 
-        double getScaleX() { return ((double)(this->getViewport().right - this->getViewport().left) / (double)getRenderer()->getDriver()->getMetrics()->width); }
+        double getScaleX() { return ((double)(this->getViewport().right - this->getViewport().left) / (double)(getRenderer()->getDriver()->getMetrics()->width)); }
         double getScaleY() { return ((double)(this->getViewport().bottom - this->getViewport().top) / (double)(getRenderer()->getDriver()->getMetrics()->height)); }
     protected:
         uint16_t x = 0;

--- a/headers/interfaces/i2c/displaybase.h
+++ b/headers/interfaces/i2c/displaybase.h
@@ -32,7 +32,8 @@ class GPGFX_DisplayBase {
 
         virtual void drawBuffer(uint8_t *pBuffer) {}
 
-        void setMetrics(GPGFX_DisplayMetrics* metrics) { _metrics = metrics; }
+        void setMetrics(GPGFX_DisplayMetrics* metrics) { this->_metrics = metrics; }
+        GPGFX_DisplayMetrics* getMetrics() { return this->_metrics; }
     protected:
         GPGFX_DisplayMetrics* _metrics;
 };

--- a/lib/WiiExtension/extensions/ExtensionBase.cpp
+++ b/lib/WiiExtension/extensions/ExtensionBase.cpp
@@ -90,12 +90,12 @@ void ExtensionBase::postProcess() {
 
             if ((i != WiiAnalogs::WII_ANALOG_LEFT_TRIGGER) && (i != WiiAnalogs::WII_ANALOG_RIGHT_TRIGGER)) {
                 outVal = map(outVal, _analogCalibration[i].minimum, _analogCalibration[i].maximum, minVal, maxVal);
-                outVal = map(outVal, minVal, maxVal, 0, (_analogPrecision[WiiAnalogs::WII_ANALOG_CALIBRATION_PRECISION].destination-1));
+                outVal = map(outVal, minVal, maxVal, 10, (_analogPrecision[WiiAnalogs::WII_ANALOG_CALIBRATION_PRECISION].destination-1));
             } else {
-                outVal = bounds(outVal, 0, (_analogPrecision[i].destination-1));
+                outVal = bounds(outVal, 10, (_analogPrecision[i].destination-1));
             }
 
-            if (outVal < 0) outVal = 0;
+            if (outVal < 0) outVal = 10;
             if (outVal > (_analogPrecision[i].destination-1)) outVal = (_analogPrecision[i].destination-1);
 #if WII_EXTENSION_DEBUG==true
             if (i == WiiAnalogs::WII_ANALOG_LEFT_X) {

--- a/lib/WiiExtension/extensions/GuitarExtension.cpp
+++ b/lib/WiiExtension/extensions/GuitarExtension.cpp
@@ -61,17 +61,17 @@ void GuitarExtension::init(uint8_t dataType) {
     }
 
     // preseed calibration data with max ranges
-    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_X].minimum          = WII_GUITAR_ANALOG_GAP;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_X].center           = WII_GUITAR_GATE_CENTER;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_X].maximum          = WII_GUITAR_GATE_CENTER+WII_GUITAR_GATE_SIZE;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_X].minimum          = 3;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_X].center           = 33;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_X].maximum          = 58;
 
-    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].minimum          = WII_GUITAR_ANALOG_GAP;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].center           = WII_GUITAR_GATE_CENTER;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].maximum          = WII_GUITAR_GATE_CENTER+WII_GUITAR_GATE_SIZE;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].minimum          = 3;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].center           = 33;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].maximum          = 58;
     
     _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].minimum         = 15;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].center          = WII_GUITAR_GATE_CENTER;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = WII_GUITAR_GATE_CENTER*2;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].center          = 19;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = 26;
     _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].useOffset       = false;
 
     _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_Y].minimum         = 0;
@@ -195,7 +195,9 @@ void GuitarExtension::process(uint8_t *inputData) {
 //        }
 //    }
 //    printf("Joy1 X=%4d Y=%4d  Whammy=%4d  U=%1d D=%1d -=%1d +=%1d\n", joy1X, joy1Y, whammyBar, directionUp, directionDown, buttonMinus, buttonPlus);
-//    printf("Whammy=%4d\n", analogState[WiiAnalogs::WII_ANALOG_RIGHT_X]);
+//    printf("Joy1 X=%4d Y=%4d\n", analogState[WiiAnalogs::WII_ANALOG_LEFT_X], analogState[WiiAnalogs::WII_ANALOG_LEFT_Y]);
+//    printf("Whammy=%4d:%4d\n", analogState[WiiAnalogs::WII_ANALOG_RIGHT_X], inputData[3]);
+//    printf("U=%1d D=%1d -=%1d +=%1d\n", buttons[WiiButtons::WII_BUTTON_UP], buttons[WiiButtons::WII_BUTTON_DOWN], buttons[WiiButtons::WII_BUTTON_MINUS], buttons[WiiButtons::WII_BUTTON_PLUS]);
 //    printf("O=%1d B=%1d Y=%1d R=%1d G=%1d\n", buttons[GuitarButtons::GUITAR_ORANGE], buttons[GuitarButtons::GUITAR_BLUE], buttons[GuitarButtons::GUITAR_YELLOW], buttons[GuitarButtons::GUITAR_RED], buttons[GuitarButtons::GUITAR_GREEN]);
 #endif
 }

--- a/src/addons/wiiext.cpp
+++ b/src/addons/wiiext.cpp
@@ -163,7 +163,7 @@ void WiiExtensionInput::update() {
             buttonA = wii->getController()->buttons[GuitarButtons::GUITAR_RED];
             buttonX = wii->getController()->buttons[GuitarButtons::GUITAR_YELLOW];
             buttonY = wii->getController()->buttons[GuitarButtons::GUITAR_BLUE];
-            buttonL = wii->getController()->buttons[GuitarButtons::GUITAR_ORANGE];
+            buttonZL = wii->getController()->buttons[GuitarButtons::GUITAR_ORANGE];
 
             // whammy currently maps to Joy2X in addition to the raw whammy value
             whammyBar = wii->getController()->analogState[WiiAnalogs::WII_ANALOG_RIGHT_X];

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1523,8 +1523,8 @@ std::string setWiiControls()
     readDoc(wiiOptions.controllers.guitar.buttonPedal, doc, "guitar.buttonPedal");
     readDoc(wiiOptions.controllers.guitar.buttonMinus, doc, "guitar.buttonMinus");
     readDoc(wiiOptions.controllers.guitar.buttonPlus, doc, "guitar.buttonPlus");
-    readDoc(wiiOptions.controllers.guitar.strumUp, doc, "guitar.strumUp");
-    readDoc(wiiOptions.controllers.guitar.strumDown, doc, "guitar.strumDown");
+    readDoc(wiiOptions.controllers.guitar.strumUp, doc, "guitar.buttonStrumUp");
+    readDoc(wiiOptions.controllers.guitar.strumDown, doc, "guitar.buttonStrumDown");
     readDoc(wiiOptions.controllers.guitar.stick.x.axisType, doc, "guitar.analogStick.x.axisType");
     readDoc(wiiOptions.controllers.guitar.stick.y.axisType, doc, "guitar.analogStick.y.axisType");
     readDoc(wiiOptions.controllers.guitar.whammyBar.axisType, doc, "guitar.analogWhammyBar.axisType");
@@ -1606,8 +1606,8 @@ std::string getWiiControls()
     writeDoc(doc, "guitar.buttonPedal", wiiOptions.controllers.guitar.buttonPedal);
     writeDoc(doc, "guitar.buttonMinus", wiiOptions.controllers.guitar.buttonMinus);
     writeDoc(doc, "guitar.buttonPlus", wiiOptions.controllers.guitar.buttonPlus);
-    writeDoc(doc, "guitar.strumUp", wiiOptions.controllers.guitar.strumUp);
-    writeDoc(doc, "guitar.strumDown", wiiOptions.controllers.guitar.strumDown);
+    writeDoc(doc, "guitar.buttonStrumUp", wiiOptions.controllers.guitar.strumUp);
+    writeDoc(doc, "guitar.buttonStrumDown", wiiOptions.controllers.guitar.strumDown);
     writeDoc(doc, "guitar.analogStick.x.axisType", wiiOptions.controllers.guitar.stick.x.axisType);
     writeDoc(doc, "guitar.analogStick.y.axisType", wiiOptions.controllers.guitar.stick.y.axisType);
     writeDoc(doc, "guitar.analogWhammyBar.axisType", wiiOptions.controllers.guitar.whammyBar.axisType);

--- a/src/display/ui/elements/GPButton.cpp
+++ b/src/display/ui/elements/GPButton.cpp
@@ -7,6 +7,25 @@ void GPButton::draw() {
     uint16_t baseY = this->y;
     Mask_t pinValues = ~gpio_get_all();
 
+    // scale to viewport
+    double scaleX = this->getScaleX();
+    double scaleY = this->getScaleY();
+
+    // set scale on X & Y to be proportionate if either is 0
+    if ((scaleX > 0.0f) & ((scaleY == 0.0f) || (scaleY == 1.0f))) {
+        scaleY = scaleX;
+    } else if (((scaleX == 0.0f) || (scaleX == 1.0f)) & (scaleY > 0.0f)) {
+        scaleX = scaleY;
+    }
+
+    if (scaleX > 0.0f) {
+        baseX = ((this->x) * scaleX + this->getViewport().left);
+    }
+
+    if (scaleY > 0.0f) {
+        baseY = ((this->y) * scaleY + this->getViewport().top);
+    }
+
     bool pinState = false;
     bool buttonState = false;
     uint16_t state = 0;
@@ -88,27 +107,30 @@ void GPButton::draw() {
 
     // base
     if (this->_shape == GP_SHAPE_ELLIPSE) {
-        uint16_t baseRadius = (uint16_t)this->_sizeX;
-        uint16_t turboRadius = (uint16_t)this->_sizeX * GP_BUTTON_TURBO_SCALE;
+        uint16_t scaledSize = (uint16_t)((double)this->_sizeX * scaleX);
+        uint16_t baseRadius = (uint16_t)scaledSize;
+        uint16_t turboRadius = (uint16_t)scaledSize * GP_BUTTON_TURBO_SCALE;
 
         getRenderer()->drawEllipse(baseX, baseY, baseRadius, baseRadius, this->strokeColor, state);
         if (this->_inputType == GP_ELEMENT_BTN_BUTTON && (getGamepad()->turboState.buttons & this->_inputMask)) {
             getRenderer()->drawEllipse(baseX, baseY, turboRadius, turboRadius, 1, 0);
         }
     } else if (this->_shape == GP_SHAPE_SQUARE) {
-        uint16_t width = this->_sizeX - baseX;
-        uint16_t height = this->_sizeY - baseY;
+        uint16_t sizeX = (this->_sizeX) * scaleX + this->getViewport().left;
+        uint16_t sizeY = (this->_sizeY) * scaleY + this->getViewport().top;
+        uint16_t width = sizeX - baseX;
+        uint16_t height = sizeY - baseY;
         uint16_t turboW = (uint16_t)round(width * GP_BUTTON_TURBO_SCALE);
         uint16_t turboH = (uint16_t)round(height * GP_BUTTON_TURBO_SCALE);
         uint16_t turboX = baseX + (width - turboW) / 2;
         uint16_t turboY = baseY + (height - turboH) / 2;
 
-        getRenderer()->drawRectangle(baseX, baseY, this->_sizeX, this->_sizeY, this->strokeColor, state);
+        getRenderer()->drawRectangle(baseX, baseY, sizeX, sizeY, this->strokeColor, state);
         if (this->_inputType == GP_ELEMENT_BTN_BUTTON && (getGamepad()->turboState.buttons & this->_inputMask)) {
             getRenderer()->drawRectangle(turboX, turboY, turboX+turboW, turboY+turboH, 1, 0);
         }
     } else if (this->_shape == GP_SHAPE_DIAMOND) {
-        uint16_t size = this->_sizeX;
+        uint16_t size = (this->_sizeX) * scaleX + this->getViewport().left;
         if (state) {
             int i;
             for (i = 0; i < size; i++) {
@@ -124,16 +146,18 @@ void GPButton::draw() {
         if (this->_inputType == GP_ELEMENT_BTN_BUTTON && (getGamepad()->turboState.buttons & this->_inputMask)) {
         }
     } else if (this->_shape == GP_SHAPE_POLYGON) {
-        uint16_t baseRadius = (uint16_t)this->_sizeX;
-        uint16_t turboRadius = (uint16_t)this->_sizeX * GP_BUTTON_TURBO_SCALE;
+        uint16_t scaledSize = (uint16_t)((double)this->_sizeX * scaleX);
+        uint16_t baseRadius = (uint16_t)scaledSize;
+        uint16_t turboRadius = (uint16_t)scaledSize * GP_BUTTON_TURBO_SCALE;
 
         getRenderer()->drawPolygon(baseX, baseY, baseRadius, this->_sizeY, this->strokeColor, state, this->_angle);
         if (this->_inputType == GP_ELEMENT_BTN_BUTTON && (getGamepad()->turboState.buttons & this->_inputMask)) {
             getRenderer()->drawPolygon(baseX, baseY, turboRadius, this->_sizeY, 1, 0, this->_angle);
         }
     } else if (this->_shape == GP_SHAPE_ARC) {
-        uint16_t baseRadius = (uint16_t)this->_sizeX;
-        uint16_t turboRadius = (uint16_t)this->_sizeX * GP_BUTTON_TURBO_SCALE;
+        uint16_t scaledSize = (uint16_t)((double)this->_sizeX * scaleX);
+        uint16_t baseRadius = (uint16_t)scaledSize;
+        uint16_t turboRadius = (uint16_t)scaledSize * GP_BUTTON_TURBO_SCALE;
 
         getRenderer()->drawArc(baseX, baseY, baseRadius, baseRadius, this->strokeColor, state, this->_angle, this->_angleEnd, this->_closed);
         if (this->_inputType == GP_ELEMENT_BTN_BUTTON && (getGamepad()->turboState.buttons & this->_inputMask)) {

--- a/src/display/ui/elements/GPLever.cpp
+++ b/src/display/ui/elements/GPLever.cpp
@@ -5,13 +5,35 @@ void GPLever::draw() {
     // radius defines the base of the lever
     // the lever indicator itself will be sized slightly smaller than the base
 
-    int baseRadius = (int)this->_radius * 1.00;
     int baseX = this->x;
     int baseY = this->y;
 
-    int leverRadius = (int)this->_radius * 0.75;
     int leverX = this->x;
     int leverY = this->y;
+
+    // scale to viewport
+    double scaleX = this->getScaleX();
+    double scaleY = this->getScaleY();
+
+    // set scale on X & Y to be proportionate if either is 0
+    if ((scaleX > 0.0f) & ((scaleY == 0.0f) || (scaleY == 1.0f))) {
+        scaleY = scaleX;
+    } else if (((scaleX == 0.0f) || (scaleX == 1.0f)) & (scaleY > 0.0f)) {
+        scaleX = scaleY;
+    }
+
+    if (scaleX > 0.0f) {
+        baseX = ((this->x) * scaleX + this->getViewport().left);
+        leverX = ((this->x) * scaleX + this->getViewport().left);
+    }
+
+    if (scaleY > 0.0f) {
+        baseY = ((this->y) * scaleY + this->getViewport().top);
+        leverY = ((this->y) * scaleY + this->getViewport().top);
+    }
+
+    int baseRadius = (int)(((double)this->_radius * 1.00) * scaleX);
+    int leverRadius = (int)(((double)this->_radius * 0.75) * scaleY);
 
     if (this->_inputType == DPAD_MODE_DIGITAL) {
         // dpad

--- a/src/display/ui/elements/GPShape.cpp
+++ b/src/display/ui/elements/GPShape.cpp
@@ -4,28 +4,52 @@ void GPShape::draw() {
     uint16_t baseX = this->x;
     uint16_t baseY = this->y;
 
+    // scale to viewport
+    double scaleX = this->getScaleX();
+    double scaleY = this->getScaleY();
+
+    // set scale on X & Y to be proportionate if either is 0
+    if ((scaleX > 0.0f) & ((scaleY == 0.0f) || (scaleY == 1.0f))) {
+        scaleY = scaleX;
+    } else if (((scaleX == 0.0f) || (scaleX == 1.0f)) & (scaleY > 0.0f)) {
+        scaleX = scaleY;
+    }
+
+    if (scaleX > 0.0f) {
+        baseX = (this->x) * scaleX + this->getViewport().left;
+    }
+
+    if (scaleY > 0.0f) {
+        baseY = (this->y) * scaleY + this->getViewport().top;
+    }
+
     // base
     if (this->_shape == GP_SHAPE_ELLIPSE) {
-        uint16_t baseRadius = (uint16_t)this->_sizeX;
+        uint16_t scaledSize = (uint16_t)((double)this->_sizeX * scaleX);
+        uint16_t baseRadius = (uint16_t)scaledSize;
 
         getRenderer()->drawEllipse(baseX, baseY, baseRadius, baseRadius, this->strokeColor, this->fillColor);
     } else if (this->_shape == GP_SHAPE_SQUARE) {
+        uint16_t sizeX = (this->_sizeX) * scaleX + this->getViewport().left;
+        uint16_t sizeY = (this->_sizeY) * scaleY + this->getViewport().top;
         uint16_t width = this->_sizeX - baseX;
         uint16_t height = this->_sizeY - baseY;
 
-        getRenderer()->drawRectangle(baseX, baseY, this->_sizeX, this->_sizeY, this->strokeColor, this->fillColor);
+        getRenderer()->drawRectangle(baseX, baseY, sizeX, sizeY, this->strokeColor, this->fillColor);
     } else if (this->_shape == GP_SHAPE_DIAMOND) {
-        uint16_t size = this->_sizeX;
+        uint16_t size = (this->_sizeX) * scaleX + this->getViewport().left;
         getRenderer()->drawLine(baseX - size, baseY, baseX, baseY - size, this->strokeColor, 0);
         getRenderer()->drawLine(baseX, baseY - size, baseX + size, baseY, this->strokeColor, 0);
         getRenderer()->drawLine(baseX + size, baseY, baseX, baseY + size, this->strokeColor, 0);
         getRenderer()->drawLine(baseX, baseY + size, baseX - size, baseY, this->strokeColor, 0);
     } else if (this->_shape == GP_SHAPE_POLYGON) {
-        uint16_t baseRadius = (uint16_t)this->_sizeX;
+        uint16_t scaledSize = (uint16_t)((double)this->_sizeX * scaleX);
+        uint16_t baseRadius = (uint16_t)scaledSize;
 
         getRenderer()->drawPolygon(baseX, baseY, baseRadius, this->_sizeY, this->strokeColor, this->fillColor, this->_angle);
     } else if (this->_shape == GP_SHAPE_ARC) {
-        uint16_t baseRadius = (uint16_t)this->_sizeX;
+        uint16_t scaledSize = (uint16_t)((double)this->_sizeX * scaleX);
+        uint16_t baseRadius = (uint16_t)scaledSize;
 
         getRenderer()->drawArc(baseX, baseY, baseRadius, baseRadius, this->strokeColor, this->fillColor, this->_angle, this->_angleEnd, this->_closed);
     }

--- a/src/display/ui/screens/ButtonLayoutScreen.cpp
+++ b/src/display/ui/screens/ButtonLayoutScreen.cpp
@@ -11,8 +11,14 @@ void ButtonLayoutScreen::init() {
     inputHistoryY = inputHistoryOptions.col;
     inputHistoryLength = inputHistoryOptions.length;
     profileDelayStart = getMillis();
-	gamepad = Storage::getInstance().GetGamepad();
-	inputMode = DriverManager::getInstance().getInputMode();
+    gamepad = Storage::getInstance().GetGamepad();
+    inputMode = DriverManager::getInstance().getInputMode();
+    
+    footer = "";
+    historyString = "";
+    inputHistory.clear();
+
+    setViewport((isInputHistoryEnabled ? 8 : 0), 0, (isInputHistoryEnabled ? 56 : getRenderer()->getDriver()->getMetrics()->height), getRenderer()->getDriver()->getMetrics()->width);
 
 	// load layout (drawElement pushes element to the display list)
     uint16_t elementCtr = 0;
@@ -69,7 +75,8 @@ int8_t ButtonLayoutScreen::update() {
     if (configMode) {
         uint8_t layoutLeft = Storage::getInstance().getDisplayOptions().buttonLayout;
         uint8_t layoutRight = Storage::getInstance().getDisplayOptions().buttonLayoutRight;
-        if ((prevLayoutLeft != layoutLeft) || (prevLayoutRight != layoutRight)) {
+        bool inputHistoryEnabled = Storage::getInstance().getAddonOptions().inputHistoryOptions.enabled;
+        if ((prevLayoutLeft != layoutLeft) || (prevLayoutRight != layoutRight) || (isInputHistoryEnabled != inputHistoryEnabled)) {
             shutdown();
             init();
         }
@@ -204,6 +211,7 @@ GPLever* ButtonLayoutScreen::addLever(uint16_t startX, uint16_t startY, uint16_t
     lever->setFillColor(fillColor);
     lever->setRadius(sizeX);
     lever->setInputType(inputType);
+    lever->setViewport(this->getViewport());
     return (GPLever*)addElement(lever);
 }
 
@@ -215,6 +223,7 @@ GPButton* ButtonLayoutScreen::addButton(uint16_t startX, uint16_t startY, uint16
     button->setFillColor(fillColor);
     button->setSize(sizeX, sizeY);
     button->setInputMask(inputMask);
+    button->setViewport(this->getViewport());
     return (GPButton*)addElement(button);
 }
 
@@ -225,6 +234,7 @@ GPShape* ButtonLayoutScreen::addShape(uint16_t startX, uint16_t startY, uint16_t
     shape->setStrokeColor(strokeColor);
     shape->setFillColor(fillColor);
     shape->setSize(sizeX,sizeY);
+    shape->setViewport(this->getViewport());
     return (GPShape*)addElement(shape);
 }
 
@@ -233,20 +243,15 @@ GPSprite* ButtonLayoutScreen::addSprite(uint16_t startX, uint16_t startY, uint16
     sprite->setRenderer(getRenderer());
     sprite->setPosition(startX, startY);
     sprite->setSize(sizeX,sizeY);
+    sprite->setViewport(this->getViewport());
     return (GPSprite*)addElement(sprite);
 }
 
 GPWidget* ButtonLayoutScreen::pushElement(GPButtonLayout element) {
-    uint16_t yOffset = 0;
-
-    if (isInputHistoryEnabled) {
-        yOffset = 5;
-    }
-
     if (element.elementType == GP_ELEMENT_LEVER) {
-        return addLever(element.parameters.x1, element.parameters.y1-yOffset, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill, element.parameters.value);
+        return addLever(element.parameters.x1, element.parameters.y1, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill, element.parameters.value);
     } else if ((element.elementType == GP_ELEMENT_BTN_BUTTON) || (element.elementType == GP_ELEMENT_DIR_BUTTON) || (element.elementType == GP_ELEMENT_PIN_BUTTON)) {
-        GPButton* button = addButton(element.parameters.x1, element.parameters.y1-yOffset, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill, element.parameters.value);
+        GPButton* button = addButton(element.parameters.x1, element.parameters.y1, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill, element.parameters.value);
 
         // set type of button
         button->setInputType(element.elementType);
@@ -260,9 +265,9 @@ GPWidget* ButtonLayoutScreen::pushElement(GPButtonLayout element) {
 
         return (GPWidget*)button;
     } else if (element.elementType == GP_ELEMENT_SPRITE) {
-        return addSprite(element.parameters.x1, element.parameters.y1-yOffset, element.parameters.x2, element.parameters.y2);
+        return addSprite(element.parameters.x1, element.parameters.y1, element.parameters.x2, element.parameters.y2);
     } else if (element.elementType == GP_ELEMENT_SHAPE) {
-        GPShape* shape = addShape(element.parameters.x1, element.parameters.y1-yOffset, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill);
+        GPShape* shape = addShape(element.parameters.x1, element.parameters.y1, element.parameters.x2, element.parameters.y2, element.parameters.stroke, element.parameters.fill);
         shape->setShape((GPShape_Type)element.parameters.shape);
         shape->setAngle(element.parameters.angleStart);
         shape->setAngleEnd(element.parameters.angleEnd);


### PR DESCRIPTION
Wii 
* Added tweaks for Wii analog calibration when calibration values do not exist.

* Fixed issue with Wii config values on strum up/down.
* Fixed issue with Wii guitar orange button being incorrectly mapped in source data.

Display
* Added display viewport object for resizing the non-status bar areas.
* Implemented button layout scaling when input history is enabled.