### PR TITLE
switch midpoint fix

### DIFF
--- a/src/drivers/switch/SwitchDriver.cpp
+++ b/src/drivers/switch/SwitchDriver.cpp
@@ -56,10 +56,10 @@ void SwitchDriver::process(Gamepad * gamepad, uint8_t * outBuffer) {
 		| (gamepad->pressedA2() ? SWITCH_MASK_CAPTURE : 0)
 	;
 
-	switchReport.lx = static_cast<uint8_t>(gamepad->state.lx >> 8);
-	switchReport.ly = static_cast<uint8_t>(gamepad->state.ly >> 8);
-	switchReport.rx = static_cast<uint8_t>(gamepad->state.rx >> 8);
-	switchReport.ry = static_cast<uint8_t>(gamepad->state.ry >> 8);
+	switchReport.lx = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
+	switchReport.ly = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
+	switchReport.rx = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
+	switchReport.ry = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
 
 	// Wake up TinyUSB device
 	if (tud_suspended())

--- a/src/drivers/switch/SwitchDriver.cpp
+++ b/src/drivers/switch/SwitchDriver.cpp
@@ -56,9 +56,9 @@ void SwitchDriver::process(Gamepad * gamepad, uint8_t * outBuffer) {
 		| (gamepad->pressedA2() ? SWITCH_MASK_CAPTURE : 0)
 	;
 
-	switchReport.lx = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
-	switchReport.ly = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
-	switchReport.rx = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
+	switchReport.lx = static_cast<uint8_t>((gamepad->state.lx + 128) >> 8);
+	switchReport.ly = static_cast<uint8_t>((gamepad->state.ly + 128) >> 8);
+	switchReport.rx = static_cast<uint8_t>((gamepad->state.rx + 128) >> 8);
 	switchReport.ry = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
 
 	// Wake up TinyUSB device

--- a/src/drivers/switch/SwitchDriver.cpp
+++ b/src/drivers/switch/SwitchDriver.cpp
@@ -56,10 +56,10 @@ void SwitchDriver::process(Gamepad * gamepad, uint8_t * outBuffer) {
 		| (gamepad->pressedA2() ? SWITCH_MASK_CAPTURE : 0)
 	;
 
-	switchReport.lx = static_cast<uint8_t>((gamepad->state.lx + 128) >> 8);
-	switchReport.ly = static_cast<uint8_t>((gamepad->state.ly + 128) >> 8);
-	switchReport.rx = static_cast<uint8_t>((gamepad->state.rx + 128) >> 8);
-	switchReport.ry = static_cast<uint8_t>((gamepad->state.ry + 128) >> 8);
+	switchReport.lx = static_cast<uint8_t>(std::min((gamepad->state.lx + 128) >> 8, 255));
+	switchReport.ly = static_cast<uint8_t>(std::min((gamepad->state.ly + 128) >> 8, 255));
+	switchReport.rx = static_cast<uint8_t>(std::min((gamepad->state.rx + 128) >> 8, 255));
+	switchReport.ry = static_cast<uint8_t>(std::min((gamepad->state.ry + 128) >> 8, 255));
 
 	// Wake up TinyUSB device
 	if (tud_suspended())

--- a/src/drivers/switch/SwitchDriver.cpp
+++ b/src/drivers/switch/SwitchDriver.cpp
@@ -56,10 +56,10 @@ void SwitchDriver::process(Gamepad * gamepad, uint8_t * outBuffer) {
 		| (gamepad->pressedA2() ? SWITCH_MASK_CAPTURE : 0)
 	;
 
-	switchReport.lx = static_cast<uint8_t>(std::min((gamepad->state.lx + 128) >> 8, 255));
-	switchReport.ly = static_cast<uint8_t>(std::min((gamepad->state.ly + 128) >> 8, 255));
-	switchReport.rx = static_cast<uint8_t>(std::min((gamepad->state.rx + 128) >> 8, 255));
-	switchReport.ry = static_cast<uint8_t>(std::min((gamepad->state.ry + 128) >> 8, 255));
+	switchReport.lx = static_cast<uint8_t>(std::min((gamepad->state.lx + 1) >> 8, 255));
+	switchReport.ly = static_cast<uint8_t>(std::min((gamepad->state.ly + 1) >> 8, 255));
+	switchReport.rx = static_cast<uint8_t>(std::min((gamepad->state.rx + 1) >> 8, 255));
+	switchReport.ry = static_cast<uint8_t>(std::min((gamepad->state.ry + 1) >> 8, 255));
 
 	// Wake up TinyUSB device
 	if (tud_suspended())


### PR DESCRIPTION
Fix the bad midpoint, from 16 to 8 bit conversion, on analogs for Switch mode. Tested on Switch to be it's true center.