### PR TITLE
fix() signal from axios.get is a specific AbortSignal

### DIFF
--- a/www/src/Services/Http.ts
+++ b/www/src/Services/Http.ts
@@ -1,8 +1,13 @@
 // This is modeled after Axios to make an easier transition, so this may need more buildout
 // if more than simple GET and POST requests are required.
 
+type GetOptions = {
+	headers?: Record<string, string>,
+	signal?: AbortSignal
+}
+
 class Http {
-	async get(url: string, headers: object = {}) {
+	async get(url: string, { headers = {}, signal }: GetOptions = {}) {
 		try {
 			const response = await fetch(url, {
 				method: 'GET',
@@ -10,6 +15,7 @@ class Http {
 					'Content-Type': 'application/json',
 					...headers,
 				},
+				signal
 			});
 
 			const json = await response.json();

--- a/www/src/Services/Http.ts
+++ b/www/src/Services/Http.ts
@@ -22,9 +22,6 @@ class Http {
 			return Promise.resolve({ data: json });
 		}
 		catch (err) {
-			if (signal?.aborted) {
-				throw new Error('ERR_CANCELED');
-			}
 			return Promise.reject(err);
 		}
 	}

--- a/www/src/Services/Http.ts
+++ b/www/src/Services/Http.ts
@@ -22,6 +22,9 @@ class Http {
 			return Promise.resolve({ data: json });
 		}
 		catch (err) {
+			if (signal?.aborted) {
+				throw new Error('ERR_CANCELED');
+			}
 			return Promise.reject(err);
 		}
 	}

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -639,7 +639,7 @@ async function getHeldPins(abortSignal) {
 		});
 		return response.data;
 	} catch (error) {
-		if (error.name === 'AbortError') return { canceled: true };
+		if (error?.name === 'AbortError') return { canceled: true };
 		else console.error(error);
 	}
 }

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -639,7 +639,7 @@ async function getHeldPins(abortSignal) {
 		});
 		return response.data;
 	} catch (error) {
-		if (error.message === 'ERR_CANCELED') return { canceled: true };
+		if (error.name === 'AbortError') return { canceled: true };
 		else console.error(error);
 	}
 }

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -639,7 +639,7 @@ async function getHeldPins(abortSignal) {
 		});
 		return response.data;
 	} catch (error) {
-		if (error?.code === 'ERR_CANCELED') return { canceled: true };
+		if (error.message === 'ERR_CANCELED') return { canceled: true };
 		else console.error(error);
 	}
 }


### PR DESCRIPTION
I noticed by chance in the [http vs axios](https://github.com/OpenStickCommunity/GP2040-CE/pull/988) PR that the signal was axios.get was merged into an header, that seems a bug to me.

Here:
https://github.com/OpenStickCommunity/GP2040-CE/pull/988/files#diff-c906511881a407b1d4a0978d708b2841f02b1a72e52c5efd1210fb16628fce6eR637

the pin mapping page is indeed pushing up this wrong header:
<img width="427" alt="image" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/fc0ff77c-44fc-48a5-bd5c-f3f24aed7c52">

This is possible in the 0.78 release:

https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/0f7a7a20-b270-49f2-9757-4ce7bba27a62

But those buttons ( skip pin, cancel and the close icon ) are not functional in current master