### PR TITLE
INIT Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## <Issue-Link>: <A brief summary of this merge request>
+
+### PROBLEM
+<!---
+Outline the problem being solved by this code change.
+-->
+
+### SOLUTION
+<!---
+Outline how this Pull Request addresses the problem.
+-->
+
+### NOTES
+
+<!---
+Any and all notes to help the reviewer when processing the merge request.
+Comments and links to issues, linked discussions, screenshots, decisions that need clarification, assumptions that were made, testing, ...
+
+An example for adding a link represented by a label:
+[link label](http://www.link.com)
+
+Screen shots can be copied-and-pasted directly into this textbox.
+
+See resources for GitHub PR template best practices, and linking GitHub Issues
+- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
+- https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls
+
+GP2040-CE Resources:
+- https://github.com/OpenStickCommunity/GP2040-CE
+  - https://github.com/OpenStickCommunity/GP2040-CE/issues
+-->


### PR DESCRIPTION
## NO-ISSUE: Init Pull Request Template

### PROBLEM
Pull Requests descriptions are variable and inconsistent, depending on the contributor.

### SOLUTION
Init a GitHub PR template to help promote consistency and make it easier for both contributors and reviewers to understand intent.

Similar to Issues templates, Pull Request templates can be helpful to make PR contributions more clear and capture context. See tagged links for more information with how these integrate with GitHub

Feel free to propose adjustments this template's content

### NOTES

<!---
Any and all notes to help the reviewer when processing the merge request.
Comments and links to issues, linked discussions, screenshots, decisions that need clarification, assumptions that were made, testing, ...

An example for adding a link represented by a label:
[link label](http://www.link.com)

Screen shots can be copied-and-pasted directly into this textbox.

See resources for GitHub PR template best practices, and linking GitHub Issues
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
- https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls

GP2040-CE Resources:
- https://github.com/OpenStickCommunity/GP2040-CE
  - https://github.com/OpenStickCommunity/GP2040-CE/issues
-->
This is purely a suggestion, no pressure to adopt this. I find it to be very valuable when there are a large number of different contributors.

Here's how this would look:

<img width="862" alt="image" src="https://github.com/user-attachments/assets/7a15046f-4935-4945-a613-a28d49ed148a">
<img width="855" alt="image" src="https://github.com/user-attachments/assets/2b0b2e23-d47c-45b0-9c63-9f76b6e0466c">

