### PR TITLE
build() deduplicate loadsh and lodash-es between dependencies

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -16,6 +16,7 @@
 				"javascript-color-gradient": "^2.4.4",
 				"jsencrypt": "^3.3.2",
 				"lodash": "^4.17.21",
+				"lodash-es": "^4.17.21",
 				"react": "^18.2.0",
 				"react-beautiful-dnd": "^13.1.1",
 				"react-bootstrap": "^2.7.4",

--- a/www/package.json
+++ b/www/package.json
@@ -11,7 +11,6 @@
 		"i18next-browser-languagedetector": "^7.0.2",
 		"javascript-color-gradient": "^2.4.4",
 		"jsencrypt": "^3.3.2",
-		"lodash": "^4.17.21",
 		"lodash-es": "^4.17.21",
 		"react": "^18.2.0",
 		"react-beautiful-dnd": "^13.1.1",

--- a/www/package.json
+++ b/www/package.json
@@ -12,6 +12,7 @@
 		"javascript-color-gradient": "^2.4.4",
 		"jsencrypt": "^3.3.2",
 		"lodash": "^4.17.21",
+		"lodash-es": "^4.17.21",
 		"react": "^18.2.0",
 		"react-beautiful-dnd": "^13.1.1",
 		"react-bootstrap": "^2.7.4",

--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"~bootstrap": path.resolve(__dirname, "node_modules/bootstrap"),
+			lodash: 'lodash-es'
 		},
 	},
 });


### PR DESCRIPTION
Formik uses lodash-es as replacement from lodash to obtain a smaller bundle size.
The web part of GP2040 uses lodash, causing both libraries to be embedded in the final bundle.

Using the alias resolve in vite built tool allows you to remove the duplication, making lodash-es as larger as necessary to cover all the functionalities that are effectively used

This removes around 9kb from the final build size

This branch

<img width="466" alt="image" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/09954be1-5a05-4138-b855-bcb71f65776f">


<img width="1545" alt="image" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/a1a47855-45e0-4e03-9091-4499bac3449a">

main

<img width="459" alt="image" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/980bece3-7452-491a-b305-97099ada9ddc">

![image](https://github.com/OpenStickCommunity/GP2040-CE/assets/1194048/770c449a-2af8-465d-8947-47018b4ef8b7)


