### PR TITLE
Fixed RGB LED remains off when the usb disconnected and reconnected

### DIFF
--- a/src/usbdriver.cpp
+++ b/src/usbdriver.cpp
@@ -40,6 +40,7 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
 void tud_mount_cb(void)
 {
 	usb_mounted = true;
+	usb_suspended = true;
 }
 
 // Invoked when device is unmounted

--- a/src/usbdriver.cpp
+++ b/src/usbdriver.cpp
@@ -40,13 +40,14 @@ void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t rep
 void tud_mount_cb(void)
 {
 	usb_mounted = true;
-	usb_suspended = true;
+	usb_suspended = false;
 }
 
 // Invoked when device is unmounted
 void tud_umount_cb(void)
 {
 	usb_mounted = false;
+	usb_suspended = false;
 }
 
 // Invoked when usb bus is suspended


### PR DESCRIPTION
This fixes an issue after turning on "Turn Off When Suspend" switch in RGB LED Configuration, RGB LED remains off when the usb disconnected and reconnected. so clearing the usb suspend status when the device is mounted.