### PR TITLE
Fixed PS4 mode support for Gamepad Host

### DIFF
--- a/headers/drivers/ps4/PS4Descriptors.h
+++ b/headers/drivers/ps4/PS4Descriptors.h
@@ -25,6 +25,8 @@
 #define DS4_VENDOR_ID       0x054C
 #define DS4_PRODUCT_ID      0x09CC
 
+#define DS4_ORG_PRODUCT_ID  0x05C4
+
 /**************************************************************************
  *
  *  Endpoint Buffer Configuration

--- a/src/addons/gamepad_usb_host_listener.cpp
+++ b/src/addons/gamepad_usb_host_listener.cpp
@@ -2,6 +2,7 @@
 #include "drivermanager.h"
 #include "storagemanager.h"
 #include "class/hid/hid_host.h"
+#include "drivers/ps4/PS4Driver.h"
 
 void GamepadUSBHostListener::setup() {
     _controller_host_enabled = false;
@@ -57,16 +58,17 @@ void GamepadUSBHostListener::process_ctrlr_report(uint8_t dev_addr, uint8_t cons
 
     switch(controller_pid)
     {
-        case 0x05c4: // Sony Dualshock 4 controller
-        case 0x09cc: // Sony Dualshock 4 controller
+        case DS4_ORG_PRODUCT_ID: // Sony Dualshock 4 controller
+        case DS4_PRODUCT_ID:     // Sony Dualshock 4 controller
+        case PS4_PRODUCT_ID:     // Razer Panthera
             process_ds4(report);
             break;
-        case 0x9400:// Google Stadia controller
+        case 0x9400:             // Google Stadia controller
             process_stadia(report);
             break;
 
-        case 0x0510: // pre-2015 Ultrakstik 360
-        case 0x0511: // Ultrakstik 360
+        case 0x0510:             // pre-2015 Ultrakstik 360
+        case 0x0511:             // Ultrakstik 360
             process_ultrastik360(report);
             break;
         default:


### PR DESCRIPTION
Changed magic numbers for PS4 device IDs to use defines in Gamepad Host.
Added main PS4 "Console" IDs to Gamepad Host device check to allow both modes to function.