### PR TITLE
Add Reflex CTRL Genesis-6, NES, Saturn, and Virtual Boy

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        GP2040_BOARDCONFIG: [Pico, PicoW, BentoBox, FightboardV3, FightboardV3Mirrored, FlatboxRev4, FlatboxRev5, FlatboxRev5RGB, FlatboxRev5Southpaw, Granola, KB2040, KeyboardConverter, Haute42COSMOX, Liatris, Mavercade, OpenCore0, OpenCore0WASD, PicoAnn, PicoFightingBoard, RanaTadpole, ReflexCtrlSNES, ReflexEncodeV1.2, ReflexEncodeV2.0, RP2040AdvancedBreakoutBoard, RP2040AdvancedBreakoutBoardUSBPassthrough, RP2040MiniBreakoutBoard, SparkFunProMicro, WaveshareZero, Stress, SGFBridget, SGFFaust]
+        GP2040_BOARDCONFIG: [Pico, PicoW, BentoBox, FightboardV3, FightboardV3Mirrored, FlatboxRev4, FlatboxRev5, FlatboxRev5RGB, FlatboxRev5Southpaw, Granola, KB2040, KeyboardConverter, Haute42COSMOX, Liatris, Mavercade, OpenCore0, OpenCore0WASD, PicoAnn, PicoFightingBoard, RanaTadpole, ReflexCtrlGenesis6, ReflexCtrlNES, ReflexCtrlSaturn, ReflexCtrlSNES, ReflexCtrlVB, ReflexEncodeV1.2, ReflexEncodeV2.0, RP2040AdvancedBreakoutBoard, RP2040AdvancedBreakoutBoardUSBPassthrough, RP2040MiniBreakoutBoard, SparkFunProMicro, WaveshareZero, Stress, SGFBridget, SGFFaust]
 
     steps:
     #Global Setup

--- a/configs/ReflexCtrlGenesis6/BoardConfig.h
+++ b/configs/ReflexCtrlGenesis6/BoardConfig.h
@@ -11,16 +11,7 @@
 
 #define BOARD_CONFIG_LABEL "Reflex CTRL Genesis 6"
 
-// Input Mode additions section.
 #define DEFAULT_INPUT_MODE_R1 INPUT_MODE_SWITCH
-
-// This is the main pin definition section.
-// This will let you specify which GPIO pin each button is assigned too.
-// You can set any of the main pins as `-1` to disable it.
-// The Turbo pin and LS + RS slider pins can also be set to `-1` to disable that functionality.
-// Please note that only when `PIN_BUTTON_TURBO` is set to `-1` will the `T##` be removed from a connected display.
-// Please note that only when `PIN_SLIDER_ONE` and  `PIN_SLIDER_TWO` are set to `-1` will the button combo shortcut for DP/LS/RS work.
-// The buttons are listed in GP2040 configuration, beside each the listed order is *GP2040 / Xinput / Switch / PS3 / Directinput / Arcade*
 
 // Main pin mapping Configuration
 //                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
@@ -31,17 +22,11 @@
 #define GPIO_PIN_06 GpioAction::BUTTON_PRESS_B1     // B1     | A      | B       | Cross    | 2      | K1     |
 #define GPIO_PIN_07 GpioAction::BUTTON_PRESS_B2     // B2     | B      | A       | Circle   | 3      | K2     |
 #define GPIO_PIN_08 GpioAction::BUTTON_PRESS_R2     // R2     | RT     | ZR      | R2       | 8      | K3     |
-//#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_L2   // L2     | LT     | ZL      | L2       | 7      | K4     |
 #define GPIO_PIN_10 GpioAction::BUTTON_PRESS_B3     // B3     | X      | Y       | Square   | 1      | P1     |
 #define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4     // B4     | Y      | X       | Triangle | 4      | P2     |
 #define GPIO_PIN_12 GpioAction::BUTTON_PRESS_R1     // R1     | RB     | R       | R1       | 6      | P3     |
-//#define GPIO_PIN_18 GpioAction::BUTTON_PRESS_L1   // L1     | LB     | L       | L1       | 5      | P4     |
 #define GPIO_PIN_19 GpioAction::BUTTON_PRESS_S1     // S1     | Back   | Minus   | Select   | 9      | Coin   |
 #define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
-//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L3   // L3     | LS     | LS      | L3       | 11     | LS     |
-//#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_R3   // R3     | RS     | RS      | R3       | 12     | RS     |
-//#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1   // A1     | Guide  | Home    | PS       | 13     | ~      |
-//#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2   // A2     | ~      | Capture | ~        | 14     | ~      |
 
 // Keyboard Mapping Configuration
 //                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |

