### PR TITLE
Update GitHub Actions runners specifying ubuntu-latest

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         GP2040_BOARDCONFIG: [ARCController, Blank, Pico, PicoW, BentoBox, ergoSHIFTRev2, FightboardV3, FightboardV3Mirrored, FlatboxRev4, FlatboxRev5, FlatboxRev5RGB, FlatboxRev5USBPassthrough, FlatboxRev5Southpaw, Granola, KB2040, KeyboardConverter, Haute42COSMOX, Liatris, MavercadeRev1, MavercadeRev2, MiSTercadeV2, OpenCore0, OpenCore0WASD, OSUMGP-RP2040, PicoAnn, PicoFightingBoard, PXPGamepad, RanaTadpole, ReflexCtrlGenesis6, ReflexCtrlNES, ReflexCtrlSaturn, ReflexCtrlSNES, ReflexCtrlVB, ReflexEncodeV1.2, ReflexEncodeV2.0, RP2040AdvancedBreakoutBoard, RP2040AdvancedBreakoutBoardUSBPassthrough, RP2040MiniBreakoutBoard, SparkFunProMicro, WaveshareZero, Stress, SGFDevices, ZeroRhythm]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-   
+    runs-on: ubuntu-22.04
+
     steps:
     - uses: actions/checkout@v4.1.1
 


### PR DESCRIPTION
Updates the workflows to use a specific version runner images rather than the named "latest" to fix CI warnings