### PR TITLE
fix(layout): swap A1 and L3 buttons to correct placement issue

### DIFF
--- a/www/src/Pages/CustomThemePage.scss
+++ b/www/src/Pages/CustomThemePage.scss
@@ -612,13 +612,13 @@ $button-keycap: 19px;
 	}
 	.L3 {
 		@include arcade-button($button-24mm, true);
-		left: calc(50% - #{$button-24mm * 3.5});
-		top: calc(50% + #{$button-24mm * 0.75});
+		left: calc(59% - #{$button-24mm});
+		top: calc(0% - #{$button-24mm * 2.15});
 	}
 	.A2 {
 		@include arcade-button($button-24mm, true);
-		left: calc(59% - #{$button-24mm});
-		top: calc(0% - #{$button-24mm * 2.15});
+		left: calc(50% - #{$button-24mm * 3.5});
+		top: calc(50% + #{$button-24mm * 0.75});
 	}
 }
 

--- a/www/src/Pages/CustomThemePage.scss
+++ b/www/src/Pages/CustomThemePage.scss
@@ -697,13 +697,13 @@ $button-keycap: 19px;
 	}
 	.L3 {
 		@include arcade-button($button-24mm, true);
-		left: calc(50% - #{$button-24mm * 11});
-		top: $button-24mm * 2;
+		left: calc(59% - #{$button-24mm});
+		top: calc(0% - #{$button-24mm * 2.15});
 	}
 	.A2 {
 		@include arcade-button($button-24mm, true);
-		left: calc(59% - #{$button-24mm});
-		top: calc(0% - #{$button-24mm * 2.15});
+		left: calc(50% - #{$button-24mm * 11});
+		top: $button-24mm * 2;
 	}
 }
 


### PR DESCRIPTION
Fixed the 16 button layout swapped the L3 and A2 positions.
 
![Screenshot 2024-06-12 at 11 59 58 AM](https://github.com/OpenStickCommunity/GP2040-CE/assets/7717223/a9101ef9-90ec-4161-b890-4fad27f6f1db)
