### PR TITLE
Added support for the Ultimarc Ultrastik 360 to the gamepad plugin

### DIFF
--- a/headers/addons/gamepad_usb_host_listener.h
+++ b/headers/addons/gamepad_usb_host_listener.h
@@ -85,6 +85,33 @@ typedef struct TU_ATTR_PACKED
     uint8_t  VEN_GamePad0021[54];
 } dualshock4_t;
 
+// Ultrastik 360
+typedef struct TU_ATTR_PACKED
+{
+    uint8_t GD_GamePadPointerX;
+    uint8_t GD_GamePadPointerY;
+
+    struct {
+        uint8_t BTN_GamePadButton1 : 1;
+        uint8_t BTN_GamePadButton2 : 1;
+        uint8_t BTN_GamePadButton3 : 1;
+        uint8_t BTN_GamePadButton4 : 1;
+        uint8_t BTN_GamePadButton5 : 1;
+        uint8_t BTN_GamePadButton6 : 1;
+        uint8_t BTN_GamePadButton7 : 1;
+        uint8_t BTN_GamePadButton8 : 1;
+        uint8_t BTN_GamePadButton9 : 1;
+        uint8_t BTN_GamePadButton10 : 1;
+        uint8_t BTN_GamePadButton11 : 1;
+        uint8_t BTN_GamePadButton12 : 1;
+        uint8_t BTN_GamePadButton13 : 1;
+        uint8_t BTN_GamePadButton14 : 1;
+        uint8_t BTN_GamePadButton15 : 1;
+        uint8_t padding : 1;
+    };
+
+} ultrastik360_t;
+
 // Add other controller structs here
 class GamepadUSBHostListener : public USBListener {
     public:// USB Listener Features
@@ -105,6 +132,7 @@ class GamepadUSBHostListener : public USBListener {
         // Controller report processor functions
         void process_ds4(uint8_t const* report);
         void process_stadia(uint8_t const* report);
+        void process_ultrastik360(uint8_t const* report);
 
         uint16_t controller_pid, controller_vid;
 

--- a/src/addons/gamepad_usb_host_listener.cpp
+++ b/src/addons/gamepad_usb_host_listener.cpp
@@ -64,6 +64,11 @@ void GamepadUSBHostListener::process_ctrlr_report(uint8_t dev_addr, uint8_t cons
         case 0x9400:// Google Stadia controller
             process_stadia(report);
             break;
+
+        case 0x0510: // pre-2015 Ultrakstik 360
+        case 0x0511: // Ultrakstik 360
+            process_ultrastik360(report);
+            break;
         default:
             break;
     }
@@ -180,4 +185,23 @@ void GamepadUSBHostListener::process_stadia(uint8_t const* report) {
     if (controller_report.GD_GamePadHatSwitch == 5) _controller_host_state.dpad |= GAMEPAD_MASK_DOWN | GAMEPAD_MASK_LEFT;
     if (controller_report.GD_GamePadHatSwitch == 6) _controller_host_state.dpad |= GAMEPAD_MASK_LEFT;
     if (controller_report.GD_GamePadHatSwitch == 7) _controller_host_state.dpad |= GAMEPAD_MASK_LEFT | GAMEPAD_MASK_UP;
+}
+
+void GamepadUSBHostListener::process_ultrastik360(uint8_t const* report) {
+
+    ultrastik360_t controller_report;
+
+    memcpy(&controller_report, report, sizeof(controller_report));
+
+    _controller_host_state.lx = map(controller_report.GD_GamePadPointerX, 0, 255, GAMEPAD_JOYSTICK_MIN,GAMEPAD_JOYSTICK_MAX);
+    _controller_host_state.ly = map(controller_report.GD_GamePadPointerY, 0, 255, GAMEPAD_JOYSTICK_MIN,GAMEPAD_JOYSTICK_MAX);
+
+    if (controller_report.BTN_GamePadButton1 == 1) _controller_host_state.buttons |= GAMEPAD_MASK_B1;
+    if (controller_report.BTN_GamePadButton2 == 1) _controller_host_state.buttons |= GAMEPAD_MASK_B2;
+    if (controller_report.BTN_GamePadButton3 == 1) _controller_host_state.buttons |= GAMEPAD_MASK_B3;
+    if (controller_report.BTN_GamePadButton4 == 1) _controller_host_state.buttons |= GAMEPAD_MASK_B4;
+    if (controller_report.BTN_GamePadButton5 == 1) _controller_host_state.buttons |= GAMEPAD_MASK_L1;
+    if (controller_report.BTN_GamePadButton6 == 1) _controller_host_state.buttons |= GAMEPAD_MASK_L2;
+    if (controller_report.BTN_GamePadButton7 == 1) _controller_host_state.buttons |= GAMEPAD_MASK_R1;
+    if (controller_report.BTN_GamePadButton8 == 1) _controller_host_state.buttons |= GAMEPAD_MASK_R2;
 }


### PR DESCRIPTION
This allows using the Ultrastick 360 to be used as an analog input by connecting it via the usb host port.