### PR TITLE
Initial LED Brightness Fix

### DIFF
--- a/src/animationstation/animationstation.cpp
+++ b/src/animationstation/animationstation.cpp
@@ -21,7 +21,6 @@ AnimationStation::AnimationStation() {
     if (animationOptions.hasCustomTheme) {
         effectCount++; // increase our effect count
     }
-    SetBrightness(1);
 }
 
 void AnimationStation::ConfigureBrightness(uint8_t max, uint8_t steps) {


### PR DESCRIPTION
Brightness fix (was always setting animationOptions.brightness to 1 out of however many steps we got)