### PR TITLE
Properly clean up JS mappings when switching profiles

### DIFF
--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -177,6 +177,9 @@ void Gamepad::reinit()
 	delete mapButtonE11;
 	delete mapButtonE12;
 	delete mapButtonFn;
+	delete mapButtonDP;
+	delete mapButtonLS;
+	delete mapButtonRS;
 
 	// reinitialize pin mappings
 	this->setup();


### PR DESCRIPTION
I missed the cleanup of the new LS/DP/RS mappings in gamepad.cpp. Switching a profile would leak this memory.