### PR TITLE
Remove the note saying the SNES Addon is disabled when Display is in use

### DIFF
--- a/www/src/Addons/SNES.tsx
+++ b/www/src/Addons/SNES.tsx
@@ -23,10 +23,6 @@ const SNES = ({ values, errors, handleChange, handleCheckbox }) => {
 			<div id="SNESpadAddonOptions" hidden={!values.SNESpadAddonEnabled}>
 				<Row>
 					<Trans ns="AddonsConfig" i18nKey="snes-extension-sub-header-text">
-						<p>
-							Note: If the Display is enabled at the same time, this Addon will
-							be disabled.
-						</p>
 						<h3>Currently Supported Controllers</h3>
 						<p>
 							SNES pad: D-Pad Supported. B = B1, A = B2, Y = B3, X = B4, L = L1,


### PR DESCRIPTION
As discussed on discord, this text was probably some remaining from the Wii Addon code that served as a base for the SNES Addon code, and Wii uses I2C (hence competing with Display) but SNES does not.