### PR TITLE
Macro Restart and UI Fixes

### DIFF
--- a/headers/addons/input_macro.h
+++ b/headers/addons/input_macro.h
@@ -45,12 +45,14 @@ private:
 	void checkMacroAction();
 	void runCurrentMacro();
 	void reset();
+	void restart(Macro& macro);
 	bool isMacroRunning;
 	bool isMacroTriggerHeld;
 	int macroPosition;
 	uint32_t macroButtonMask;
 	uint32_t macroPinMasks[6];
 	uint64_t macroStartTime;
+	uint64_t currentMicros;
 	int pressedMacro;
 	int macroInputPosition;
 	uint32_t macroInputHoldTime;

--- a/src/addons/input_macro.cpp
+++ b/src/addons/input_macro.cpp
@@ -85,6 +85,14 @@ void InputMacro::reset() {
     }
 }
 
+void InputMacro::restart(Macro& macro) {
+    macroStartTime = currentMicros;
+    macroInputPosition = 0;
+    MacroInput& newMacroInput = macro.macroInputs[macroInputPosition];
+    uint32_t newMacroInputDuration = newMacroInput.duration + newMacroInput.waitDuration;
+    macroInputHoldTime = newMacroInputDuration <= 0 ? INPUT_HOLD_US : newMacroInputDuration;
+}
+
 void InputMacro::checkMacroPress() {
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
     Mask_t allPins = gamepad->debouncedGpio;
@@ -171,7 +179,7 @@ void InputMacro::runCurrentMacro() {
 
     MacroInput& macroInput = macro.macroInputs[macroInputPosition];
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
-    uint64_t currentMicros = getMicro();
+    currentMicros = getMicro();
 
     if (!macro.interruptible && macro.exclusive) {
         // Prevent any other inputs from modifying our input (Exclusive)
@@ -188,6 +196,24 @@ void InputMacro::runCurrentMacro() {
             // Macro is interruptible and a user pressed something
             reset();
             return;
+        }
+    }
+
+    // Have we elapsed the input hold time?
+    if ((currentMicros - macroStartTime) >= macroInputHoldTime) {
+        macroStartTime = currentMicros;
+        macroInputPosition++;
+        
+        if (macroInputPosition >= (macro.macroInputs_count)) {
+            if ( macro.macroType == ON_PRESS ) {
+                reset(); // On press = no more macro
+            } else {
+                restart(macro); // On Hold-Repeat or On Toggle = start macro again
+            }
+        } else {
+            MacroInput& newMacroInput = macro.macroInputs[macroInputPosition];
+            uint32_t newMacroInputDuration = newMacroInput.duration + newMacroInput.waitDuration;
+            macroInputHoldTime = newMacroInputDuration <= 0 ? INPUT_HOLD_US : newMacroInputDuration;
         }
     }
 
@@ -211,30 +237,6 @@ void InputMacro::runCurrentMacro() {
         // Macro LED is on if we're currently running and inputs are doing something (wait-timers turn it off)
         if (boardLedEnabled) {
             gpio_put(BOARD_LED_PIN, (gamepad->state.dpad || gamepad->state.buttons) ? 1 : 0);
-        }
-    }
-
-    // Have we elapsed the input hold time?
-    if ((currentMicros - macroStartTime) >= macroInputHoldTime) {
-        macroStartTime = currentMicros;
-        macroInputPosition++;
-        if (macroInputPosition >= (macro.macroInputs_count)) {
-            if ( macro.macroType == ON_PRESS ) {
-                reset(); // On press = no more macro
-            } else {
-                if ( macro.macroType == ON_HOLD_REPEAT) {
-                    reset(); // On repeat, reset but keep the button held
-                } else {
-                    macroInputPosition = 0; // On Hold-Repeat or On Toggle = start macro again
-                    MacroInput& newMacroInput = macro.macroInputs[macroInputPosition];
-                    uint32_t newMacroInputDuration = newMacroInput.duration + newMacroInput.waitDuration;
-                    macroInputHoldTime = newMacroInputDuration <= 0 ? INPUT_HOLD_US : newMacroInputDuration;
-                }
-            }
-        } else {
-            MacroInput& newMacroInput = macro.macroInputs[macroInputPosition];
-            uint32_t newMacroInputDuration = newMacroInput.duration + newMacroInput.waitDuration;
-            macroInputHoldTime = newMacroInputDuration <= 0 ? INPUT_HOLD_US : newMacroInputDuration;
         }
     }
 }

--- a/www/src/Pages/InputMacroAddonPage.tsx
+++ b/www/src/Pages/InputMacroAddonPage.tsx
@@ -98,13 +98,10 @@ const FormContext = () => {
 		}
 		fetchData();
 	}, [setValues]);
