### PR TITLE
PS Feature reports causing unexpected behavior on startup

### DIFF
--- a/src/drivers/ps4/PS4Driver.cpp
+++ b/src/drivers/ps4/PS4Driver.cpp
@@ -66,6 +66,8 @@ void PS4Driver::initialize() {
     uint8_t descSize = sizeof(ps4_device_descriptor);
     memcpy(deviceDescriptor, &ps4_device_descriptor, descSize);
 
+    memset(&ps4Features, 0, sizeof(ps4Features));
+
     bool isDeviceEmulated = options.ps4ControllerIDMode == PS4ControllerIDMode::PS4_ID_EMULATION;
 
     if (!isDeviceEmulated) {


### PR DESCRIPTION
This should address the issue where the PS features were unexpectedly enabling the lightbar on startup, as well as a number of other incorrect values in the feature report.