### PR TITLE
Unknown UF2 URL Downloads Fix

### DIFF
--- a/www/src/Store/useSystemStats.ts
+++ b/www/src/Store/useSystemStats.ts
@@ -74,7 +74,7 @@ const useSystemStats = create<State & Actions>()((set) => ({
 							?.replace('.uf2', '')
 							?.toLowerCase() === firmwareVersion.boardConfig.toLowerCase(),
 				)?.browser_download_url ||
-				`https://github.com/OpenStickCommunity/GP2040-CE/releases/tag/${latestRelease.data.tag_name}`;
+				`https://github.com/OpenStickCommunity/GP2040-CE/releases/tag/${latestRelease.tag_name}`;
 
 			set({
 				currentVersion: firmwareVersion.version,


### PR DESCRIPTION
Fix for URL tag name on unknown downloads for UF2.

Github might have changed this from release.data.tag_name to release.tag_name at some point here