-/*
+
 	useEffect(() => {
-		async function setData() {
-			await setValues(filterMacroInputs(values));
-		}
-		setData();
-	}, [values, setValues]);*/
+		setValues(filterMacroInputs(values));
+	}, [values, setValues]);
 
 	return null;
 };
@@ -126,7 +123,6 @@ const ButtonMasksComponent = (props) => {
 				size="sm"
 				name={`${key}.buttonMask`}
 				className="form-control col-sm-auto"
-				groupClassName="col-sm-1"
 				value={value}
 				error={error}
 				isInvalid={isInvalid}
@@ -190,13 +186,11 @@ const MacroInputComponent = (props) => {
 					</Col>
 				</Row>
 			</Col>
-			<Col sm={"auto"} key={`${key}.buttons`}>
+			<Col sm={"auto"}>
 				<Row className="d-flex justify-content-center">
-					{BUTTON_MASKS.map((mask, i1) =>
-						buttonMask & mask.value ? (
-						<Col sm={"auto"} className="px-1">
+					{BUTTON_MASKS.filter(mask => buttonMask & mask.value).map((mask, i1) =>
+						<Col key={`${key}.buttonMask[${i1}]`} sm={"auto"} className="px-1">
 							<ButtonMasksComponent
-								key={`${key}.buttonMask[${i1}]`}
 								id={`${key}.buttonMask[${i1}]`}
 								value={buttonMask & mask.value}
 								onChange={(e) => {
@@ -211,15 +205,10 @@ const MacroInputComponent = (props) => {
 								buttonLabelType={buttonLabelType}
 								buttonMasks={BUTTON_MASKS}
 							/>
-						</Col>) : (
-							<></>
-						),
+						</Col>
 					)}
-					<Col sm={"auto"} className="px-1"
-						key={`${key}.buttonMask[placeholder]`}
-					>
+					<Col sm={"auto"} className="px-1">
 						<ButtonMasksComponent
-							key={`${key}.buttonMaskPlaceholder`}
 							id={`${key}.buttonMaskPlaceholder`}
 							className="col-sm-auto"
 							value={0}
@@ -361,7 +350,6 @@ const MacroComponent = (props) => {
 					<Form.Select
 						name={`${key}.macroType`}
 						className="form-select-sm sm-1"
-						groupClassName="mb-3"
 						value={macroType}
 						onChange={(e) => {
 							setFieldValue(`${key}.macroType`, parseInt(e.target.value));
@@ -585,7 +573,7 @@ export default function MacrosPage() {
 												</thead>
 												<tbody>
 											{values.macroList.map((macro, i) => (
-												<tr>
+												<tr key={`macro-list-item-${i}`}>
 													<td>{i+1}</td>
 													<td>{macro.macroLabel.length==0 && <em>None</em>}{macro.macroLabel.length>0 && macro.macroLabel.slice(0,32)}{macro.macroLabel.length>32 && "..."}</td>
 													<td>{t(MACRO_TYPES.find((m) => m.value === macro.macroType).label)}</td>
@@ -634,7 +622,7 @@ export default function MacrosPage() {
 										</Section>
 										</Tab.Pane>
 										{values.macroList.map((macro, i) => (
-											<Tab.Pane eventKey={`macro-${i}`}>
+											<Tab.Pane key={`macro-list-tab-pane-${i}`} eventKey={`macro-${i}`}>
 											<Section title={`Macro ${i+1}`}>
 												<MacroComponent
 														key={`macroList[${i}]`}


### PR DESCRIPTION
The macro logic was processing macro inputs into gamepad state prior to checking if the macro needed to be reset. This resulted in repeating macros missing applying gamepad state at the end of the macro. Swapping the check for resetting the macro to before the gamepad inputs are applied and creating a `restart()` method solves this issue.

Also fixed an issue on the macro config page when adding and deleting macro actions. The deleted lines weren't being filtered out, causing no console errors but preventing any changes to the macro actions array. Fixed up the React key errors in the console for this page as well.

Addresses https://github.com/OpenStickCommunity/GP2040-CE/issues/975 & https://github.com/OpenStickCommunity/GP2040-CE/issues/976
