### PR TITLE
don't initialize the USB host if no one is listening

### DIFF
--- a/src/usbhostmanager.cpp
+++ b/src/usbhostmanager.cpp
@@ -12,7 +12,7 @@
 
 void USBHostManager::start() {
     // This will happen after Gamepad has initialized
-    if (PeripheralManager::getInstance().isUSBEnabled(0)) {
+    if (PeripheralManager::getInstance().isUSBEnabled(0) && listeners.size() > 0) {
         pio_usb_configuration_t* pio_cfg = PeripheralManager::getInstance().getUSB(0)->getController();
         tuh_configure(1, TUH_CFGID_RPI_PIO_USB_CONFIGURATION, pio_cfg);
         tuh_init(BOARD_TUH_RHPORT);


### PR DESCRIPTION
Found this while looking into a different issue. if there's no drivers/addons that have registered as a USB host listener, there's no point in initializing it, so don't.

I wonder if we should also only underclock ourselves in this block too? (Not that I think it matters much.)