### PR TITLE
Added additional ways to get into BootSel mode

### DIFF
--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -372,9 +372,13 @@ GP2040::BootAction GP2040::getBootAction() {
 					return BootAction::ENTER_USB_MODE;
 				} else if (!webConfigLocked && gamepad->pressedS2()) {
 					return BootAction::ENTER_WEBCONFIG_MODE;
-				} else if (gamepad->pressedUp() && gamepad->pressedDown()) {
+				} else if (gamepad->pressedUp() && gamepad->pressedRight()) {
                     return BootAction::ENTER_USB_MODE;
-                } else if (gamepad->pressedLeft() && gamepad->pressedRight()) {
+                } else if (gamepad->pressedDown() && gamepad->pressedRight()) {
+                    return BootAction::ENTER_USB_MODE;
+				} else if (gamepad->pressedUp() && gamepad->pressedLeft()) {
+                    return BootAction::ENTER_USB_MODE;
+                } else if (gamepad->pressedDown() && gamepad->pressedLeft()) {
                     return BootAction::ENTER_USB_MODE;
                 } else {
                     if (!modeSwitchLocked) {

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -372,6 +372,10 @@ GP2040::BootAction GP2040::getBootAction() {
 					return BootAction::ENTER_USB_MODE;
 				} else if (!webConfigLocked && gamepad->pressedS2()) {
 					return BootAction::ENTER_WEBCONFIG_MODE;
+				} else if (gamepad->pressedUp() && gamepad->pressedDown()) {
+                    return BootAction::ENTER_USB_MODE;
+                } else if (gamepad->pressedLeft() && gamepad->pressedRight()) {
+                    return BootAction::ENTER_USB_MODE;
                 } else {
                     if (!modeSwitchLocked) {
                         if (auto search = bootActions.find(gamepad->state.buttons); search != bootActions.end()) {


### PR DESCRIPTION
This PR adds two additional ways to get into BootSel mode for instances where you may not have a mapped S2 button or access to a mapped S2 button for a web-config BootSel reboot.