--- a/configs/ReflexCtrlGenesis6/BoardConfig.h
+++ b/configs/ReflexCtrlGenesis6/BoardConfig.h
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#ifndef PICO_BOARD_CONFIG_H_
+#define PICO_BOARD_CONFIG_H_
+
+#include "enums.pb.h"
+#include "class/hid/hid.h"
+
+#define BOARD_CONFIG_LABEL "Reflex CTRL Genesis 6"
+
+// Input Mode additions section.
+#define DEFAULT_INPUT_MODE_R1 INPUT_MODE_SWITCH
+
+// This is the main pin definition section.
+// This will let you specify which GPIO pin each button is assigned too.
+// You can set any of the main pins as `-1` to disable it.
+// The Turbo pin and LS + RS slider pins can also be set to `-1` to disable that functionality.
+// Please note that only when `PIN_BUTTON_TURBO` is set to `-1` will the `T##` be removed from a connected display.
+// Please note that only when `PIN_SLIDER_ONE` and  `PIN_SLIDER_TWO` are set to `-1` will the button combo shortcut for DP/LS/RS work.
+// The buttons are listed in GP2040 configuration, beside each the listed order is *GP2040 / Xinput / Switch / PS3 / Directinput / Arcade*
+
+// Main pin mapping Configuration
+//                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
+#define GPIO_PIN_03 GpioAction::BUTTON_PRESS_DOWN   // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
+#define GPIO_PIN_04 GpioAction::BUTTON_PRESS_RIGHT  // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |
+#define GPIO_PIN_05 GpioAction::BUTTON_PRESS_LEFT   // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
+#define GPIO_PIN_06 GpioAction::BUTTON_PRESS_B1     // B1     | A      | B       | Cross    | 2      | K1     |
+#define GPIO_PIN_07 GpioAction::BUTTON_PRESS_B2     // B2     | B      | A       | Circle   | 3      | K2     |
+#define GPIO_PIN_08 GpioAction::BUTTON_PRESS_R2     // R2     | RT     | ZR      | R2       | 8      | K3     |
+//#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_L2   // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define GPIO_PIN_10 GpioAction::BUTTON_PRESS_B3     // B3     | X      | Y       | Square   | 1      | P1     |
+#define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4     // B4     | Y      | X       | Triangle | 4      | P2     |
+#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_R1     // R1     | RB     | R       | R1       | 6      | P3     |
+//#define GPIO_PIN_18 GpioAction::BUTTON_PRESS_L1   // L1     | LB     | L       | L1       | 5      | P4     |
+#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_S1     // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
+//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L3   // L3     | LS     | LS      | L3       | 11     | LS     |
+//#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_R3   // R3     | RS     | RS      | R3       | 12     | RS     |
+//#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1   // A1     | Guide  | Home    | PS       | 13     | ~      |
+//#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2   // A2     | ~      | Capture | ~        | 14     | ~      |
+
+// Keyboard Mapping Configuration
+//                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP     | UP     | UP      | UP       | UP     | UP     |
+#define KEY_DPAD_DOWN   HID_KEY_ARROW_DOWN    // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   | 
+#define KEY_DPAD_RIGHT  HID_KEY_ARROW_RIGHT   // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  | 
+#define KEY_DPAD_LEFT   HID_KEY_ARROW_LEFT    // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   | 
+#define KEY_BUTTON_B1   HID_KEY_SHIFT_LEFT    // B1     | A      | B       | Cross    | 2      | K1     |
+#define KEY_BUTTON_B2   HID_KEY_Z             // B2     | B      | A       | Circle   | 3      | K2     |
+#define KEY_BUTTON_R2   HID_KEY_X             // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define KEY_BUTTON_L2   HID_KEY_V             // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define KEY_BUTTON_B3   HID_KEY_CONTROL_LEFT  // B3     | X      | Y       | Square   | 1      | P1     |
+#define KEY_BUTTON_B4   HID_KEY_ALT_LEFT      // B4     | Y      | X       | Triangle | 4      | P2     |
+#define KEY_BUTTON_R1   HID_KEY_SPACE         // R1     | RB     | R       | R1       | 6      | P3     |
+#define KEY_BUTTON_L1   HID_KEY_C             // L1     | LB     | L       | L1       | 5      | P4     |
+#define KEY_BUTTON_S1   HID_KEY_5             // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define KEY_BUTTON_S2   HID_KEY_1             // S2     | Start  | Plus    | Start    | 10     | Start  |
+#define KEY_BUTTON_L3   HID_KEY_EQUAL         // L3     | LS     | LS      | L3       | 11     | LS     |
+#define KEY_BUTTON_R3   HID_KEY_MINUS         // R3     | RS     | RS      | R3       | 12     | RS     |
+#define KEY_BUTTON_A1   HID_KEY_9             // A1     | Guide  | Home    | PS       | 13     | ~      |
+#define KEY_BUTTON_A2   HID_KEY_F2            // A2     | ~      | Capture | ~        | 14     | ~      |
+#define KEY_BUTTON_FN   -1                    // Hotkey Function                                        |
+
+#define BOARD_LED_ENABLED 1
+#define BOARD_LED_TYPE ON_BOARD_LED_MODE_INPUT_TEST
+
+#endif

