### PR TITLE
Update to allow the `SOCD none` mode in the new USB HID input mode

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -199,7 +199,6 @@ public:
 	inline static const SOCDMode resolveSOCDMode(const GamepadOptions& options) {
 		return (options.socdMode == SOCD_MODE_BYPASS &&
 				(options.inputMode == INPUT_MODE_PS3 ||
-				 options.inputMode == INPUT_MODE_GENERIC ||
 				options.inputMode == INPUT_MODE_SWITCH ||
 				options.inputMode == INPUT_MODE_NEOGEO ||
 				options.inputMode == INPUT_MODE_PS4)) ?


### PR DESCRIPTION
Very small PR to address #1248 

This allows SOCD none in the new USB HID mode.