### PR TITLE
Enables choosing turbo and macro in pin mapping

### DIFF
--- a/www/src/Pages/PinMapping.tsx
+++ b/www/src/Pages/PinMapping.tsx
@@ -37,8 +37,6 @@ type PinSectionType = {
 const disabledOptions = [
 	BUTTON_ACTIONS.RESERVED,
 	BUTTON_ACTIONS.ASSIGNED_TO_ADDON,
-	BUTTON_ACTIONS.BUTTON_PRESS_TURBO,
-	BUTTON_ACTIONS.BUTTON_PRESS_MACRO,
 ];
 
 const getMask = (maskArr, key) =>


### PR DESCRIPTION
`GPIO pin to trigger 2+ buttons` Was started before these options could be done in the pin mapping, and was missed on merge.

Now selectable again
<img width="502" alt="Screenshot 2024-07-01 at 19 38 11" src="https://github.com/OpenStickCommunity/GP2040-CE/assets/5345892/7e137a4d-966b-46b6-a18a-49b2c1a3350d">

Thanks to Hylian for finding it!