### PR TITLE
Generate compile commands file used by IDE's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 include(CMakePrintHelpers)
 
-
-
+# enable compile commands for use by IDE autocompletion
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # initialize the SDK based on PICO_SDK_PATH
 # note: this must happen before project()


### PR DESCRIPTION
This enables generation of a `compile_commands.json` file during the build, which many IDE's and LSP servers can automatically detect and use to provide better jump-to-source, code completion, et cetera.