### PR TITLE
Fix for i2c enabled always on

### DIFF
--- a/headers/addons/display.h
+++ b/headers/addons/display.h
@@ -23,7 +23,7 @@
 #include "peripheral_spi.h"
 
 #ifndef HAS_I2C_DISPLAY
-#define HAS_I2C_DISPLAY -1
+#define HAS_I2C_DISPLAY 0
 #endif
 
 #ifndef DISPLAY_I2C_ADDR


### PR DESCRIPTION
This will fix i2c0 enable being set to true even if i2c0 is disabled.