### PR TITLE
Keyboard Volume Dial - Rotary Encoder Extension

### DIFF
--- a/headers/drivers/keyboard/KeyboardDriver.h
+++ b/headers/drivers/keyboard/KeyboardDriver.h
@@ -8,6 +8,7 @@
 
 #include "gpdriver.h"
 #include "drivers/keyboard/KeyboardDescriptors.h"
+#include "eventmanager.h"
 
 class KeyboardDriver : public GPDriver {
 public:

--- a/headers/drivers/keyboard/KeyboardDriver.h
+++ b/headers/drivers/keyboard/KeyboardDriver.h
@@ -25,6 +25,7 @@ public:
     virtual const uint8_t * get_descriptor_device_qualifier_cb();
     virtual uint16_t GetJoystickMidValue();
     virtual USBListener * get_usb_auth_listener() { return nullptr; }
+    void handleEncoder(GPEvent* e); // for Volume - rotary encoder
 private:
     void releaseAllKeys(void);
 	void pressKey(uint8_t code);
@@ -33,6 +34,7 @@ private:
     uint8_t last_report[CFG_TUD_ENDPOINT0_SIZE] = { };
     uint16_t last_report_size;
     KeyboardReport keyboardReport;
+    int8_t volumeChange;
 };
 
 #endif // _KEYBOARD_DRIVER_H_

--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -450,6 +450,7 @@ enum RotaryEncoderPinMode
     ENCODER_MODE_RIGHT_TRIGGER = 6;
     ENCODER_MODE_DPAD_X = 7;
     ENCODER_MODE_DPAD_Y = 8;
+    ENCODER_MODE_VOLUME = 9;
 };
 
 enum ReactiveLEDMode

--- a/src/addons/rotaryencoder.cpp
+++ b/src/addons/rotaryencoder.cpp
@@ -124,6 +124,8 @@ void RotaryEncoderInput::process()
                 int8_t axis = mapEncoderValueDPad(i, encoderValues[i], encoderMap[i].pulsesPerRevolution);
                 dpadUp = (axis == 1);
                 dpadDown = (axis == -1);
