### PR TITLE
apply --abbrev=7 to git describe, ignoring the birthday problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # set the version for webconfig, etc. based on git
 find_package(Git)
-execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty --abbrev=7
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	OUTPUT_VARIABLE GIT_REPO_VERSION
 	OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
the current regex to generate CMAKE_GIT_REPO_VERSION, which is especially touchy, expects git SHA lengths of exactly 7 characters. apparently the repo is big enough now that that's not enough, so git is returning SHAs of length 8, throwing off the regex

alternatively the regex could be updated to allow 7 or 8, but I hope we don't get to the point that two builds ever have the same 7-char SHA, let alone it being ambiguous what you are working with in that scenario