### PR TITLE
Add Development link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Links
 
-[Downloads](https://gp2040-ce.info/downloads) | [Installation](https://gp2040-ce.info/installation) | [Wiring](https://gp2040-ce.info/controller-build/wiring) | [Usage](https://gp2040-ce.info/usage) | [FAQ](https://gp2040-ce.info/faq/faq-general) | [GitHub](https://github.com/OpenStickCommunity/GP2040-CE)
+[Downloads](https://gp2040-ce.info/downloads) | [Installation](https://gp2040-ce.info/installation) | [Wiring](https://gp2040-ce.info/controller-build/wiring) | [Usage](https://gp2040-ce.info/usage) | [FAQ](https://gp2040-ce.info/faq/faq-general) | [GitHub](https://github.com/OpenStickCommunity/GP2040-CE) | [Development](https://gp2040-ce.info/development/firmware-development)
 
 Full documentation can be found at [https://gp2040-ce.info](https://gp2040-ce.info)
 


### PR DESCRIPTION
https://github.com/OpenStickCommunity/GP2040-CE/issues/1020
It was hard for me to find build instructions because I didn't think they were written in Contribute tab. So I suggest adding a link.