### PR TITLE
Fix for toast and bounce screen saver logos

### DIFF
--- a/headers/display/ui/screens/DisplaySaverScreen.h
+++ b/headers/display/ui/screens/DisplaySaverScreen.h
@@ -30,7 +30,7 @@ class DisplaySaverScreen : public GPScreen {
         uint16_t bounceSpriteX = 0;
         uint16_t bounceSpriteY = 0;
         uint16_t bounceSpriteWidth = 128;
-        uint16_t bounceSpriteHeight = 64;
+        uint16_t bounceSpriteHeight = 35;
         double bounceSpriteVelocityX = 1;
         double bounceSpriteVelocityY = 1;
         double bounceScale = 0.5;
@@ -50,10 +50,8 @@ class DisplaySaverScreen : public GPScreen {
 
         std::vector<ToastParams> toasters;
         uint16_t numberOfToasters = 10;
-        //uint16_t toasterSpriteWidth = 43;
-        //uint16_t toasterSpriteHeight = 39;
         uint16_t toasterSpriteWidth = 128;
-        uint16_t toasterSpriteHeight = 64;
+        uint16_t toasterSpriteHeight = 35;
         void initToasters();
         void drawToasterScene();
 };

--- a/src/display/ui/screens/DisplaySaverScreen.cpp
+++ b/src/display/ui/screens/DisplaySaverScreen.cpp
@@ -1,4 +1,5 @@
 #include "DisplaySaverScreen.h"
+#include "BitmapScreens.h"
 
 #include "drivermanager.h"
 #include "pico/stdlib.h"
@@ -21,6 +22,8 @@ void DisplaySaverScreen::init() {
         case DisplaySaverMode::DISPLAY_SAVER_TOAST:
             initToasters();
             break;
+        default:
+            break;
     }
 }
 
@@ -41,6 +44,8 @@ void DisplaySaverScreen::drawScreen() {
             break;
         case DisplaySaverMode::DISPLAY_SAVER_TOAST:
             drawToasterScene();
+            break;
+        default:
             break;
     }
 }
@@ -118,7 +123,7 @@ void DisplaySaverScreen::drawBounceScene() {
 
     if (bounceSpriteY <= 0 || bounceSpriteY + scaledHeight >= SCREEN_HEIGHT) bounceSpriteVelocityY = -bounceSpriteVelocityY;
 
-    getRenderer()->drawSprite((uint8_t *)getDisplayOptions().splashImage.bytes, bounceSpriteWidth, bounceSpriteHeight, 0, bounceSpriteX, bounceSpriteY, 0, bounceScale);
+    getRenderer()->drawSprite((uint8_t *)bitmapGP2040Logo, bounceSpriteWidth, bounceSpriteHeight, 0, bounceSpriteX, bounceSpriteY, 0, bounceScale);
 }
 
 void DisplaySaverScreen::drawPipeScene() {
@@ -161,8 +166,8 @@ void DisplaySaverScreen::drawPipeScene() {
 void DisplaySaverScreen::initToasters() {
     for (uint16_t i = 0; i < numberOfToasters; ++i) {
         double scale = 1.0 / ((i/2)+2);
-        int16_t dx = (-1 - rand() % 3);
-        int16_t dy = (1 + rand() % 3);
+        int16_t dx = (-1 - rand() % 2);
+        int16_t dy = (1 + rand() % 2);
 
         toasters.push_back({
             scale,
@@ -178,7 +183,7 @@ void DisplaySaverScreen::drawToasterScene() {
     for (uint16_t i = 0; i < toasters.size(); ++i) {
         ToastParams& sprite = toasters[i];
 
-        getRenderer()->drawSprite((uint8_t *) getDisplayOptions().splashImage.bytes, toasterSpriteWidth, toasterSpriteHeight, 0, sprite.x, sprite.y, 0, sprite.scale);
+        getRenderer()->drawSprite((uint8_t *)bitmapGP2040Logo, toasterSpriteWidth, toasterSpriteHeight, 0, sprite.x, sprite.y, 0, sprite.scale);
 
         sprite.x += sprite.dx;
         sprite.y += sprite.dy;
@@ -186,8 +191,8 @@ void DisplaySaverScreen::drawToasterScene() {
         if (sprite.x + toasterSpriteWidth * sprite.scale < 0) {
             sprite.x = SCREEN_WIDTH;
             sprite.y = rand() % (SCREEN_HEIGHT - static_cast<int16_t>(toasterSpriteHeight * sprite.scale));
-            sprite.dx = (-1 - rand() % 3);
-            sprite.dy = (1 + rand() % 3);
+            sprite.dx = (-1 - rand() % 2);
+            sprite.dy = (1 + rand() % 2);
         }
 
         if (sprite.y > SCREEN_HEIGHT) {


### PR DESCRIPTION
Fixes the graphics for the toast and bounce images to use our gp2040-ce logo.

Slowed down toast so its not so chaotic.