### PR TITLE
Wii guitar range adjustments and analog trigger handling

### DIFF
--- a/lib/WiiExtension/extensions/GuitarExtension.cpp
+++ b/lib/WiiExtension/extensions/GuitarExtension.cpp
@@ -69,9 +69,9 @@ void GuitarExtension::init(uint8_t dataType) {
     _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].center           = WII_GUITAR_GATE_CENTER;
     _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].maximum          = WII_GUITAR_GATE_CENTER+WII_GUITAR_GATE_SIZE;
     
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].minimum         = 243;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].center          = 246;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = 249;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].minimum         = 241;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].center          = 243;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = 246;
     _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].useOffset       = false;
 
     _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_Y].minimum         = 0;
@@ -101,7 +101,7 @@ void GuitarExtension::process(uint8_t *inputData) {
             
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].minimum         = 15;
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].center          = 19;
-            _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = 26;
+            _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = 20;
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].useOffset       = false;
 
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_Y].minimum         = 0;

--- a/lib/WiiExtension/extensions/GuitarExtension.cpp
+++ b/lib/WiiExtension/extensions/GuitarExtension.cpp
@@ -69,10 +69,10 @@ void GuitarExtension::init(uint8_t dataType) {
     _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].center           = WII_GUITAR_GATE_CENTER;
     _analogCalibration[WiiAnalogs::WII_ANALOG_LEFT_Y].maximum          = WII_GUITAR_GATE_CENTER+WII_GUITAR_GATE_SIZE;
     
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].minimum         = 241;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].center          = 243;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = 246;
-    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].useOffset       = false;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].minimum         = 131;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].center          = 169;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = 207;
+    _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].useOffset       = true;
 
     _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_Y].minimum         = 0;
     _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_Y].center          = WII_GUITAR_GATE_CENTER;
@@ -102,7 +102,7 @@ void GuitarExtension::process(uint8_t *inputData) {
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].minimum         = 15;
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].center          = 19;
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].maximum         = 20;
-            _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].useOffset       = false;
+            _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_X].useOffset       = true;
 
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_Y].minimum         = 0;
             _analogCalibration[WiiAnalogs::WII_ANALOG_RIGHT_Y].center          = WII_GUITAR_GATE_CENTER;

--- a/src/addons/wiiext.cpp
+++ b/src/addons/wiiext.cpp
@@ -176,6 +176,8 @@ void WiiExtensionInput::update() {
 
             triggerLeft = 0;
             triggerRight = 0;
+
+            isAnalogTriggers = true;
         } else if (wii->extensionType == WII_EXTENSION_TAIKO) {
             buttonL = wii->getController()->buttons[TaikoButtons::TATA_KAT_LEFT];
             buttonR = wii->getController()->buttons[TaikoButtons::TATA_KAT_RIGHT];
@@ -200,6 +202,8 @@ void WiiExtensionInput::update() {
 
             triggerLeft = 0;
             triggerRight = 0;
+
+            isAnalogTriggers = true;
         } else if (wii->extensionType == WII_EXTENSION_TURNTABLE) {
             buttonSelect = wii->getController()->buttons[WiiButtons::WII_BUTTON_MINUS];
             buttonStart = wii->getController()->buttons[WiiButtons::WII_BUTTON_PLUS];
@@ -427,11 +431,11 @@ void WiiExtensionInput::updateAnalogState() {
                     break;
                 case WII_ANALOG_TYPE_LEFT_TRIGGER:
                     axisToChange = WII_ANALOG_TYPE_LEFT_TRIGGER;
-                    adjustedValue = bounds(analogValue,minValue,maxValue);
+                    adjustedValue = map(analogValue,minValue,maxValue,GAMEPAD_TRIGGER_MIN,GAMEPAD_TRIGGER_MAX);
                     break;
                 case WII_ANALOG_TYPE_RIGHT_TRIGGER:
                     axisToChange = WII_ANALOG_TYPE_RIGHT_TRIGGER;
-                    adjustedValue = bounds(analogValue,minValue,maxValue);
+                    adjustedValue = map(analogValue,minValue,maxValue,GAMEPAD_TRIGGER_MIN,GAMEPAD_TRIGGER_MAX);
                     break;
                 // advanced types
                 case WII_ANALOG_TYPE_LEFT_STICK_X_PLUS:


### PR DESCRIPTION
* Fixes issue where controller modes that support a single direction of analog movement (triggers mainly) would not function.
* Removed previous fallback calibration for guitars which was based on a broken whammy bar.