--- a/configs/ReflexCtrlGenesis6/README.md
+++ b/configs/ReflexCtrlGenesis6/README.md
@@ -1,0 +1,12 @@
+# GP2040-CE Configuration for the Reflex CTRL Genesis 6 Board by MiSTer Addons
+
+![Reflex CTRL Genesis 6](https://github.com/misteraddons/Reflex-CTRL/raw/main/Images/genesis6.png)
+
+Open source replacement PCB for Sega Genesis controllers
+* USA 6 button controllers
+* Japanese 6 button controller
+* Retro-Bit Saturn controller
+
+Purchase: https://misteraddons.com/products/Reflex-CTRL
+
+GitHub: https://github.com/misteraddons/Reflex-CTRL

--- a/configs/ReflexCtrlNES/BoardConfig.h
+++ b/configs/ReflexCtrlNES/BoardConfig.h
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#ifndef PICO_BOARD_CONFIG_H_
+#define PICO_BOARD_CONFIG_H_
+
+#include "enums.pb.h"
+#include "class/hid/hid.h"
+
+#define BOARD_CONFIG_LABEL "Reflex CTRL Genesis 6"
+
+// Input Mode additions section.
+#define DEFAULT_INPUT_MODE_R1 INPUT_MODE_SWITCH
+
+// This is the main pin definition section.
+// This will let you specify which GPIO pin each button is assigned too.
+// You can set any of the main pins as `-1` to disable it.
+// The Turbo pin and LS + RS slider pins can also be set to `-1` to disable that functionality.
+// Please note that only when `PIN_BUTTON_TURBO` is set to `-1` will the `T##` be removed from a connected display.
+// Please note that only when `PIN_SLIDER_ONE` and  `PIN_SLIDER_TWO` are set to `-1` will the button combo shortcut for DP/LS/RS work.
+// The buttons are listed in GP2040 configuration, beside each the listed order is *GP2040 / Xinput / Switch / PS3 / Directinput / Arcade*
+
+// Main pin mapping Configuration
+//                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
+#define GPIO_PIN_03 GpioAction::BUTTON_PRESS_DOWN   // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
+#define GPIO_PIN_04 GpioAction::BUTTON_PRESS_RIGHT  // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |
+#define GPIO_PIN_05 GpioAction::BUTTON_PRESS_LEFT   // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
+#define GPIO_PIN_06 GpioAction::BUTTON_PRESS_B1     // B1     | A      | B       | Cross    | 2      | K1     |
+#define GPIO_PIN_07 GpioAction::BUTTON_PRESS_B2     // B2     | B      | A       | Circle   | 3      | K2     |
+//#define GPIO_PIN_08 GpioAction::BUTTON_PRESS_R2   // R2     | RT     | ZR      | R2       | 8      | K3     |
+//#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_L2   // L2     | LT     | ZL      | L2       | 7      | K4     |
+//#define GPIO_PIN_10 GpioAction::BUTTON_PRESS_B3   // B3     | X      | Y       | Square   | 1      | P1     |
+//#define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4   // B4     | Y      | X       | Triangle | 4      | P2     |
+//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_R1   // R1     | RB     | R       | R1       | 6      | P3     |
+//#define GPIO_PIN_18 GpioAction::BUTTON_PRESS_L1   // L1     | LB     | L       | L1       | 5      | P4     |
+#define GPIO_PIN_16 GpioAction::BUTTON_PRESS_S1     // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
+//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L3   // L3     | LS     | LS      | L3       | 11     | LS     |
+//#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_R3   // R3     | RS     | RS      | R3       | 12     | RS     |
+//#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1   // A1     | Guide  | Home    | PS       | 13     | ~      |
+//#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2   // A2     | ~      | Capture | ~        | 14     | ~      |
+
+// Keyboard Mapping Configuration
+//                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP     | UP     | UP      | UP       | UP     | UP     |
+#define KEY_DPAD_DOWN   HID_KEY_ARROW_DOWN    // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   | 
+#define KEY_DPAD_RIGHT  HID_KEY_ARROW_RIGHT   // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  | 
+#define KEY_DPAD_LEFT   HID_KEY_ARROW_LEFT    // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   | 
+#define KEY_BUTTON_B1   HID_KEY_SHIFT_LEFT    // B1     | A      | B       | Cross    | 2      | K1     |
+#define KEY_BUTTON_B2   HID_KEY_Z             // B2     | B      | A       | Circle   | 3      | K2     |
+#define KEY_BUTTON_R2   HID_KEY_X             // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define KEY_BUTTON_L2   HID_KEY_V             // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define KEY_BUTTON_B3   HID_KEY_CONTROL_LEFT  // B3     | X      | Y       | Square   | 1      | P1     |
+#define KEY_BUTTON_B4   HID_KEY_ALT_LEFT      // B4     | Y      | X       | Triangle | 4      | P2     |
+#define KEY_BUTTON_R1   HID_KEY_SPACE         // R1     | RB     | R       | R1       | 6      | P3     |
+#define KEY_BUTTON_L1   HID_KEY_C             // L1     | LB     | L       | L1       | 5      | P4     |
+#define KEY_BUTTON_S1   HID_KEY_5             // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define KEY_BUTTON_S2   HID_KEY_1             // S2     | Start  | Plus    | Start    | 10     | Start  |
+#define KEY_BUTTON_L3   HID_KEY_EQUAL         // L3     | LS     | LS      | L3       | 11     | LS     |
+#define KEY_BUTTON_R3   HID_KEY_MINUS         // R3     | RS     | RS      | R3       | 12     | RS     |
+#define KEY_BUTTON_A1   HID_KEY_9             // A1     | Guide  | Home    | PS       | 13     | ~      |
+#define KEY_BUTTON_A2   HID_KEY_F2            // A2     | ~      | Capture | ~        | 14     | ~      |
+#define KEY_BUTTON_FN   -1                    // Hotkey Function                                        |
+
+#define BOARD_LED_ENABLED 1
+#define BOARD_LED_TYPE ON_BOARD_LED_MODE_INPUT_TEST
+
+#endif

--- a/configs/ReflexCtrlNES/BoardConfig.h
+++ b/configs/ReflexCtrlNES/BoardConfig.h
@@ -11,16 +11,7 @@
 
 #define BOARD_CONFIG_LABEL "Reflex CTRL Genesis 6"
 
-// Input Mode additions section.
 #define DEFAULT_INPUT_MODE_R1 INPUT_MODE_SWITCH
-
-// This is the main pin definition section.
-// This will let you specify which GPIO pin each button is assigned too.
-// You can set any of the main pins as `-1` to disable it.
-// The Turbo pin and LS + RS slider pins can also be set to `-1` to disable that functionality.
-// Please note that only when `PIN_BUTTON_TURBO` is set to `-1` will the `T##` be removed from a connected display.
-// Please note that only when `PIN_SLIDER_ONE` and  `PIN_SLIDER_TWO` are set to `-1` will the button combo shortcut for DP/LS/RS work.
-// The buttons are listed in GP2040 configuration, beside each the listed order is *GP2040 / Xinput / Switch / PS3 / Directinput / Arcade*
 
 // Main pin mapping Configuration
 //                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
@@ -30,18 +21,8 @@
 #define GPIO_PIN_05 GpioAction::BUTTON_PRESS_LEFT   // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
 #define GPIO_PIN_06 GpioAction::BUTTON_PRESS_B1     // B1     | A      | B       | Cross    | 2      | K1     |
 #define GPIO_PIN_07 GpioAction::BUTTON_PRESS_B2     // B2     | B      | A       | Circle   | 3      | K2     |
-//#define GPIO_PIN_08 GpioAction::BUTTON_PRESS_R2   // R2     | RT     | ZR      | R2       | 8      | K3     |
-//#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_L2   // L2     | LT     | ZL      | L2       | 7      | K4     |
-//#define GPIO_PIN_10 GpioAction::BUTTON_PRESS_B3   // B3     | X      | Y       | Square   | 1      | P1     |
-//#define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4   // B4     | Y      | X       | Triangle | 4      | P2     |
-//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_R1   // R1     | RB     | R       | R1       | 6      | P3     |
-//#define GPIO_PIN_18 GpioAction::BUTTON_PRESS_L1   // L1     | LB     | L       | L1       | 5      | P4     |
 #define GPIO_PIN_16 GpioAction::BUTTON_PRESS_S1     // S1     | Back   | Minus   | Select   | 9      | Coin   |
 #define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
-//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L3   // L3     | LS     | LS      | L3       | 11     | LS     |
-//#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_R3   // R3     | RS     | RS      | R3       | 12     | RS     |
-//#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1   // A1     | Guide  | Home    | PS       | 13     | ~      |
-//#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2   // A2     | ~      | Capture | ~        | 14     | ~      |
 
 // Keyboard Mapping Configuration
 //                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |

--- a/configs/ReflexCtrlNES/README.md
+++ b/configs/ReflexCtrlNES/README.md
@@ -1,0 +1,9 @@
+# GP2040-CE Configuration for the Reflex CTRL NES Board by MiSTer Addons
+
+![Reflex CTRL NES](https://github.com/misteraddons/Reflex-CTRL/raw/main/Images/nes.png)
+
+Open source replacement PCB for Nintendo NES-004 controllers
+
+Purchase: https://misteraddons.com/products/Reflex-CTRL
+
+GitHub: https://github.com/misteraddons/Reflex-CTRL

--- a/configs/ReflexCtrlSNES/BoardConfig.h
+++ b/configs/ReflexCtrlSNES/BoardConfig.h
@@ -12,7 +12,7 @@
 #define BOARD_CONFIG_LABEL "Reflex Ctrl SNES"
 
 // Main pin mapping Configuration
-//                          // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+//                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
 #define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
 #define GPIO_PIN_03 GpioAction::BUTTON_PRESS_DOWN   // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
 #define GPIO_PIN_04 GpioAction::BUTTON_PRESS_RIGHT  // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |

--- a/configs/ReflexCtrlSNES/README.md
+++ b/configs/ReflexCtrlSNES/README.md
@@ -1,14 +1,9 @@
 # GP2040-CE Configuration for the Reflex CTRL SNES Board by MiSTer Addons
 
+![Reflex CTRL SNES](https://github.com/misteraddons/Reflex-CTRL/raw/main/Images/snes.png)
 
-![Reflex Board](assets/ReflexCTRLSNES.jpeg)
+Open source replacement PCB for Nintendo SNES-001 controllers
 
-Reflex Board
-Open source PCB for SNES Controller replacement PCBs
+Purchase: https://misteraddons.com/products/Reflex-CTRL
 
 GitHub: https://github.com/misteraddons/Reflex-CTRL
-Purchase from: 
-
-MiSTer Addons: https://misteraddons.com/
-
-

--- a/configs/ReflexCtrlSaturn/BoardConfig.h
+++ b/configs/ReflexCtrlSaturn/BoardConfig.h
@@ -19,15 +19,6 @@
 #define USB_PERIPHERAL_PIN_DPLUS 14
 #define USB_PERIPHERAL_PIN_ORDER 0
 
-// This is the main pin definition section.
-// This will let you specify which GPIO pin each button is assigned too.
-// You can set any of the main pins as `-1` to disable it.
-// The Turbo pin and LS + RS slider pins can also be set to `-1` to disable that functionality.
-// Please note that only when `PIN_BUTTON_TURBO` is set to `-1` will the `T##` be removed from a connected display.
-// Please note that only when `PIN_SLIDER_ONE` and  `PIN_SLIDER_TWO` are set to `-1` will the button combo shortcut for DP/LS/RS work.
-// The buttons are listed in GP2040 configuration, beside each the listed order is *GP2040 / Xinput / Switch / PS3 / Directinput / Arcade*
-
-
 // Main pin mapping Configuration
 //                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
 #define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
@@ -42,12 +33,7 @@
 #define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4     // B4     | Y      | X       | Triangle | 4      | P2     |
 #define GPIO_PIN_08 GpioAction::BUTTON_PRESS_R1     // R1     | RB     | R       | R1       | 6      | P3     |
 #define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L1     // L1     | LB     | L       | L1       | 5      | P4     |
-//#define GPIO_PIN_16 GpioAction::BUTTON_PRESS_S1   // S1     | Back   | Minus   | Select   | 9      | Coin   |
 #define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
-//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L3   // L3     | LS     | LS      | L3       | 11     | LS     |
-//#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_R3   // R3     | RS     | RS      | R3       | 12     | RS     |
-//#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1   // A1     | Guide  | Home    | PS       | 13     | ~      |
-//#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2   // A2     | ~      | Capture | ~        | 14     | ~      |
 
 // Keyboard Mapping Configuration
 //                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |

--- a/configs/ReflexCtrlSaturn/BoardConfig.h
+++ b/configs/ReflexCtrlSaturn/BoardConfig.h
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#ifndef PICO_BOARD_CONFIG_H_
+#define PICO_BOARD_CONFIG_H_
+
+#include "enums.pb.h"
+#include "class/hid/hid.h"
+
+#define BOARD_CONFIG_LABEL "Reflex CTRL Saturn"
+
+#define DEFAULT_INPUT_MODE_R1 INPUT_MODE_XBONE
+#define DEFAULT_INPUT_MODE_B4 INPUT_MODE_PS5
+#define DEFAULT_PS5AUTHENTICATION_TYPE INPUT_MODE_AUTH_TYPE_USB
+#define XBONEPASSTHROUGH_ENABLED 1
+#define USB_PERIPHERAL_ENABLED 1
+#define USB_PERIPHERAL_PIN_DPLUS 14
+#define USB_PERIPHERAL_PIN_ORDER 0
+
+// This is the main pin definition section.
+// This will let you specify which GPIO pin each button is assigned too.
+// You can set any of the main pins as `-1` to disable it.
+// The Turbo pin and LS + RS slider pins can also be set to `-1` to disable that functionality.
+// Please note that only when `PIN_BUTTON_TURBO` is set to `-1` will the `T##` be removed from a connected display.
+// Please note that only when `PIN_SLIDER_ONE` and  `PIN_SLIDER_TWO` are set to `-1` will the button combo shortcut for DP/LS/RS work.
+// The buttons are listed in GP2040 configuration, beside each the listed order is *GP2040 / Xinput / Switch / PS3 / Directinput / Arcade*
+
+
+// Main pin mapping Configuration
+//                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
+#define GPIO_PIN_03 GpioAction::BUTTON_PRESS_DOWN   // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
+#define GPIO_PIN_04 GpioAction::BUTTON_PRESS_RIGHT  // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |
+#define GPIO_PIN_05 GpioAction::BUTTON_PRESS_LEFT   // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
+#define GPIO_PIN_06 GpioAction::BUTTON_PRESS_B1     // B1     | A      | B       | Cross    | 2      | K1     |
+#define GPIO_PIN_07 GpioAction::BUTTON_PRESS_B2     // B2     | B      | A       | Circle   | 3      | K2     |
+#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_R2     // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define GPIO_PIN_18 GpioAction::BUTTON_PRESS_L2     // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define GPIO_PIN_10 GpioAction::BUTTON_PRESS_B3     // B3     | X      | Y       | Square   | 1      | P1     |
+#define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4     // B4     | Y      | X       | Triangle | 4      | P2     |
+#define GPIO_PIN_08 GpioAction::BUTTON_PRESS_R1     // R1     | RB     | R       | R1       | 6      | P3     |
+#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L1     // L1     | LB     | L       | L1       | 5      | P4     |
+//#define GPIO_PIN_16 GpioAction::BUTTON_PRESS_S1   // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
+//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L3   // L3     | LS     | LS      | L3       | 11     | LS     |
+//#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_R3   // R3     | RS     | RS      | R3       | 12     | RS     |
+//#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1   // A1     | Guide  | Home    | PS       | 13     | ~      |
+//#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2   // A2     | ~      | Capture | ~        | 14     | ~      |
+
+// Keyboard Mapping Configuration
+//                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP     | UP     | UP      | UP       | UP     | UP     |
+#define KEY_DPAD_DOWN   HID_KEY_ARROW_DOWN    // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   | 
+#define KEY_DPAD_RIGHT  HID_KEY_ARROW_RIGHT   // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  | 
+#define KEY_DPAD_LEFT   HID_KEY_ARROW_LEFT    // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   | 
+#define KEY_BUTTON_B1   HID_KEY_SHIFT_LEFT    // B1     | A      | B       | Cross    | 2      | K1     |
+#define KEY_BUTTON_B2   HID_KEY_Z             // B2     | B      | A       | Circle   | 3      | K2     |
+#define KEY_BUTTON_R2   HID_KEY_X             // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define KEY_BUTTON_L2   HID_KEY_V             // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define KEY_BUTTON_B3   HID_KEY_CONTROL_LEFT  // B3     | X      | Y       | Square   | 1      | P1     |
+#define KEY_BUTTON_B4   HID_KEY_ALT_LEFT      // B4     | Y      | X       | Triangle | 4      | P2     |
+#define KEY_BUTTON_R1   HID_KEY_SPACE         // R1     | RB     | R       | R1       | 6      | P3     |
+#define KEY_BUTTON_L1   HID_KEY_C             // L1     | LB     | L       | L1       | 5      | P4     |
+#define KEY_BUTTON_S1   HID_KEY_5             // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define KEY_BUTTON_S2   HID_KEY_1             // S2     | Start  | Plus    | Start    | 10     | Start  |
+#define KEY_BUTTON_L3   HID_KEY_EQUAL         // L3     | LS     | LS      | L3       | 11     | LS     |
+#define KEY_BUTTON_R3   HID_KEY_MINUS         // R3     | RS     | RS      | R3       | 12     | RS     |
+#define KEY_BUTTON_A1   HID_KEY_9             // A1     | Guide  | Home    | PS       | 13     | ~      |
+#define KEY_BUTTON_A2   HID_KEY_F2            // A2     | ~      | Capture | ~        | 14     | ~      |
+#define KEY_BUTTON_FN   -1                    // Hotkey Function                                        |
+
+
+#define HOTKEY_01_AUX_MASK 0
+#define HOTKEY_01_BUTTONS_MASK 576 // L2+Start
+#define HOTKEY_01_DPAD_MASK 1      // Up
+#define HOTKEY_01_ACTION 4         // Home
+
+#define HOTKEY_02_AUX_MASK 0
+#define HOTKEY_02_BUTTONS_MASK 576 // L2+Start
+#define HOTKEY_02_DPAD_MASK 2      // Down
+#define HOTKEY_02_ACTION 1         // D-Pad Digital Mode
+
+#define HOTKEY_03_AUX_MASK 0
+#define HOTKEY_03_BUTTONS_MASK 576 // L2+Start
+#define HOTKEY_03_DPAD_MASK 4      // Left
+#define HOTKEY_03_ACTION 2         // Left Analog Mode
+
+#define HOTKEY_04_AUX_MASK 0
+#define HOTKEY_04_BUTTONS_MASK 576 // L2+Start
+#define HOTKEY_04_DPAD_MASK 8      // Right
+#define HOTKEY_04_ACTION 3         // Right Analog Mode
+
+#define BOARD_LED_ENABLED 1
+#define BOARD_LED_TYPE ON_BOARD_LED_MODE_INPUT_TEST
+
+#endif

--- a/configs/ReflexCtrlSaturn/README.md
+++ b/configs/ReflexCtrlSaturn/README.md
@@ -1,0 +1,12 @@
+# GP2040-CE Configuration for the Reflex CTRL Saturn Board by MiSTer Addons
+
+![Reflex CTRL Saturn](https://github.com/misteraddons/Reflex-CTRL/raw/main/Images/saturn.png)
+
+Open source replacement PCB for Sega Saturn controllers
+* USA Model 2 controller
+* Japanese controller
+* Retro-Bit Saturn controller
+
+Purchase: https://misteraddons.com/products/Reflex-CTRL
+
+GitHub: https://github.com/misteraddons/Reflex-CTRL

--- a/configs/ReflexCtrlVB/BoardConfig.h
+++ b/configs/ReflexCtrlVB/BoardConfig.h
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2021 Jason Skuby (mytechtoybox.com)
+ */
+
+#ifndef PICO_BOARD_CONFIG_H_
+#define PICO_BOARD_CONFIG_H_
+
+#include "enums.pb.h"
+#include "class/hid/hid.h"
+
+#define BOARD_CONFIG_LABEL "Reflex CTRL Virtual Boy"
+
+// Input Mode additions section.
+#define DEFAULT_INPUT_MODE_R1 INPUT_MODE_SWITCH
+
+// This is the main pin definition section.
+// This will let you specify which GPIO pin each button is assigned too.
+// You can set any of the main pins as `-1` to disable it.
+// The Turbo pin and LS + RS slider pins can also be set to `-1` to disable that functionality.
+// Please note that only when `PIN_BUTTON_TURBO` is set to `-1` will the `T##` be removed from a connected display.
+// Please note that only when `PIN_SLIDER_ONE` and  `PIN_SLIDER_TWO` are set to `-1` will the button combo shortcut for DP/LS/RS work.
+// The buttons are listed in GP2040 configuration, beside each the listed order is *GP2040 / Xinput / Switch / PS3 / Directinput / Arcade*
+
+// Main pin mapping Configuration
+//                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
+#define GPIO_PIN_03 GpioAction::BUTTON_PRESS_DOWN   // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
+#define GPIO_PIN_04 GpioAction::BUTTON_PRESS_RIGHT  // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |
+#define GPIO_PIN_05 GpioAction::BUTTON_PRESS_LEFT   // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
+#define GPIO_PIN_10 GpioAction::BUTTON_PRESS_B1     // B1     | A      | B       | Cross    | 2      | K1     |
+#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_B2     // B2     | B      | A       | Circle   | 3      | K2     |
+#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_R2     // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define GPIO_PIN_18 GpioAction::BUTTON_PRESS_L2     // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_B3     // B3     | X      | Y       | Square   | 1      | P1     |
+#define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4     // B4     | Y      | X       | Triangle | 4      | P2     |
+#define GPIO_PIN_07 GpioAction::BUTTON_PRESS_R1     // R1     | RB     | R       | R1       | 6      | P3     |
+#define GPIO_PIN_06 GpioAction::BUTTON_PRESS_L1     // L1     | LB     | L       | L1       | 5      | P4     |
+#define GPIO_PIN_16 GpioAction::BUTTON_PRESS_S1     // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
+//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L3   // L3     | LS     | LS      | L3       | 11     | LS     |
+//#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_R3   // R3     | RS     | RS      | R3       | 12     | RS     |
+//#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1   // A1     | Guide  | Home    | PS       | 13     | ~      |
+//#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2   // A2     | ~      | Capture | ~        | 14     | ~      |
+
+// Keyboard Mapping Configuration
+//                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP     | UP     | UP      | UP       | UP     | UP     |
+#define KEY_DPAD_DOWN   HID_KEY_ARROW_DOWN    // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   | 
+#define KEY_DPAD_RIGHT  HID_KEY_ARROW_RIGHT   // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  | 
+#define KEY_DPAD_LEFT   HID_KEY_ARROW_LEFT    // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   | 
+#define KEY_BUTTON_B1   HID_KEY_SHIFT_LEFT    // B1     | A      | B       | Cross    | 2      | K1     |
+#define KEY_BUTTON_B2   HID_KEY_Z             // B2     | B      | A       | Circle   | 3      | K2     |
+#define KEY_BUTTON_R2   HID_KEY_X             // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define KEY_BUTTON_L2   HID_KEY_V             // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define KEY_BUTTON_B3   HID_KEY_CONTROL_LEFT  // B3     | X      | Y       | Square   | 1      | P1     |
+#define KEY_BUTTON_B4   HID_KEY_ALT_LEFT      // B4     | Y      | X       | Triangle | 4      | P2     |
+#define KEY_BUTTON_R1   HID_KEY_SPACE         // R1     | RB     | R       | R1       | 6      | P3     |
+#define KEY_BUTTON_L1   HID_KEY_C             // L1     | LB     | L       | L1       | 5      | P4     |
+#define KEY_BUTTON_S1   HID_KEY_5             // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define KEY_BUTTON_S2   HID_KEY_1             // S2     | Start  | Plus    | Start    | 10     | Start  |
+#define KEY_BUTTON_L3   HID_KEY_EQUAL         // L3     | LS     | LS      | L3       | 11     | LS     |
+#define KEY_BUTTON_R3   HID_KEY_MINUS         // R3     | RS     | RS      | R3       | 12     | RS     |
+#define KEY_BUTTON_A1   HID_KEY_9             // A1     | Guide  | Home    | PS       | 13     | ~      |
+#define KEY_BUTTON_A2   HID_KEY_F2            // A2     | ~      | Capture | ~        | 14     | ~      |
+#define KEY_BUTTON_FN   -1                    // Hotkey Function                                        |
+
+#define BOARD_LED_ENABLED 1
+#define BOARD_LED_TYPE ON_BOARD_LED_MODE_INPUT_TEST
+
+#endif

--- a/configs/ReflexCtrlVB/BoardConfig.h
+++ b/configs/ReflexCtrlVB/BoardConfig.h
@@ -14,14 +14,6 @@
 // Input Mode additions section.
 #define DEFAULT_INPUT_MODE_R1 INPUT_MODE_SWITCH
 
-// This is the main pin definition section.
-// This will let you specify which GPIO pin each button is assigned too.
-// You can set any of the main pins as `-1` to disable it.
-// The Turbo pin and LS + RS slider pins can also be set to `-1` to disable that functionality.
-// Please note that only when `PIN_BUTTON_TURBO` is set to `-1` will the `T##` be removed from a connected display.
-// Please note that only when `PIN_SLIDER_ONE` and  `PIN_SLIDER_TWO` are set to `-1` will the button combo shortcut for DP/LS/RS work.
-// The buttons are listed in GP2040 configuration, beside each the listed order is *GP2040 / Xinput / Switch / PS3 / Directinput / Arcade*
-
 // Main pin mapping Configuration
 //                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
 #define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
@@ -38,10 +30,6 @@
 #define GPIO_PIN_06 GpioAction::BUTTON_PRESS_L1     // L1     | LB     | L       | L1       | 5      | P4     |
 #define GPIO_PIN_16 GpioAction::BUTTON_PRESS_S1     // S1     | Back   | Minus   | Select   | 9      | Coin   |
 #define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
-//#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_L3   // L3     | LS     | LS      | L3       | 11     | LS     |
-//#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_R3   // R3     | RS     | RS      | R3       | 12     | RS     |
-//#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1   // A1     | Guide  | Home    | PS       | 13     | ~      |
-//#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2   // A2     | ~      | Capture | ~        | 14     | ~      |
 
 // Keyboard Mapping Configuration
 //                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |

--- a/configs/ReflexCtrlVB/README.md
+++ b/configs/ReflexCtrlVB/README.md
@@ -1,0 +1,11 @@
+# GP2040-CE Configuration for the Reflex CTRL Virtual Boy Board by MiSTer Addons
+
+![Reflex CTRL Virtual Boy](https://github.com/misteraddons/Reflex-CTRL/raw/main/Images/vb.png)
+
+Open source replacement PCB for Nintendo Virtual Boy controllers
+
+Note: Do not connect any packs to the controller. The USB cable powers the controller.
+
+Purchase: https://misteraddons.com/products/Reflex-CTRL
+
+GitHub: https://github.com/misteraddons/Reflex-CTRL


### PR DESCRIPTION
Drop-in USB conversions for classic controllers.