### PR TITLE
Fix initialization of new profiles' blocked pins and counts

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -560,6 +560,8 @@ std::string setProfileOptions()
                 profileOptions.gpioMappingsSets[altsIndex].pins[pin].customDpadMask = (uint32_t)alt[pinName]["customDpadMask"];
             }
         }
+        profileOptions.gpioMappingsSets[altsIndex].pins_count = NUM_BANK0_GPIOS;
+
         size_t profileLabelSize = sizeof(profileOptions.gpioMappingsSets[altsIndex].profileLabel);
         strncpy(profileOptions.gpioMappingsSets[altsIndex].profileLabel, alt["profileLabel"], profileLabelSize - 1);
         profileOptions.gpioMappingsSets[altsIndex].profileLabel[profileLabelSize - 1] = '\0';


### PR DESCRIPTION
Fixes two fatal bugs:
1. Creating a totally new profile would not have any pins on a subsequent load of the board, making using the profile lead to an inoperable controller, because the pin count wasn't retained in protobuf.
2. Creating a totally new profile would not retain the `RESERVED` or `ASSIGNED_TO_ADDON` actions, because the old code assumed other methods were populating those profiles' values, but that is not possible on a totally new profile.