### PR TITLE
Only allow selecting existing profiles in gamepad settings, add profile labels

### DIFF
--- a/www/src/Locales/de-DE/SettingsPage.jsx
+++ b/www/src/Locales/de-DE/SettingsPage.jsx
@@ -31,7 +31,7 @@ export default {
 		'first-win': 'Erster Gewinnt',
 		off: 'Aus',
 	},
-	'profile-number-label': 'Profil Nummer',
+	'profile-label': 'Profil',
 	'debounce-delay-label': 'Entprellverzögerung in Millisekunden',
 	'hotkey-settings-label': 'Hotkey Einstellungen',
 	'hotkey-settings-sub-header':

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -55,7 +55,7 @@ export default {
 		'first-win': 'First Win',
 		off: 'Off',
 	},
-	'profile-number-label': 'Profile Number',
+	'profile-label': 'Profile',
 	'debounce-delay-label': 'Debounce Delay in milliseconds',
 	'ps4-mode-explanation-text':
 		'PS4 mode allows GP2040-CE to run as an authenticated PS4 controller.',
@@ -63,13 +63,12 @@ export default {
 		'<span>⏳ WARNING ⏳:</span> PS4 will timeout after 8 minutes without authentication.',
 	'ps4-usb-host-mode-text':
 		'<span>INFO:</span> Please ensure USB Peripheral is enabled and a PS4 compatible USB device is plugged in.',
-	'ps4-id-mode-label':
-		'Identification Mode',
+	'ps4-id-mode-label': 'Identification Mode',
 	'ps4-id-mode-explanation-text':
 		'<ul><li>Console mode is used when connecting primarily to a PS4 console.</li><li>Remote/Emulation mode should only be used when connecting to an emulation layer or remote playing environment that requires a DualShock 4-compatible controller.</li></ul>',
 	'ps4-id-mode-options': {
-		'console': 'Console',
-		'emulation': 'Remote/Emulation',
+		console: 'Console',
+		emulation: 'Remote/Emulation',
 	},
 	'ps5-mode-explanation-text':
 		'PS5 mode allows GP2040-CE to run as an authenticated PS5 compatible arcade stick.',

--- a/www/src/Locales/ja-JP/SettingsPage.jsx
+++ b/www/src/Locales/ja-JP/SettingsPage.jsx
@@ -47,7 +47,7 @@ export default {
 		'first-win': '先入力優先',
 		off: '無効',
 	},
-	'profile-number-label': 'プロファイル番号',
+	'profile-label': 'プロファイル',
 	'debounce-delay-label': 'チャタリング除去ディレイ(ミリ秒)',
 	'ps4-mode-explanation-text':
 		'PS4モードはGP2040-CEコントローラを認証済みPS4コントローラとして動作させることができます。',

--- a/www/src/Locales/pt-BR/SettingsPage.jsx
+++ b/www/src/Locales/pt-BR/SettingsPage.jsx
@@ -30,7 +30,7 @@ export default {
 		'first-win': 'Primeira Vitória',
 		off: 'Desativado',
 	},
-	'profile-number-label': 'Número de Perfil',
+	'profile-label': 'Perfil',
 	'hotkey-settings-label': 'Configurações de Teclas de Atalho',
 	'hotkey-settings-sub-header':
 		'O controle deslizante <strong>Fn</strong> fornece um botão de função mapeável na página de <link_pinmap>Mapeamento de Pinos</link_pinmap>. Ao selecionar a opção de controle deslizante <strong>Fn</strong>, o botão de função deve ser mantido junto com as configurações de teclas de atalho selecionadas.<br />Além disso, selecione <strong>Nenhum</strong> no menu suspenso para desatribuir qualquer botão.',

--- a/www/src/Locales/zh-CN/SettingsPage.jsx
+++ b/www/src/Locales/zh-CN/SettingsPage.jsx
@@ -55,7 +55,6 @@ export default {
 		'first-win': '先输入优先',
 		off: '关闭',
 	},
-	'profile-number-label': '档案编号',
 	'debounce-delay-label': '去抖动延迟 (以毫秒为单位)',
 	'ps4-mode-explanation-text':
 		'PS4 模式允许 GP2040-CE 作为经过认证的 PS4 控制器运行。',

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -6,9 +6,11 @@ import * as yup from 'yup';
 import { Trans, useTranslation } from 'react-i18next';
 import JSEncrypt from 'jsencrypt';
 import isNil from 'lodash/isNil';
-import ContextualHelpOverlay from '../Components/ContextualHelpOverlay';
 
+import useProfilesStore from '../Store/useProfilesStore';
 import { AppContext } from '../Contexts/AppContext';
+
+import ContextualHelpOverlay from '../Components/ContextualHelpOverlay';
 import KeyboardMapper, { validateMappings } from '../Components/KeyboardMapper';
 import Section from '../Components/Section';
 import WebApi, { baseButtonMappings } from '../Services/WebApi';
@@ -120,7 +122,8 @@ const SHA256 = (ascii) => {
 };
 
 const INPUT_MODES = [
-	{ labelKey: 'input-mode-options.xinput',
+	{
+		labelKey: 'input-mode-options.xinput',
 		value: 0,
 		group: 'primary',
 		optional: ['usb'],
@@ -476,11 +479,17 @@ export default function SettingsPage() {
 		buttonLabels,
 		setButtonLabels,
 		getAvailablePeripherals,
-		getSelectedPeripheral,
-		getAvailableAddons,
 		updateAddons,
 		updatePeripherals,
 	} = useContext(AppContext);
+
+	const fetchProfiles = useProfilesStore((state) => state.fetchProfiles);
+	const profiles = useProfilesStore((state) => state.profiles);
+
+	useEffect(() => {
+		fetchProfiles();
+	}, []);
+
 	const [saveMessage, setSaveMessage] = useState('');
 	const [warning, setWarning] = useState({ show: false, acceptText: '' });
 	const [validated, setValidated] = useState(false);
@@ -1312,7 +1321,7 @@ export default function SettingsPage() {
 													</Form.Group>
 													<Form.Group className="row mb-3">
 														<Form.Label>
-															{t('SettingsPage:profile-number-label')}
+															{t('SettingsPage:profile-label')}
 														</Form.Label>
 														<Col sm={3}>
 															<Form.Select
@@ -1322,12 +1331,17 @@ export default function SettingsPage() {
 																onChange={handleChange}
 																isInvalid={errors.profileNumber}
 															>
-																{[1, 2, 3, 4].map((i) => (
+																{profiles.map((profile, index) => (
 																	<option
-																		key={`button-profileNumber-option-${i}`}
-																		value={i}
+																		key={`button-profileNumber-option-${
+																			index + 1
+																		}`}
+																		value={index + 1}
 																	>
-																		{i}
+																		{profile.profileLabel ||
+																			t('PinMapping:profile-label-default', {
+																				profileNumber: index + 1,
+																			})}
 																	</option>
 																))}
 															</Form.Select>


### PR DESCRIPTION
This fixes a bug that allows a users to select a non-existing profile, leaving the controller in a state with no pin config.
<img width="539" alt="Screenshot 2024-09-28 at 12 58 33" src="https://github.com/user-attachments/assets/25a47e17-d47a-44d0-84e8-7ddf7e22bf1b">
