### PR TITLE
only load a profile if profileNum exists and is enabled

### DIFF
--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -162,8 +162,12 @@ char* Storage::currentProfileLabel() {
 void Storage::setFunctionalPinMappings()
 {
 	GpioMappingInfo* alts = nullptr;
-	if (config.gamepadOptions.profileNumber >= 2 && config.gamepadOptions.profileNumber <= 4)
-		alts = this->config.profileOptions.gpioMappingsSets[config.gamepadOptions.profileNumber-2].pins;
+	if (config.gamepadOptions.profileNumber >= 2 &&
+			config.gamepadOptions.profileNumber <= config.profileOptions.gpioMappingsSets_count + 1) {
+		if (config.profileOptions.gpioMappingsSets[config.gamepadOptions.profileNumber-2].enabled) {
+			alts = config.profileOptions.gpioMappingsSets[config.gamepadOptions.profileNumber-2].pins;
+		}
+	}
 
 	for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++) {
 		// assign the functional pin to the profile pin if:


### PR DESCRIPTION
This handles both the gamepad profile number being a number that doesn't exist (even though that shouldn't be possible via webconfig), or if the profile is disabled (which could happen if the user picks profile N and then disables it afterwards). In both cases, this doesn't load the `alts` pins, so the functional pins come from profile 1.