### PR TITLE
Fix bare URLs in Markdown files to ensure they are displayed properly

### DIFF
--- a/configs/MiSTercadeV2/README.md
+++ b/configs/MiSTercadeV2/README.md
@@ -13,9 +13,9 @@ Features
 * Supports MiSTercade Remote and MiSTercade Versus accessories
 
 
-Purchase: https://misteraddons.com/products/mistercade-v2-kit-mister-fpga-jamma-arcade-kit
+Purchase: <https://misteraddons.com/products/mistercade-v2-kit-mister-fpga-jamma-arcade-kit>
 
-GitHub: https://github.com/misteraddons/MiSTercade-Config
+GitHub: <https://github.com/misteraddons/MiSTercade-Config>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/PXPGamepad/README.md
+++ b/configs/PXPGamepad/README.md
@@ -1,6 +1,6 @@
 # GP2040 Configuration for the PXP-Gamepad
 
-https://github.com/MegaBitmap/PXP-Gamepad
+<https://github.com/MegaBitmap/PXP-Gamepad>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/RanaTadpole/README.md
+++ b/configs/RanaTadpole/README.md
@@ -8,7 +8,7 @@ Basic button setup for the Rana Tadpole.
 ![Buttons](assets/RanaTadpole_buttons.png)
 
 GitHub repo for the Tadpole:
-https://github.com/rana-sylvatica/rana-tadpole
+<https://github.com/rana-sylvatica/rana-tadpole>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/ReflexCtrlGenesis6/README.md
+++ b/configs/ReflexCtrlGenesis6/README.md
@@ -7,9 +7,9 @@ Open source replacement PCB for Sega Genesis controllers
 * Japanese 6 button controller
 * Retro-Bit Saturn controller
 
-Purchase: https://misteraddons.com/products/Reflex-CTRL
+Purchase: <https://misteraddons.com/products/Reflex-CTRL>
 
-GitHub: https://github.com/misteraddons/Reflex-CTRL
+GitHub: <https://github.com/misteraddons/Reflex-CTRL>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/ReflexCtrlNES/README.md
+++ b/configs/ReflexCtrlNES/README.md
@@ -4,9 +4,9 @@
 
 Open source replacement PCB for Nintendo NES-004 controllers
 
-Purchase: https://misteraddons.com/products/Reflex-CTRL
+Purchase: <https://misteraddons.com/products/Reflex-CTRL>
 
-GitHub: https://github.com/misteraddons/Reflex-CTRL
+GitHub: <https://github.com/misteraddons/Reflex-CTRL>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/ReflexCtrlSNES/README.md
+++ b/configs/ReflexCtrlSNES/README.md
@@ -4,9 +4,9 @@
 
 Open source replacement PCB for Nintendo SNES-001 controllers
 
-Purchase: https://misteraddons.com/products/Reflex-CTRL
+Purchase: <https://misteraddons.com/products/Reflex-CTRL>
 
-GitHub: https://github.com/misteraddons/Reflex-CTRL
+GitHub: <https://github.com/misteraddons/Reflex-CTRL>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/ReflexCtrlSaturn/README.md
+++ b/configs/ReflexCtrlSaturn/README.md
@@ -7,9 +7,9 @@ Open source replacement PCB for Sega Saturn controllers
 * Japanese controller
 * Retro-Bit Saturn controller
 
-Purchase: https://misteraddons.com/products/Reflex-CTRL
+Purchase: <https://misteraddons.com/products/Reflex-CTRL>
 
-GitHub: https://github.com/misteraddons/Reflex-CTRL
+GitHub: <https://github.com/misteraddons/Reflex-CTRL>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/ReflexCtrlVB/README.md
+++ b/configs/ReflexCtrlVB/README.md
@@ -6,9 +6,9 @@ Open source replacement PCB for Nintendo Virtual Boy controllers
 
 Note: Do not connect any packs to the controller. The USB cable powers the controller.
 
-Purchase: https://misteraddons.com/products/Reflex-CTRL
+Purchase: <https://misteraddons.com/products/Reflex-CTRL>
 
-GitHub: https://github.com/misteraddons/Reflex-CTRL
+GitHub: <https://github.com/misteraddons/Reflex-CTRL>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/ReflexEncodeV1.2/README.md
+++ b/configs/ReflexEncodeV1.2/README.md
@@ -6,10 +6,10 @@
 Reflex Board v1.2
 Open source PCB for arcade sticks using Raspberry Pi Pico's RP2040 microcontroller.
 
-GitHub: https://github.com/misteraddons/ReflexFightingBoard/tree/main/boards/Reflex_Encode-V1.2-GP2040-CE
-Purchase from: https://misteraddons.com/collections/parts/products/reflex-encode-fighting-board
+GitHub: <https://github.com/misteraddons/ReflexFightingBoard/tree/main/boards/Reflex_Encode-V1.2-GP2040-CE>
+Purchase from: <https://misteraddons.com/collections/parts/products/reflex-encode-fighting-board>
 
-MiSTer addons: https://misteraddons.com/
+MiSTer addons: <https://misteraddons.com/>
 
 ## Main Pin Mapping Configuration
 

--- a/configs/ReflexEncodeV2.0/README.md
+++ b/configs/ReflexEncodeV2.0/README.md
@@ -8,10 +8,10 @@ Open source PCB for arcade sticks using Raspberry Pi Pico's RP2040 microcontroll
 
 v2.0 adds USB passthrough authentication via GPIO14 (D+) and DPIO15 (D-).
 
-GitHub: https://github.com/misteraddons/ReflexFightingBoard/tree/main/boards/Reflex_Encode-V2.0-GP2040-CE-USB_Pass_Auth
-Purchase from: https://misteraddons.com/collections/parts/products/reflex-encode-fighting-board
+GitHub: <https://github.com/misteraddons/ReflexFightingBoard/tree/main/boards/Reflex_Encode-V2.0-GP2040-CE-USB_Pass_Auth>
+Purchase from: <https://misteraddons.com/collections/parts/products/reflex-encode-fighting-board>
 
-MiSTer addons: https://misteraddons.com/
+MiSTer addons: <https://misteraddons.com/>
 
 ## Main Pin Mapping Configuration
 

--- a/www/README.md
+++ b/www/README.md
@@ -12,7 +12,7 @@ Simple web application for gamepad configuration.
 
 Run `npm run dev`. This will start up the React app and an Express instance for mock data during development, allowing testing of the configurator without loading it onto the MCU, which is a SLOW process.
 
-The mock data Express server is running at http://localhost:8080.
+The mock data Express server is running at <http://localhost:8080>.
 
 ### Connected board
 


### PR DESCRIPTION
Wrap bare URLs with angle brackets in Markdown files.

Rationale: Without angle brackets, a bare URL or email isn't converted into a link by some Markdown parsers.

https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md034---bare-url-used