### PR TITLE
Updating SDK to 2.1.1

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,7 +78,7 @@ jobs:
         fetch-tags: true
 
     - name: Setup SDK pipeline
-      uses: Fortinbra/RaspberryPiPicoBuild@v3
+      uses: Fortinbra/RaspberryPiPicoBuild@v4
 
     - name: Download a Build Artifact
       uses: actions/download-artifact@v4.1.2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,7 +78,7 @@ jobs:
         fetch-tags: true
 
     - name: Setup SDK pipeline
-      uses: Fortinbra/RaspberryPiPicoBuild@v4
+      uses: Fortinbra/RaspberryPiPicoBuild@v6
 
     - name: Download a Build Artifact
       uses: actions/download-artifact@v4.1.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/sekigon-gonnoc/Pico-PIO-USB
 [submodule "lib/tinyusb"]
 	path = lib/tinyusb
-	url = https://github.com/hathach/tinyusb/
+	url = https://github.com/Fortinbra/tinyusb/

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/sekigon-gonnoc/Pico-PIO-USB
 [submodule "lib/tinyusb"]
 	path = lib/tinyusb
-	url = https://github.com/Fortinbra/tinyusb/
+	url = https://github.com/hathach/tinyusb/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.5)
 include(CMakePrintHelpers)
 
 # enable compile commands for use by IDE autocompletion

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,20 @@
-cmake_minimum_required(VERSION 3.5)
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 2.1.1)
+set(toolchainVersion 14_2_Rel1)
+set(picotoolVersion 2.1.1)
+set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+if (EXISTS ${picoVscode})
+    include(${picoVscode})
+endif()
+# ====================================================================================
+set(PICO_BOARD pico CACHE STRING "Board type")
+
+cmake_minimum_required(VERSION 3.10...4.0)
 include(CMakePrintHelpers)
 
 # enable compile commands for use by IDE autocompletion
@@ -8,8 +24,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # note: this must happen before project()
 include(pico_sdk_import.cmake)
 
