### PR TITLE
feat(): Add a mode for the rotatory encoder to trigger 2 buttons

### DIFF
--- a/headers/addons/rotaryencoder.h
+++ b/headers/addons/rotaryencoder.h
@@ -116,6 +116,7 @@ private:
     EncoderPinState encoderState[MAX_ENCODERS];
     int32_t encoderValues[MAX_ENCODERS];
     int32_t prevValues[MAX_ENCODERS];
+    int8_t lastValue = 0;
     EncoderPinMap encoderMap[MAX_ENCODERS] = {
         {false, -1, -1, 24, ENCODER_MODE_NONE, -1, -1},
         {false, -1, -1, 24, ENCODER_MODE_NONE, -1, -1},

--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -370,4 +370,5 @@ enum RotaryEncoderPinMode
     ENCODER_MODE_RIGHT_TRIGGER = 6;
     ENCODER_MODE_DPAD_X = 7;
     ENCODER_MODE_DPAD_Y = 8;
+    ENCODER_MODE_BUTTONS = 9;
 };

--- a/src/addons/rotaryencoder.cpp
+++ b/src/addons/rotaryencoder.cpp
@@ -136,9 +136,13 @@ void RotaryEncoderInput::process()
                 encoderState[i].changeTime = now;
             }
 
+            //
+            if (lastChange > 500 && encoderValues[i] == prevValues[i]) {
+                lastValue = 0;
+            }
+
             if ((encoderMap[i].resetAfter > 0) && (lastChange >= encoderMap[i].resetAfter)) {
                 encoderValues[i] = 0;
-                lastValue = 0;
             }
         }
 

--- a/src/addons/rotaryencoder.cpp
+++ b/src/addons/rotaryencoder.cpp
@@ -83,8 +83,10 @@ void RotaryEncoderInput::process()
                     if ((encoderState[i].pinA == encoderState[i].prevA) && (encoderState[i].pinB == encoderState[i].prevB)) {
                         if ((encoderState[i].pinA && !encoderState[i].pinB && pinBValue) || (!encoderState[i].pinA && encoderState[i].pinB && !pinBValue)) {
                             encoderValues[i]+=encoderIncrement;
+                            lastValue = 1;
                         } else if ((!encoderState[i].pinA && encoderState[i].pinB && pinBValue) || (encoderState[i].pinA && !encoderState[i].pinB && !pinBValue)) {
                             encoderValues[i]-=encoderIncrement;
+                            lastValue = -1;
                         }
                     }
                 }
@@ -123,9 +125,9 @@ void RotaryEncoderInput::process()
                 dpadUp = (axis == 1);
                 dpadDown = (axis == -1);
             } else if (encoderMap[i].mode == ENCODER_MODE_BUTTONS) {
-                if (encoderValues[i] < prevValues[i]) {
+                if (lastValue == -1) {
                     gamepad->state.buttons |= GAMEPAD_MASK_L1;
-                } else if (encoderValues[i] > prevValues[i]) {
+                } else if (lastValue == 1) {
                     gamepad->state.buttons |= GAMEPAD_MASK_L2;
                 }
             }
@@ -136,6 +138,7 @@ void RotaryEncoderInput::process()
 
             if ((encoderMap[i].resetAfter > 0) && (lastChange >= encoderMap[i].resetAfter)) {
                 encoderValues[i] = 0;
+                lastValue = 0;
             }
         }
 

--- a/src/addons/rotaryencoder.cpp
+++ b/src/addons/rotaryencoder.cpp
@@ -136,14 +136,19 @@ void RotaryEncoderInput::process()
                 encoderState[i].changeTime = now;
             }
 
-            //
-            if (lastChange > 500 && encoderValues[i] == prevValues[i]) {
-                lastValue = 0;
+            // if we are using mode_buttons we do not want to reset encoder values to 0
+            // but we want to just reset the button value.
+            // Resetting encoderValues will produce empty clicks
+            if (encoderMap[i].mode == ENCODER_MODE_BUTTONS) {
+                if (lastChange > encoderMap[i].resetAfter && encoderValues[i] == prevValues[i]) {
+                    lastValue = 0;
+                }
+            } else {
+                if ((encoderMap[i].resetAfter > 0) && (lastChange >= encoderMap[i].resetAfter)) {
+                    encoderValues[i] = 0;
+                }
             }
 
-            if ((encoderMap[i].resetAfter > 0) && (lastChange >= encoderMap[i].resetAfter)) {
-                encoderValues[i] = 0;
-            }
         }
 
         prevValues[i] = encoderValues[i];

