### PR TITLE
Add validation for duplicate hotkey combinations

### DIFF
--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -99,7 +99,7 @@ const SHA256 = (ascii) => {
 								(rightRotate(w15, 7) ^ rightRotate(w15, 18) ^ (w15 >>> 3)) + // s0
 								w[i - 7] +
 								(rightRotate(w2, 17) ^ rightRotate(w2, 19) ^ (w2 >>> 10))) | // s1
-							0);
+						  0);
 			// This is only used once, so *could* be moved below, but it only saves 4 bytes and makes things unreadble
 			const temp2 =
 				(rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22)) + // S0
@@ -324,7 +324,28 @@ const hotkeyFields = Array(16)
 		const newSchema = yup
 			.object()
 			.label('Hotkey ' + number)
-			.shape({ ...hotkeySchema });
+			.shape({ ...hotkeySchema })
+			.test(
+				'duplicate-hotkeys',
+				'Duplicate button combinations are not allowed',
+				function (currentValue) {
+					return !Object.entries(this.parent).some(
+						([key, { buttonsMask, auxMask }]) => {
+							if (
+								!key.includes('hotkey') || // Skip non-hotkey rows
+								key === 'hotkey' + number || // Skip current hotkey
+								!Boolean(currentValue.buttonsMask + currentValue.auxMask) // Skip unset hotkey rows
+							) {
+								return false;
+							}
+							return (
+								buttonsMask === currentValue.buttonsMask &&
+								auxMask === currentValue.auxMask
+							);
+						},
+					);
+				},
+			);
 		acc['hotkey' + number] = newSchema;
 		return acc;
 	}, {});
@@ -1678,18 +1699,25 @@ export default function SettingsPage() {
 															{t('SettingsPage:hotkey-settings-warning')}
 														</div>
 													)}
-													<div id="Hotkeys" hidden={values.lockHotkeys}>
+													<div
+														id="Hotkeys"
+														hidden={values.lockHotkeys}
+														className="d-grid gap-2"
+													>
 														{Object.keys(hotkeyFields).map((o, i) => (
 															<Form.Group
 																key={`hotkey-${i}-base`}
-																className="row row-gap-2 gx-2 pb-2"
+																className={`row row-gap-2 align-items-center gx-2`}
 															>
-																<Col sm="auto">
+																<Col
+																	sm="auto"
+																	className="d-flex align-items-center"
+																>
 																	<Form.Check
 																		name={`${o}.auxMask`}
-																		label="&nbsp;&nbsp;Fn"
+																		label="Fn"
 																		type="switch"
-																		className="form-select-sm"
+																		className="text my-auto"
 																		disabled={values.fnButtonPin === -1}
 																		checked={values[o] && !!values[o]?.auxMask}
 																		onChange={(e) => {
@@ -1698,7 +1726,7 @@ export default function SettingsPage() {
 																				e.target.checked ? 32768 : 0,
 																			);
 																		}}
-																		isInvalid={errors[o] && errors[o]?.auxMask}
+																		isInvalid={errors[o] || errors[o]?.auxMask}
 																	/>
 																	<Form.Control.Feedback type="invalid">
 																		{errors[o] && errors[o]?.action}
@@ -1718,10 +1746,10 @@ export default function SettingsPage() {
 																						values[o]?.buttonsMask & mask.value
 																					}
 																					error={
-																						errors[o] && errors[o]?.buttonsMask
+																						errors[o] || errors[o]?.buttonsMask
 																					}
 																					isInvalid={
-																						errors[o] && errors[o]?.buttonsMask
+																						errors[o] || errors[o]?.buttonsMask
 																					}
 																					onChange={(e) => {
 																						setFieldValue(
@@ -1812,6 +1840,12 @@ export default function SettingsPage() {
 																		</Button>
 																	</Col>
 																)}
+																<Form.Control.Feedback
+																	type="invalid"
+																	className={errors[o] ? 'd-block' : ''}
+																>
+																	{errors[o]}
+																</Form.Control.Feedback>
 															</Form.Group>
 														))}
 													</div>


### PR DESCRIPTION
Validation for this until how/if we should handle different hotkeys with the same combination.
 
<img width="806" alt="Screenshot 2025-01-27 at 00 43 12" src="https://github.com/user-attachments/assets/c2933d5c-3c93-470c-baaa-2602bd42061c" />

- Also aligns all the content in the rows vertically, some inputs where previously not centered

Could be better ways to do this, but could not think of any.