### PR TITLE
Move SOCD settings to profiles

### DIFF
--- a/www/server/app.js
+++ b/www/server/app.js
@@ -19,7 +19,11 @@ const { pico: picoController } = JSON.parse(
 
 // Structure pin mappings to include masks and profile label
 const createPinMappings = ({ profileLabel = 'Profile' }) => {
-	let pinMappings = { profileLabel, enabled: true };
+	let pinMappings = {
+		profileLabel,
+		enabled: true,
+		socdMode: 1, // SOCD Neutral,
+	};
 
 	for (const [key, value] of Object.entries(picoController)) {
 		pinMappings[key] = {
@@ -95,7 +99,6 @@ app.get('/api/getGamepadOptions', (req, res) => {
 	return res.send({
 		dpadMode: 0,
 		inputMode: 4,
-		socdMode: 2,
 		switchTpShareForDs4: 0,
 		forcedSetupMode: 0,
 		lockHotkeys: 0,

--- a/www/src/Locales/en/PinMapping.jsx
+++ b/www/src/Locales/en/PinMapping.jsx
@@ -18,6 +18,16 @@ export default {
 	'profile-pins-warning':
 		'Try to avoid changing the buttons and/or directions used for the switch profile hotkeys. Otherwise, it will be difficult to understand what profile is being selected!',
 	'profile-copy-base': 'Copy base profile',
+	'socd-mode-label': 'SOCD Cleaning Mode',
+	'socd-mode-description':
+		'PS4, PS3, Nintendo Switch, and mini series modes do not support setting SOCD Cleaning to Off and will default to Neutral SOCD Cleaning mode.',
+	'socd-modes': {
+		SOCD_MODE_UP_PRIORITY: 'Up Priority',
+		SOCD_MODE_NEUTRAL: 'Neutral',
+		SOCD_MODE_SECOND_INPUT_PRIORITY: 'Last Win',
+		SOCD_MODE_FIRST_INPUT_PRIORITY: 'First Win',
+		SOCD_MODE_BYPASS: 'Off',
+	},
 	errors: {
 		conflict: 'Pin {{pin}} is already assigned to {{conflictedMappings}}',
 		required: '{{button}} is required',

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -45,16 +45,6 @@ export default {
 		'left-analog': 'Left Analog',
 		'right-analog': 'Right Analog',
 	},
-	'socd-cleaning-mode-label': 'SOCD Cleaning Mode',
-	'socd-cleaning-mode-note':
-		'Note: PS4, PS3, Nintendo Switch, and mini series modes do not support setting SOCD Cleaning to Off and will default to Neutral SOCD Cleaning mode.',
-	'socd-cleaning-mode-options': {
-		'up-priority': 'Up Priority',
-		neutral: 'Neutral',
-		'last-win': 'Last Win',
-		'first-win': 'First Win',
-		off: 'Off',
-	},
 	'profile-label': 'Profile',
 	'debounce-delay-label': 'Debounce Delay in milliseconds',
 	'ps4-mode-explanation-text':

--- a/www/src/Locales/ja-JP/PinMapping.jsx
+++ b/www/src/Locales/ja-JP/PinMapping.jsx
@@ -18,6 +18,18 @@ export default {
 	'profile-pins-warning':
 		'プロファイルの変更ホットキーに設定しているボタンや方向キーの設定変更は、現在のプロファイル選択状況がわからなくなる原因となるため非推奨です。',
 	'profile-copy-base': 'Baseプロファイルをコピー',
+
+	'socd-mode-label': 'SOCDクリーニングモード',
+	'socd-mode-description':
+		'注：PS4、PS3、任天堂SwitchおよびミニコンソールシリーズのモードではSOCDクリーニングモード無効設定はできないため、ニュートラルSOCDクリーニングに設定されます。',
+	'socd-modes': {
+		SOCD_MODE_UP_PRIORITY: '上優先',
+		SOCD_MODE_NEUTRAL: 'ニュートラル',
+		SOCD_MODE_SECOND_INPUT_PRIORITY: '後入力優先',
+		SOCD_MODE_FIRST_INPUT_PRIORITY: '先入力優先',
+		SOCD_MODE_BYPASS: '無効',
+	},
+
 	errors: {
 		conflict: '{{pin}} 番端子は既に{{conflictedMappings}}に割り当て済みです',
 		required: '{{button}}の設定は必須です',

--- a/www/src/Locales/ja-JP/SettingsPage.jsx
+++ b/www/src/Locales/ja-JP/SettingsPage.jsx
@@ -37,16 +37,6 @@ export default {
 		'left-analog': '左アナログ',
 		'right-analog': '右アナログ',
 	},
-	'socd-cleaning-mode-label': 'SOCDクリーニングモード',
-	'socd-cleaning-mode-note':
-		'注：PS4、PS3、任天堂SwitchおよびミニコンソールシリーズのモードではSOCDクリーニングモード無効設定はできないため、ニュートラルSOCDクリーニングに設定されます。',
-	'socd-cleaning-mode-options': {
-		'up-priority': '上優先',
-		neutral: 'ニュートラル',
-		'last-win': '後入力優先',
-		'first-win': '先入力優先',
-		off: '無効',
-	},
 	'profile-label': 'プロファイル',
 	'debounce-delay-label': 'チャタリング除去ディレイ(ミリ秒)',
 	'ps4-mode-explanation-text':

--- a/www/src/Locales/ko-KR/PinMapping.jsx
+++ b/www/src/Locales/ko-KR/PinMapping.jsx
@@ -1,6 +1,7 @@
 export default {
 	'header-text': '단자 할당 설정',
-	'sub-header-text': '여기에서는 어떤 핀에 어떤 기능을 할당할지 설정할 수 있습니다. 어떤 버튼이 어떤 핀에 할당되어 있는지 모르겠다면 핀 확인 기능을 사용해 보세요',
+	'sub-header-text':
+		'여기에서는 어떤 핀에 어떤 기능을 할당할지 설정할 수 있습니다. 어떤 버튼이 어떤 핀에 할당되어 있는지 모르겠다면 핀 확인 기능을 사용해 보세요',
 	'alert-text':
 		'연결되지 않거나 구현되지 않은 핀에 할당 설정을 하면 컨트롤러가 작동하지 않는 상태가 될 수 있습니다. 잘못된 설정을 초기화하고 싶다면 <2>설정 초기화</2> 페이지에서 초기화를 실행해 주세요.',
 	'pin-viewer': '단자 확인',
@@ -18,8 +19,19 @@ export default {
 	'profile-pins-warning':
 		'프로파일 변경 핫키로 설정된 버튼이나 방향키의 설정 변경은 현재 프로파일 선택상황을 햇갈리게 할 수 있으므로 권장하지 않습니다',
 	'profile-copy-base': 'Base 프로파일을 복사',
+	'socd-mode-label': 'SOCD 클리닝 모드',
+	'socd-mode-description':
+		'주의：PS4、PS3、닌텐도Switch 또는 미니 콘솔 시리즈 모드에서는 SOCD 클리닝 모드 끄기 설정이 불가능하므로, 중립 SOCD 클리닝으로 설정됩니다.',
+	'socd-modes': {
+		SOCD_MODE_UP_PRIORITY: '위 우선',
+		SOCD_MODE_NEUTRAL: '중립',
+		SOCD_MODE_SECOND_INPUT_PRIORITY: '후 입력 우선',
+		SOCD_MODE_FIRST_INPUT_PRIORITY: '선 입력 우선',
+		SOCD_MODE_BYPASS: '끄기',
+	},
 	errors: {
-		conflict: '{{pin}} 번 단자에 이미 {{conflictedMappings}}에 할당 되어 있습니다.',
+		conflict:
+			'{{pin}} 번 단자에 이미 {{conflictedMappings}}에 할당 되어 있습니다.',
 		required: '{{button}}의 설정은 필수 입니다.',
 		invalid: '{{pin}}번 단자는 이 보드에서는 사용 할 수 없습니다.',
 		used: '{{pin}}번 단자는 이미 다른기능에 할당 되어 있습니다.',

--- a/www/src/Locales/ko-KR/SettingsPage.jsx
+++ b/www/src/Locales/ko-KR/SettingsPage.jsx
@@ -37,16 +37,6 @@ export default {
 		'left-analog': '왼쪽 아날로그',
 		'right-analog': '오른쪽 아날로그',
 	},
-	'socd-cleaning-mode-label': 'SOCD 클리닝 모드',
-	'socd-cleaning-mode-note':
-		'주의：PS4、PS3、닌텐도Switch 또는 미니 콘솔 시리즈 모드에서는 SOCD 클리닝 모드 끄기 설정이 불가능하므로, 중립 SOCD 클리닝으로 설정됩니다.',
-	'socd-cleaning-mode-options': {
-		'up-priority': '위 우선',
-		neutral: '중립',
-		'last-win': '후 입력 우선',
-		'first-win': '선 입력 우선',
-		off: '끄기',
-	},
 	'profile-label': '프로파일',
 	'debounce-delay-label': '채터링 제거 딜레이(밀리 초)',
 	'ps4-mode-explanation-text':

--- a/www/src/Locales/pt-BR/PinMapping.jsx
+++ b/www/src/Locales/pt-BR/PinMapping.jsx
@@ -7,6 +7,16 @@ export default {
 	'pin-header-label': 'Pino',
 	'profile-pins-warning':
 		'Tente evitar alterar os botões/direções usados para seus atalhos de perfil de troca, caso contrário, ficará difícil entender qual perfil você está selecionando!',
+	'socd-mode-label': 'Modo de Limpeza SOCD',
+	'socd-mode-description':
+		'Observação: Os modos PS4, PS3 e Nintendo Switch não suportam a configuração SOCD Cleaning como Desativado e padrão para o modo de Limpeza SOCD Neutra.',
+	'socd-modes': {
+		SOCD_MODE_UP_PRIORITY: 'Prioridade para Cima',
+		SOCD_MODE_NEUTRAL: 'Neutra',
+		SOCD_MODE_SECOND_INPUT_PRIORITY: 'Última Vitória',
+		SOCD_MODE_FIRST_INPUT_PRIORITY: 'Primeira Vitória',
+		SOCD_MODE_BYPASS: 'Desativado',
+	},
 	errors: {
 		conflict: 'O Pino {{pin}} já está atribuído a {{conflictedMappings}}',
 		required: '{{button}} é obrigatório',

--- a/www/src/Locales/pt-BR/SettingsPage.jsx
+++ b/www/src/Locales/pt-BR/SettingsPage.jsx
@@ -20,16 +20,6 @@ export default {
 		'left-analog': 'Analógico Esquerdo',
 		'right-analog': 'Analógico Direito',
 	},
-	'socd-cleaning-mode-label': 'Modo de Limpeza SOCD',
-	'socd-cleaning-mode-note':
-		'Observação: Os modos PS4, PS3 e Nintendo Switch não suportam a configuração SOCD Cleaning como Desativado e padrão para o modo de Limpeza SOCD Neutra.',
-	'socd-cleaning-mode-options': {
-		'up-priority': 'Prioridade para Cima',
-		neutral: 'Neutra',
-		'last-win': 'Última Vitória',
-		'first-win': 'Primeira Vitória',
-		off: 'Desativado',
-	},
 	'profile-label': 'Perfil',
 	'hotkey-settings-label': 'Configurações de Teclas de Atalho',
 	'hotkey-settings-sub-header':

--- a/www/src/Locales/zh-CN/PinMapping.jsx
+++ b/www/src/Locales/zh-CN/PinMapping.jsx
@@ -1,24 +1,31 @@
 export default {
 	'header-text': '引脚映射',
-	'sub-header-text':
-		'使用引脚查看器来查看按键到引脚的连接。',
+	'sub-header-text': '使用引脚查看器来查看按键到引脚的连接。',
 	'alert-text':
 		'将按键映射到未连接或不可用的引脚可能会导致设备无法正常工作。要清除无效配置，请转到 <2>恢复默认设置</2> 页面。',
 	'pin-viewer': '引脚查看器',
 	'pin-pressed': '按下的引脚：{{pressedPin}}',
 	'pin-header-label': '引脚',
 	'profile-label-title': '档案名称',
-	'profile-label-description':
-		'最多16个字符。允许使用字母、数字和空格。',
+	'profile-label-description': '最多16个字符。允许使用字母、数字和空格。',
 	'profile-pin-mapping-title': '{{profileLabel}} - 引脚映射',
 	'profile-label-default': 'Profile {{profileNumber}}',
 	'profile-add-button': '+ 新增档案',
 	'profile-disabled': ' - (禁用)',
-	'profile-enabled-tooltip':
-		'禁用的档案在使用快捷键切换档案时将不可用。',
+	'profile-enabled-tooltip': '禁用的档案在使用快捷键切换档案时将不可用。',
 	'profile-pins-warning':
 		'尽量避免修改已设置为切换档案快捷键的按键或方向键，否则之后将很难理解你选择的档案配置！',
 	'profile-copy-base': '复制基础档案',
+	'socd-mode-label': 'SOCD 覆盖模式',
+	'socd-mode-description':
+		'注意：PS4、PS3、Nintendo Switch以及迷你系列模式不支持将 SOCD 覆盖模式设置为关闭，默认设置为回中模式。',
+	'socd-modes': {
+		SOCD_MODE_UP_PRIORITY: '上优先',
+		SOCD_MODE_NEUTRAL: '回中',
+		SOCD_MODE_SECOND_INPUT_PRIORITY: '后输入优先',
+		SOCD_MODE_FIRST_INPUT_PRIORITY: '先输入优先',
+		SOCD_MODE_BYPASS: '关闭',
+	},
 	errors: {
 		conflict: '引脚 {{pin}} 已分配给 {{conflictedMappings}}',
 		required: '{{button}} 是必需的',

--- a/www/src/Locales/zh-CN/SettingsPage.jsx
+++ b/www/src/Locales/zh-CN/SettingsPage.jsx
@@ -45,16 +45,6 @@ export default {
 		'left-analog': '左模拟摇杆',
 		'right-analog': '右模拟摇杆',
 	},
-	'socd-cleaning-mode-label': 'SOCD 覆盖模式',
-	'socd-cleaning-mode-note':
-		'注意：PS4、PS3、Nintendo Switch以及迷你系列模式不支持将 SOCD 覆盖模式设置为关闭，默认设置为回中模式。',
-	'socd-cleaning-mode-options': {
-		'up-priority': '上优先',
-		neutral: '回中',
-		'last-win': '后输入优先',
-		'first-win': '先输入优先',
-		off: '关闭',
-	},
 	'profile-label': '档案',
 	'debounce-delay-label': '去抖动延迟 (以毫秒为单位)',
 	'ps4-mode-explanation-text':

--- a/www/src/Pages/InputMacroAddonPage.tsx
+++ b/www/src/Pages/InputMacroAddonPage.tsx
@@ -107,16 +107,13 @@ const ButtonMasksComponent = (props) => {
 		onChange,
 		error,
 		isInvalid,
-		className,
 		buttonLabelType,
 		buttonMasks,
 	} = props;
 	return (
-		// <div key={key} className={className}>
 		<Form.Select
 			size="sm"
 			name={`${key}.buttonMask`}
-			// className="form-control"
 			value={value}
 			error={error}
 			isInvalid={isInvalid}
@@ -128,7 +125,6 @@ const ButtonMasksComponent = (props) => {
 				</option>
 			))}
 		</Form.Select>
-		// </div>
 	);
 };
 
@@ -200,7 +196,6 @@ const MacroInputComponent = (props) => {
 			<Col xs="auto">
 				<ButtonMasksComponent
 					id={`${key}.buttonMaskPlaceholder`}
-					className="col-sm-auto"
 					value={0}
 					onChange={(e) => {
 						setFieldValue(`${key}.buttonMask`, buttonMask | e.target.value);
@@ -397,7 +392,6 @@ const MacroComponent = (props) => {
 						</Col>
 						<Col sm={'auto'}>
 							<ButtonMasksComponent
-								className="col-sm-auto"
 								value={macroTriggerButton}
 								onChange={(e) => {
 									setFieldValue(

--- a/www/src/Pages/PinMapping.tsx
+++ b/www/src/Pages/PinMapping.tsx
@@ -24,7 +24,11 @@ import invert from 'lodash/invert';
 import omit from 'lodash/omit';
 
 import { AppContext } from '../Contexts/AppContext';
-import useProfilesStore, { MAX_PROFILES } from '../Store/useProfilesStore';
+import useProfilesStore, {
+	MAX_PROFILES,
+	SOCD_MODE_VALUES,
+	SOCD_MODES,
+} from '../Store/useProfilesStore';
 
 import Section from '../Components/Section';
 import CustomSelect from '../Components/CustomSelect';
@@ -130,7 +134,7 @@ const ProfileLabel = memo(function ProfileLabel({
 	);
 
 	return (
-		<div className="pin-grid">
+		<div>
 			<Form.Label>{t('PinMapping:profile-label-title')}</Form.Label>
 			<Form.Control
 				type="text"
@@ -156,7 +160,11 @@ const PinSelectList = memo(function PinSelectList({
 
 	const pins = useProfilesStore(
 		useShallow((state) =>
-			omit(state.profiles[profileIndex], ['profileLabel', 'enabled']),
+			omit(state.profiles[profileIndex], [
+				'profileLabel',
+				'enabled',
+				'socdMode',
+			]),
 		),
 	);
 	const { t } = useTranslation('');
@@ -256,6 +264,7 @@ const PinSection = memo(function PinSection({
 	const { t } = useTranslation('');
 	const copyBaseProfile = useProfilesStore((state) => state.copyBaseProfile);
 	const setProfilePin = useProfilesStore((state) => state.setProfilePin);
+	const setSocdMode = useProfilesStore((state) => state.setSocdMode);
 	const saveProfiles = useProfilesStore((state) => state.saveProfiles);
 	const toggleProfileEnabled = useProfilesStore(
 		(state) => state.toggleProfileEnabled,
@@ -268,6 +277,9 @@ const PinSection = memo(function PinSection({
 		t('PinMapping:profile-label-default', {
 			profileNumber: profileIndex + 1,
 		});
+	const socdMode = useProfilesStore(
+		(state) => state.profiles[profileIndex].socdMode,
+	);
 
 	const { updateUsedPins, buttonLabels } = useContext(AppContext);
 	const { buttonLabelType, swapTpShareLabels } = buttonLabels;
@@ -307,36 +319,62 @@ const PinSection = memo(function PinSection({
 				})}
 			>
 				<Form onSubmit={handleSubmit}>
-					<div className="d-flex justify-content-between">
-						<ProfileLabel profileIndex={profileIndex} />
-						{profileIndex > 0 && (
-							<div className="d-flex">
-								<FormCheck
-									size={3}
-									label={
-										<OverlayTrigger
-											overlay={
-												<Tooltip>
-													{t('PinMapping:profile-enabled-tooltip')}
-												</Tooltip>
-											}
-										>
-											<div className="d-flex gap-1">
-												<label>{t('Common:switch-enabled')} </label>
-												<InfoCircle />
-											</div>
-										</OverlayTrigger>
+					{profileIndex > 0 && (
+						<div className="d-flex justify-content-end">
+							<FormCheck
+								size={3}
+								label={
+									<OverlayTrigger
+										overlay={
+											<Tooltip>
+												{t('PinMapping:profile-enabled-tooltip')}
+											</Tooltip>
+										}
+									>
+										<div className="d-flex gap-1">
+											<label>{t('Common:switch-enabled')} </label>
+											<InfoCircle />
+										</div>
+									</OverlayTrigger>
+								}
+								type="switch"
+								reverse
+								checked={enabled}
+								onChange={() => {
+									toggleProfileEnabled(profileIndex);
+								}}
+							/>
+						</div>
+					)}
+					<div className="row gap-2 gap-md-0">
+						<div className="col-md">
+							<ProfileLabel profileIndex={profileIndex} />
+						</div>
+						<div className="col-md">
+							<Form.Group>
+								<Form.Label>{t('PinMapping:socd-mode-label')}</Form.Label>
+								<Form.Select
+									value={socdMode}
+									onChange={(e) =>
+										setSocdMode(
+											profileIndex,
+											parseInt(e.target.value) as SOCD_MODE_VALUES,
+										)
 									}
-									type="switch"
-									reverse
-									checked={enabled}
-									onChange={() => {
-										toggleProfileEnabled(profileIndex);
-									}}
-								/>
-							</div>
-						)}
+								>
+									{Object.entries(SOCD_MODES).map(([key, value]) => (
+										<option key={`button-socdMode-option-${key}`} value={value}>
+											{t(`PinMapping:socd-modes.${key}`)}
+										</option>
+									))}
+								</Form.Select>
+								<Form.Text muted>
+									{t('PinMapping:socd-mode-description')}
+								</Form.Text>
+							</Form.Group>
+						</div>
 					</div>
+
 					<hr />
 					<div className="pin-grid gap-3 mt-3">
 						<PinSelectList profileIndex={profileIndex} />

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -215,14 +215,6 @@ const DPAD_MODES = [
 	{ labelKey: 'd-pad-mode-options.right-analog', value: 2 },
 ];
 
-const SOCD_MODES = [
-	{ labelKey: 'socd-cleaning-mode-options.up-priority', value: 0 },
-	{ labelKey: 'socd-cleaning-mode-options.neutral', value: 1 },
-	{ labelKey: 'socd-cleaning-mode-options.last-win', value: 2 },
-	{ labelKey: 'socd-cleaning-mode-options.first-win', value: 3 },
-	{ labelKey: 'socd-cleaning-mode-options.off', value: 4 },
-];
-
 const PS4_MODES = [
 	{ labelKey: 'ps4-mode-options.controller', value: 0 },
 	{ labelKey: 'ps4-mode-options.arcadestick', value: 7 },
@@ -338,11 +330,6 @@ const schema = yup.object().shape({
 		.required()
 		.oneOf(INPUT_MODES.map((o) => o.value))
 		.label('Input Mode'),
-	socdMode: yup
-		.number()
-		.required()
-		.oneOf(SOCD_MODES.map((o) => o.value))
-		.label('SOCD Cleaning Mode'),
 	switchTpShareForDs4: yup
 		.number()
 		.required()
@@ -438,7 +425,6 @@ const FormContext = ({ setButtonLabels, setKeyMappings }) => {
 	useEffect(() => {
 		if (!!values.dpadMode) values.dpadMode = parseInt(values.dpadMode);
 		if (!!values.inputMode) values.inputMode = parseInt(values.inputMode);
-		if (!!values.socdMode) values.socdMode = parseInt(values.socdMode);
 		if (!!values.switchTpShareForDs4)
 			values.switchTpShareForDs4 = parseInt(values.switchTpShareForDs4);
 		if (!!values.forcedSetupMode)
@@ -1110,7 +1096,6 @@ export default function SettingsPage() {
 	const translatedInputModes = translateArray(checkRequiredArray(INPUT_MODES));
 	const translatedInputModeGroups = translateArray(INPUT_MODE_GROUPS);
 	const translatedDpadModes = translateArray(DPAD_MODES);
-	const translatedSocdModes = translateArray(SOCD_MODES);
 	const translatedHotkeyActions = translateArray(HOTKEY_ACTIONS);
 	const translatedForcedSetupModes = translateArray(FORCED_SETUP_MODES);
 	// Not currently used but we might add the option at a later date (wheel type, etc.)
@@ -1255,33 +1240,6 @@ export default function SettingsPage() {
 															/>
 														</Col>
 													</Form.Group>
-													<Form.Group className="row mb-3">
-														<Form.Label>
-															{t('SettingsPage:socd-cleaning-mode-label')}
-														</Form.Label>
-														<Col sm={3}>
-															<Form.Select
-																name="socdMode"
-																className="form-select-sm"
-																value={values.socdMode}
-																onChange={handleChange}
-																isInvalid={errors.socdMode}
-															>
-																{translatedSocdModes.map((o, i) => (
-																	<option
-																		key={`button-socdMode-option-${i}`}
-																		value={o.value}
-																	>
-																		{o.label}
-																	</option>
-																))}
-															</Form.Select>
-															<Form.Control.Feedback type="invalid">
-																{errors.socdMode}
-															</Form.Control.Feedback>
-														</Col>
-													</Form.Group>
-													<p>{t('SettingsPage:socd-cleaning-mode-note')}</p>
 													<Form.Group className="row mb-3">
 														<Form.Label>
 															{t('SettingsPage:forced-setup-mode-label')}

--- a/www/src/Store/useProfilesStore.ts
+++ b/www/src/Store/useProfilesStore.ts
@@ -5,6 +5,16 @@ import { PinActionValues } from '../Data/Pins';
 // Max number of profiles that can be created, including the base profile
 export const MAX_PROFILES = 4;
 
+export const SOCD_MODES = {
+	SOCD_MODE_UP_PRIORITY: 0, // U+D=U, L+R=N
+	SOCD_MODE_NEUTRAL: 1, // U+D=N, L+R=N
+	SOCD_MODE_SECOND_INPUT_PRIORITY: 2, // U>D=D, L>R=R (Last Input Priority, aka Last Win)
+	SOCD_MODE_FIRST_INPUT_PRIORITY: 3, // U>D=U, L>R=L (First Input Priority, aka First Win)
+	SOCD_MODE_BYPASS: 4, // U+D=UD, L+R=LR (No cleaning applied)
+} as const;
+
+export type SOCD_MODE_VALUES = (typeof SOCD_MODES)[keyof typeof SOCD_MODES];
+
 type CustomMasks = {
 	customButtonMask: number;
 	customDpadMask: number;
@@ -47,6 +57,7 @@ export type PinsType = {
 	pin29: MaskPayload;
 	profileLabel: string;
 	enabled: boolean;
+	socdMode: SOCD_MODE_VALUES;
 };
 
 type State = {
@@ -67,6 +78,7 @@ type Actions = {
 	saveProfiles: () => Promise<object>;
 	setProfileLabel: (profileIndex: number, profileLabel: string) => void;
 	setProfilePin: SetProfilePinType;
+	setSocdMode: (profileIndex: number, socdMode: SOCD_MODE_VALUES) => void;
 	toggleProfileEnabled: (profileIndex: number) => void;
 };
 
@@ -139,6 +151,12 @@ const useProfilesStore = create<State & Actions>()((set, get) => ({
 		set((state) => {
 			const profiles = [...state.profiles];
 			profiles[profileIndex] = { ...profiles[profileIndex], profileLabel };
+			return { profiles };
+		}),
+	setSocdMode: (profileIndex, socdMode) =>
+		set((state) => {
+			const profiles = [...state.profiles];
+			profiles[profileIndex] = { ...profiles[profileIndex], socdMode };
 			return { profiles };
 		}),
 	saveProfiles: async () => {


### PR DESCRIPTION
This PR only contains web ui changes, if someone wants to continue then this is a good start.

Adds `socdMode` to `setProfileOptions` and `setPinMappings`

<img width="1004" alt="Screenshot 2024-10-14 at 00 27 24" src="https://github.com/user-attachments/assets/96667334-7a43-4db1-996e-45cb77a8e3de">
