### PR TITLE
Update to the images used for capture and home in the input history

### DIFF
--- a/headers/display/ui/screens/ButtonLayoutScreen.h
+++ b/headers/display/ui/screens/ButtonLayoutScreen.h
@@ -26,8 +26,8 @@
 #define CHAR_DL       "\x8A"
 #define CHAR_DR       "\x8B"
 
-#define CHAR_HOME_S   "\x8C"
-#define CHAR_CAP_S    "\x8D"
+#define CHAR_CAP_S    "\x8C"
+#define CHAR_HOME_S   "\x8D"
 
 #define CHAR_VIEW_X   "\x8E"
 #define CHAR_MENU_X   "\x8F"


### PR DESCRIPTION
The icons for the home and capture buttons in the input history on Switch mode were swapped.  This RP swaps them back.