### PR TITLE
Buttons Angled layout using wrong definition

### DIFF
--- a/src/layoutmanager.cpp
+++ b/src/layoutmanager.cpp
@@ -122,7 +122,7 @@ LayoutManager::LayoutList LayoutManager::getRightLayout(uint16_t index) {
         case BUTTON_LAYOUT_STICKLESSB:
             return this->drawSticklessButtons();
         case BUTTON_LAYOUT_BUTTONS_ANGLEDB:
-            return this->drawMAMEB();
+            return this->drawWasdButtons();
         case BUTTON_LAYOUT_VEWLIX:
             return this->drawVewlix();
         case BUTTON_LAYOUT_VEWLIX7:


### PR DESCRIPTION
Fixed incorrect function for "Buttons Angled" right-side layout.