### PR TITLE
Value of rotatory encoder jumping from 0.999 to -1

### DIFF
--- a/src/addons/rotaryencoder.cpp
+++ b/src/addons/rotaryencoder.cpp
@@ -103,13 +103,13 @@ void RotaryEncoderInput::process()
             uint32_t lastChange = now - encoderState[i].changeTime;
 
             if (encoderMap[i].mode == ENCODER_MODE_LEFT_ANALOG_X) {
-                gamepad->state.lx = -mapEncoderValueStick(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
+                gamepad->state.lx = mapEncoderValueStick(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
             } else if (encoderMap[i].mode == ENCODER_MODE_LEFT_ANALOG_Y) {
-                gamepad->state.ly = -mapEncoderValueStick(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
+                gamepad->state.ly = mapEncoderValueStick(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
             } else if (encoderMap[i].mode == ENCODER_MODE_RIGHT_ANALOG_X) {
-                gamepad->state.rx = -mapEncoderValueStick(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
+                gamepad->state.rx = mapEncoderValueStick(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
             } else if (encoderMap[i].mode == ENCODER_MODE_RIGHT_ANALOG_Y) {
-                gamepad->state.ry = -mapEncoderValueStick(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
+                gamepad->state.ry = mapEncoderValueStick(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
             } else if (encoderMap[i].mode == ENCODER_MODE_LEFT_TRIGGER) {
                 gamepad->state.lt = mapEncoderValueTrigger(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
             } else if (encoderMap[i].mode == ENCODER_MODE_RIGHT_TRIGGER) {

--- a/src/addons/rotaryencoder.cpp
+++ b/src/addons/rotaryencoder.cpp
@@ -155,7 +155,7 @@ uint16_t RotaryEncoderInput::mapEncoderValueStick(int8_t index, int32_t encoderV
         return encoderValue;
     } else {
         int32_t mappedValue = map(encoderValue, minValue, maxValue, encoderMap[index].minRange, encoderMap[index].maxRange);
-        int32_t constrainedValue = bounds(mappedValue, encoderMap[index].minRange, encoderMap[index].maxRange-1);
+        int32_t constrainedValue = bounds(mappedValue, encoderMap[index].minRange, encoderMap[index].maxRange);
 
         return constrainedValue;
     }


### PR DESCRIPTION
Hi everyone :wave:

I have been trying the hw-40 rotatory encoder with the pico board and i noticed that the encoder goes from -1 to 1 but then jump abruptly to -1 again and doesn't move from there anymore if not by rotating backward ( is not a wrap around )

Removing the minus sign from the function call fixes the issue but **does swap** the rotation direction.

I do think the rotation swapped is more natural, clockwise on the right, counter clockwise on the left, it makes sense for example for a steering wheel because is what we are used to, but i m not going to argue which one i better i can understand is not an absolute point of view.

Encoder addon settings:
<img width="528" alt="image" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/d5aa757c-52f2-4ed2-966c-565a45221b95">

## current 0.7.8 release:

Testing on https://hardwaretester.com/gamepad turning the knob 180+ degree counter clockwise and then going back to center and adding 180 clockwise


https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/b45c2169-c9d0-48be-b563-05b7bc2d3306

## current patch in this branch, same movement


https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/8c656740-ca8c-4076-b15f-8064c3ce3a1c



 compiled code for testing [GP2040-CE_0.7.8_Pico.uf2.zip](https://github.com/OpenStickCommunity/GP2040-CE/files/15197144/GP2040-CE_0.7.8_Pico.uf2.zip)

This is my encoder:
![image](https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/a525fc1b-a17b-44ec-8064-fa1c1470e8c6)

And those are the specs:
https://www.elecom.sk/rotary-encoder-module-with-demo-code-for-uno-r3/