-if (PICO_SDK_VERSION_STRING VERSION_LESS "1.5.0")
-  message(FATAL_ERROR "Raspberry Pi Pico SDK version 1.5.0 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
+if (PICO_SDK_VERSION_STRING VERSION_LESS "2.1.1")
+  message(FATAL_ERROR "Raspberry Pi Pico SDK version 2.1.1 (or later) required. Your version is ${PICO_SDK_VERSION_STRING}")
 endif()
 
 # set the version for webconfig, etc. based on git

--- a/lib/NeoPico/src/generated/ws2812.pio.h
+++ b/lib/NeoPico/src/generated/ws2812.pio.h
@@ -14,6 +14,7 @@
 
 #define ws2812_wrap_target 0
 #define ws2812_wrap 3
+#define ws2812_pio_version 0
 
 #define ws2812_T1 2
 #define ws2812_T2 5
@@ -21,10 +22,10 @@
 
 static const uint16_t ws2812_program_instructions[] = {
             //     .wrap_target
-    0x6221, //  0: out    x, 1            side 0 [2] 
-    0x1123, //  1: jmp    !x, 3           side 1 [1] 
-    0x1400, //  2: jmp    0               side 1 [4] 
-    0xa442, //  3: nop                    side 0 [4] 
+    0x6221, //  0: out    x, 1            side 0 [2]
+    0x1123, //  1: jmp    !x, 3           side 1 [1]
+    0x1400, //  2: jmp    0               side 1 [4]
+    0xa442, //  3: nop                    side 0 [4]
             //     .wrap
 };
 
@@ -33,6 +34,10 @@ static const struct pio_program ws2812_program = {
     .instructions = ws2812_program_instructions,
     .length = 4,
     .origin = -1,
+    .pio_version = ws2812_pio_version,
+#if PICO_PIO_VERSION > 0
+    .used_gpio_ranges = 0x0
+#endif
 };
 
 static inline pio_sm_config ws2812_program_get_default_config(uint offset) {
@@ -65,6 +70,7 @@ static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, 
 
 #define ws2812_parallel_wrap_target 0
 #define ws2812_parallel_wrap 3
+#define ws2812_parallel_pio_version 0
 
 #define ws2812_parallel_T1 2
 #define ws2812_parallel_T2 5
@@ -72,10 +78,10 @@ static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, 
 
 static const uint16_t ws2812_parallel_program_instructions[] = {
             //     .wrap_target
-    0x6020, //  0: out    x, 32                      
-    0xa10b, //  1: mov    pins, !null            [1] 
-    0xa401, //  2: mov    pins, x                [4] 
-    0xa103, //  3: mov    pins, null             [1] 
+    0x6020, //  0: out    x, 32
+    0xa10b, //  1: mov    pins, ~null            [1]
+    0xa401, //  2: mov    pins, x                [4]
+    0xa103, //  3: mov    pins, null             [1]
             //     .wrap
 };
 
@@ -84,6 +90,10 @@ static const struct pio_program ws2812_parallel_program = {
     .instructions = ws2812_parallel_program_instructions,
     .length = 4,
     .origin = -1,
+    .pio_version = ws2812_parallel_pio_version,
+#if PICO_PIO_VERSION > 0
+    .used_gpio_ranges = 0x0
+#endif
 };
 
 static inline pio_sm_config ws2812_parallel_program_get_default_config(uint offset) {

--- a/lib/WiiExtension/WiiExtension.h
+++ b/lib/WiiExtension/WiiExtension.h
@@ -90,7 +90,7 @@ typedef enum {
 #endif
 
 #define WII_ALARM_NUM 0
-#define WII_ALARM_IRQ TIMER1_IRQ_0
+#define WII_ALARM_IRQ TIMER_IRQ_0
 
 #define WII_CHECKSUM_MAGIC 0x55
 #define WII_CALIBRATION_SIZE 0x10

--- a/lib/WiiExtension/WiiExtension.h
+++ b/lib/WiiExtension/WiiExtension.h
@@ -90,7 +90,7 @@ typedef enum {
 #endif
 
 #define WII_ALARM_NUM 0
-#define WII_ALARM_IRQ TIMER_IRQ_0
+#define WII_ALARM_IRQ TIMER1_IRQ_0
 
 #define WII_CHECKSUM_MAGIC 0x55
 #define WII_CALIBRATION_SIZE 0x10

--- a/pico_sdk_import.cmake
+++ b/pico_sdk_import.cmake
@@ -3,6 +3,28 @@
 # This can be dropped into an external project to help locate this SDK
 # It should be include()ed prior to project()
 
+# Copyright 2020 (c) 2020 Raspberry Pi (Trading) Ltd.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+# following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+# disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
     set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
     message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
@@ -18,9 +40,20 @@ if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_P
     message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
 endif ()
 
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_TAG} AND (NOT PICO_SDK_FETCH_FROM_GIT_TAG))
+    set(PICO_SDK_FETCH_FROM_GIT_TAG $ENV{PICO_SDK_FETCH_FROM_GIT_TAG})
+    message("Using PICO_SDK_FETCH_FROM_GIT_TAG from environment ('${PICO_SDK_FETCH_FROM_GIT_TAG}')")
+endif ()
+
+if (PICO_SDK_FETCH_FROM_GIT AND NOT PICO_SDK_FETCH_FROM_GIT_TAG)
+  set(PICO_SDK_FETCH_FROM_GIT_TAG "master")
+  message("Using master as default value for PICO_SDK_FETCH_FROM_GIT_TAG")
+endif()
+
 set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
 set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
 set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+set(PICO_SDK_FETCH_FROM_GIT_TAG "${PICO_SDK_FETCH_FROM_GIT_TAG}" CACHE FILEPATH "release tag for SDK")
 
 if (NOT PICO_SDK_PATH)
     if (PICO_SDK_FETCH_FROM_GIT)
@@ -29,25 +62,40 @@ if (NOT PICO_SDK_PATH)
         if (PICO_SDK_FETCH_FROM_GIT_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
-        # GIT_SUBMODULES_RECURSE was added in 3.17
-        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
-            FetchContent_Declare(
-                    pico_sdk
-                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
-                    GIT_SUBMODULES_RECURSE FALSE
-            )
-        else ()
-            FetchContent_Declare(
-                    pico_sdk
-                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
-            )
-        endif ()
+        FetchContent_Declare(
+                pico_sdk
+                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+        )
 
         if (NOT pico_sdk)
             message("Downloading Raspberry Pi Pico SDK")
-            FetchContent_Populate(pico_sdk)
+            # GIT_SUBMODULES_RECURSE was added in 3.17
+            if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+                FetchContent_Populate(
+                        pico_sdk
+                        QUIET
+                        GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                        GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+                        GIT_SUBMODULES_RECURSE FALSE
+
+                        SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                        BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                        SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+                )
+            else ()
+                FetchContent_Populate(
+                        pico_sdk
+                        QUIET
+                        GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                        GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+
+                        SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                        BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                        SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+                )
+            endif ()
+
             set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
         endif ()
         set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})


### PR DESCRIPTION
Until the Mbedtls issue is fixed, we're still blocked, but this should clear the other issues with TinyUSB and Cmake 4.0... Not a good way to force our hand at an upgrade, but we were going to do it eventually.