### PR TITLE
Custom led theme

### DIFF
--- a/www/src/Data/Buttons.js
+++ b/www/src/Data/Buttons.js
@@ -162,7 +162,7 @@ export const BUTTONS = {
 	},
 };
 
-export const AUX_BUTTONS = ['S1', 'S2', 'L3', 'R3', 'A1', 'A2', 'Fn'];
+export const AUX_BUTTONS = ['S1', 'S2', 'L3', 'R3', 'A1', 'A2'];
 export const MAIN_BUTTONS = [
 	'Up',
 	'Down',

--- a/www/src/Pages/CustomThemePage.scss
+++ b/www/src/Pages/CustomThemePage.scss
@@ -141,7 +141,6 @@ $button-keycap: 19px;
 		#000 -1px 0 0.5px,
 		0 0 2px #000;
 	box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.1);
-	cursor: pointer;
 
 	&.selected {
 		border: 3px solid red;


### PR DESCRIPTION
We have not implemented being able to set color to the function button. this results in an error when pressing it.
Unsure if it was ever intended, the rendering was a biproduct of having an incorrect const.
Api does not support it either, i've removed it so the user doesn't think it's possible to change it until we are done with LED rework.

Before
<img width="822" alt="Screenshot 2024-04-06 at 00 10 49" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/5345892/ee72f46a-1d1a-4ef2-9da2-f87ee8465158">

After
<img width="819" alt="Screenshot 2024-04-06 at 00 11 01" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/5345892/eba7eac8-0372-4bed-81dc-0569fb567127">


#927 