+            } else if (encoderMap[i].mode == ENCODER_MODE_VOLUME) {
+                // Prevents NONE kick-out, do nothing for now but rely on GP events
             }
 
             if ((encoderValues[i] - prevValues[i]) != 0) {

--- a/src/drivers/keyboard/KeyboardDriver.cpp
+++ b/src/drivers/keyboard/KeyboardDriver.cpp
@@ -95,10 +95,8 @@ void KeyboardDriver::process(Gamepad * gamepad) {
 
     if( volumeChange > 0 ) {
         pressKey(KEYBOARD_MULTIMEDIA_VOLUME_UP);
-        volumeChange--;
     } else if ( volumeChange < 0 ) {
         pressKey(KEYBOARD_MULTIMEDIA_VOLUME_DOWN);
-        volumeChange++;
     }
 
 	// Wake up TinyUSB device
@@ -123,6 +121,13 @@ void KeyboardDriver::process(Gamepad * gamepad) {
 			if ( tud_hid_report(keyboardReport.reportId, keyboard_report_payload, keyboard_report_size) ) {
 				memcpy(last_report, keyboard_report_payload, keyboard_report_size);
 				last_report_size = keyboard_report_size;
+
+                // Adjust volume on success
+                if( volumeChange > 0 ) {
+                    volumeChange--;
+                } else if ( volumeChange < 0 ) {
+                    volumeChange++;
+                }
 			}
 		}
 	}

--- a/src/drivers/keyboard/KeyboardDriver.cpp
+++ b/src/drivers/keyboard/KeyboardDriver.cpp
@@ -3,6 +3,8 @@
 #include "drivers/shared/driverhelper.h"
 #include "drivers/hid/HIDDescriptors.h"
 
+#include "eventmanager.h"
+
 void KeyboardDriver::initialize() {
 	keyboardReport = {
 		.keycode = { 0 },
@@ -20,6 +22,10 @@ void KeyboardDriver::initialize() {
 		.xfer_cb = hidd_xfer_cb,
 		.sof = NULL
 	};
+
+    // Handle Volume for Rotary Encoder
+    EventManager::getInstance().registerEventHandler(GP_EVENT_ENCODER_CHANGE, GPEVENT_CALLBACK(this->handleEncoder(event)));
+    volumeChange = 0; // no change
 }
 
 uint8_t KeyboardDriver::getModifier(uint8_t code) {
@@ -86,6 +92,14 @@ void KeyboardDriver::process(Gamepad * gamepad) {
 	if(gamepad->pressedE10()) 	{ pressKey(keyboardMapping.keyButtonE10); }
 	if(gamepad->pressedE11()) 	{ pressKey(keyboardMapping.keyButtonE11); }
 	if(gamepad->pressedE12()) 	{ pressKey(keyboardMapping.keyButtonE12); }
+
+    if( volumeChange > 0 ) {
+        pressKey(KEYBOARD_MULTIMEDIA_VOLUME_UP);
+        volumeChange--;
+    } else if ( volumeChange < 0 ) {
+        pressKey(KEYBOARD_MULTIMEDIA_VOLUME_DOWN);
+        volumeChange++;
+    }
 
 	// Wake up TinyUSB device
 	if (tud_suspended())
@@ -173,4 +187,15 @@ const uint8_t * KeyboardDriver::get_descriptor_device_qualifier_cb() {
 
 uint16_t KeyboardDriver::GetJoystickMidValue() {
 	return HID_JOYSTICK_MID << 8;
+}
+
+void KeyboardDriver::handleEncoder(GPEvent* e) {
+    GPEncoderChangeEvent * encoderEvent = (GPEncoderChangeEvent*)e;
+    if ( encoderEvent->direction == 1 ) {
+        // volume up
+        volumeChange++;
+    } else if ( encoderEvent->direction == -1 ) {
+        // volume down
+        volumeChange--;
+    }
 }

--- a/www/src/Addons/Rotary.tsx
+++ b/www/src/Addons/Rotary.tsx
@@ -17,7 +17,7 @@ const ENCODER_MODES = [
 	{ label: 'encoder-mode-right-trigger', value: 6 },
 	{ label: 'encoder-mode-dpad-x', value: 7 },
 	{ label: 'encoder-mode-dpad-y', value: 8 },
-    { label: 'encoder-mode-volume', value: 9 },
+	{ label: 'encoder-mode-volume', value: 9 },
 ];
 
 const ENCODER_MULTIPLES = [

--- a/www/src/Addons/Rotary.tsx
+++ b/www/src/Addons/Rotary.tsx
@@ -44,7 +44,7 @@ export const rotaryScheme = {
 		.number()
 		.required()
 		.label('Rotary Encoder Add-On Enabled'),
-	encoderOneEnabled: yup.number().required().label('Encoder One Enabled'),
+	encoderOneEnabled: yup.boolean().required().label('Encoder One Enabled'),
 	encoderOnePinA: yup
 		.number()
 		.label('Encoder One Pin A')
@@ -66,7 +66,7 @@ export const rotaryScheme = {
 		.required()
 		.label('Encoder One Allow Wrap Around'),
 	encoderOneMultiplier: yup.number().label('Encoder One Multiplier').required(),
-	encoderTwoEnabled: yup.number().required().label('Encoder Two Enabled'),
+	encoderTwoEnabled: yup.boolean().required().label('Encoder Two Enabled'),
 	encoderTwoPinA: yup
 		.number()
 		.label('Encoder Two Pin A')

--- a/www/src/Addons/Rotary.tsx
+++ b/www/src/Addons/Rotary.tsx
@@ -17,6 +17,7 @@ const ENCODER_MODES = [
 	{ label: 'encoder-mode-right-trigger', value: 6 },
 	{ label: 'encoder-mode-dpad-x', value: 7 },
 	{ label: 'encoder-mode-dpad-y', value: 8 },
+    { label: 'encoder-mode-volume', value: 9 },
 ];
 
 const ENCODER_MULTIPLES = [

--- a/www/src/Locales/en/Addons/Rotary.jsx
+++ b/www/src/Locales/en/Addons/Rotary.jsx
@@ -18,4 +18,5 @@ export default {
 	'encoder-mode-right-trigger': 'Right Trigger',
 	'encoder-mode-dpad-x': 'D-Pad Left/Right',
 	'encoder-mode-dpad-y': 'D-Pad Up/Down',
+    'encoder-mode-volume': 'Volume (Keyboard Only)',
 };

--- a/www/src/Locales/en/Addons/Rotary.jsx
+++ b/www/src/Locales/en/Addons/Rotary.jsx
@@ -18,5 +18,5 @@ export default {
 	'encoder-mode-right-trigger': 'Right Trigger',
 	'encoder-mode-dpad-x': 'D-Pad Left/Right',
 	'encoder-mode-dpad-y': 'D-Pad Up/Down',
-    'encoder-mode-volume': 'Volume (Keyboard Only)',
+	'encoder-mode-volume': 'Volume (Keyboard Only)',
 };


### PR DESCRIPTION
Extended the rotary encoder to be used as a volume dial in the keyboard input driver.

This allows you to use the add-on Rotary Encoder, set your pins, and once in keyboard input mode it will up/down your volume.