--- a/src/addons/rotaryencoder.cpp
+++ b/src/addons/rotaryencoder.cpp
@@ -122,6 +122,12 @@ void RotaryEncoderInput::process()
                 int8_t axis = mapEncoderValueDPad(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
                 dpadUp = (axis == 1);
                 dpadDown = (axis == -1);
+            } else if (encoderMap[i].mode == ENCODER_MODE_BUTTONS) {
+                if (encoderValues[i] < prevValues[i]) {
+                    gamepad->state.buttons |= GAMEPAD_MASK_L1;
+                } else if (encoderValues[i] > prevValues[i]) {
+                    gamepad->state.buttons |= GAMEPAD_MASK_L2;
+                }
             }
 
             if ((encoderValues[i] - prevValues[i]) != 0) {

--- a/www/src/Addons/Rotary.tsx
+++ b/www/src/Addons/Rotary.tsx
@@ -17,6 +17,7 @@ const ENCODER_MODES = [
     { label: 'encoder-mode-right-trigger', value: 6 },
     { label: 'encoder-mode-dpad-x', value: 7 },
     { label: 'encoder-mode-dpad-y', value: 8 },
+    { label: 'encoder-mode-buttons', value: 9 },
 ];
 
 const ENCODER_MULTIPLES = [

--- a/www/src/Locales/en/Addons/Rotary.jsx
+++ b/www/src/Locales/en/Addons/Rotary.jsx
@@ -16,6 +16,7 @@ export default {
     'encoder-mode-right-analog-y': 'Right Analog Y',
     'encoder-mode-left-trigger': 'Left Trigger',
     'encoder-mode-right-trigger': 'Right Trigger',
+    'encoder-mode-buttons': 'Buttons + / -',
     'encoder-mode-dpad-x': 'D-Pad Left/Right',
     'encoder-mode-dpad-y': 'D-Pad Up/Down',
 };


### PR DESCRIPTION
This is the feature i originally wanted and i though i could now have it since most of the code is there.

For some arcade situations in which the DPAD is used and the analog controllers are not supported, having a rotatory encoder mapping on buttons is useful.

This is what i was thinking:
- i add a lastValue var where i keep the last state of the encoder, positive or negative.
- i add a new enum for the mode and relative web code to configure it
- i assign last value from the rotatory decode code and i keep it of the same value until it change or until a timeout pass ( using the available reset timer, otherwise the button press are like 1 ms long and most of the time are not captured, at least this is my understanding )

Using this configuration

<img width="532" alt="image" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/f870ea03-debb-42e7-96b9-0eba286f9551">


I tested it only with https://hardwaretester.com/gamepad for now

## In action

Here is a test with an arcade game from mister that support either a spinner or buttons, in button mode:

https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/e6965896-3c58-48f3-9e3a-545377d1b21c

## Why

The difference with the current modes is the absence of a central dead zone and the ability to go right and left immediately.

Both DPAD and Analog stick requires you to cross the center zone or to go through the reset after X millisecond.
If the reset is too quick you are always fighting with the center dead zone, if the the reset is too slow or the movement too quick you are not going back to the center first and you need to change direction by rotating a lot.

This different method is very useful for games that uses 2 buttons for rotation.

## How to use it

You select the new mode from the dropdown and you have to set the 'reset after' time.
The code will detect the change only for 1 tick ( around 1ms ) if you don't set a reset after time.
In this case the reset after time is cancelling the button press. A rotatory tick will push the button down and the reset time will push the button back up, the value you want to set depend on the game, some games will support continue press, others maybe not, and the more the reset after time is large the more the button stay pressed.

This is the first implementation i managed to make work and worked well, the rest can be built with feedback and other opinions