### PR TITLE
Board config updates

### DIFF
--- a/configs/FlatboxRev5RGB/BoardConfig.h
+++ b/configs/FlatboxRev5RGB/BoardConfig.h
@@ -36,11 +36,6 @@
 // Setting GPIO pins to assigned by add-on
 //
 #define GPIO_PIN_00 GpioAction::ASSIGNED_TO_ADDON
-#define GPIO_PIN_11 GpioAction::ASSIGNED_TO_ADDON
-#define GPIO_PIN_24 GpioAction::ASSIGNED_TO_ADDON
-#define GPIO_PIN_25 GpioAction::ASSIGNED_TO_ADDON
-#define GPIO_PIN_26 GpioAction::ASSIGNED_TO_ADDON
-#define GPIO_PIN_27 GpioAction::ASSIGNED_TO_ADDON
 
 // Keyboard Mapping Configuration
 //                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
@@ -68,6 +63,7 @@
 
 #define LED_BRIGHTNESS_MAXIMUM 50
 #define LED_BRIGHTNESS_STEPS 5
+#define LEDS_BASE_ANIMATION_INDEX 1
 #define LEDS_PER_PIXEL 2
 
 #define LEDS_DPAD_LEFT   0

--- a/configs/Mavercade/BoardConfig.h
+++ b/configs/Mavercade/BoardConfig.h
@@ -36,7 +36,6 @@
 // Setting GPIO pins to assigned by add-on
 //
 #define GPIO_PIN_00 GpioAction::ASSIGNED_TO_ADDON
-#define GPIO_PIN_01 GpioAction::ASSIGNED_TO_ADDON
 
 // Keyboard Mapping Configuration
 //                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
@@ -78,7 +77,7 @@
 #define LEDS_BUTTON_L2   11
 #define LEDS_BUTTON_A2   12
 
-#define EXTRA_BUTTON_MASK GAMEPAD_MASK_DU 
-#define EXTRA_BUTTON_PIN 1
+// Additional Button Support
+#define GPIO_PIN_01 GpioAction::BUTTON_PRESS_UP
 
 #endif

--- a/configs/OpenCore0WASD/BoardConfig.h
+++ b/configs/OpenCore0WASD/BoardConfig.h
@@ -36,6 +36,7 @@
 //
 #define GPIO_PIN_00 GpioAction::ASSIGNED_TO_ADDON
 #define GPIO_PIN_01 GpioAction::ASSIGNED_TO_ADDON
+#define GPIO_PIN_08 GpioAction::ASSIGNED_TO_ADDON
 #define GPIO_PIN_22 GpioAction::ASSIGNED_TO_ADDON
 #define GPIO_PIN_28 GpioAction::ASSIGNED_TO_ADDON
 #define GPIO_PIN_29 GpioAction::ASSIGNED_TO_ADDON

--- a/configs/SGFBridget/BoardConfig.h
+++ b/configs/SGFBridget/BoardConfig.h
@@ -77,4 +77,6 @@
 #define LEDS_BUTTON_B1   10
 #define LEDS_DPAD_UP     11
 
+#define HAS_I2C_DISPLAY 0 //This needs to be defined or the LEDs will not work
+
 #endif

--- a/configs/SGFFaust/BoardConfig.h
+++ b/configs/SGFFaust/BoardConfig.h
@@ -86,4 +86,6 @@
 #define LEDS_BUTTON_B1   10
 #define LEDS_DPAD_UP     11
 
+#define HAS_I2C_DISPLAY 0 //This needs to be defined or the LEDs will not work
+
 #endif


### PR DESCRIPTION
Updates to the board config files + small fixes.

Flatbox Rev 5 RGB - Updated to remove assigned to addon warning on for PLED chain order + removed GPIO11 which was not assigned to anything 
Mavercade - Removed EXTRA_BUTTON_MASK and replaced with new pin mapping system 
Open_Core0 WASD - Added GPIO08 to assigned to addon section for board LEDs 
SGF Bridget - Added HAS_I2C_DISPLAY 0 to address bug with board LEDs 
SGF Faust - Added HAS_I2C_DISPLAY 0 to address bug with board LEDs