### PR TITLE
Custom Theme Pressed Fix

### DIFF
--- a/src/animationstation/effects/customthemepressed.cpp
+++ b/src/animationstation/effects/customthemepressed.cpp
@@ -31,6 +31,29 @@ CustomThemePressed::CustomThemePressed(PixelMatrix &matrix) : Animation(matrix) 
 
 CustomThemePressed::CustomThemePressed(PixelMatrix &matrix, std::vector<Pixel> &pixels) : Animation(matrix), pixels(&pixels) {
   this->filtered = true;
+
+  AnimationOptions & animationOptions = Storage::getInstance().getAnimationOptions();
+  if (animationOptions.hasCustomTheme)
+	{
+      theme[GAMEPAD_MASK_DU] = RGB(animationOptions.customThemeUpPressed);
+      theme[GAMEPAD_MASK_DD] = RGB(animationOptions.customThemeDownPressed);
+      theme[GAMEPAD_MASK_DL] = RGB(animationOptions.customThemeLeftPressed);
+      theme[GAMEPAD_MASK_DR] = RGB(animationOptions.customThemeRightPressed);
+      theme[GAMEPAD_MASK_B1] = RGB(animationOptions.customThemeB1Pressed);
+      theme[GAMEPAD_MASK_B2] = RGB(animationOptions.customThemeB2Pressed);
+      theme[GAMEPAD_MASK_B3] = RGB(animationOptions.customThemeB3Pressed);
+      theme[GAMEPAD_MASK_B4] = RGB(animationOptions.customThemeB4Pressed);
+      theme[GAMEPAD_MASK_L1] = RGB(animationOptions.customThemeL1Pressed);
+      theme[GAMEPAD_MASK_R1] = RGB(animationOptions.customThemeR1Pressed);
+      theme[GAMEPAD_MASK_L2] = RGB(animationOptions.customThemeL2Pressed);
+      theme[GAMEPAD_MASK_R2] = RGB(animationOptions.customThemeR2Pressed);
+      theme[GAMEPAD_MASK_S1] = RGB(animationOptions.customThemeS1Pressed);
+      theme[GAMEPAD_MASK_S2] = RGB(animationOptions.customThemeS2Pressed);
+      theme[GAMEPAD_MASK_A1] = RGB(animationOptions.customThemeA1Pressed);
+      theme[GAMEPAD_MASK_A2] = RGB(animationOptions.customThemeA2Pressed);
+      theme[GAMEPAD_MASK_L3] = RGB(animationOptions.customThemeL3Pressed);
+      theme[GAMEPAD_MASK_R3] = RGB(animationOptions.customThemeR3Pressed);
+	}
 }
 
 bool CustomThemePressed::Animate(RGB (&frame)[100]) {

--- a/src/animationstation/effects/statictheme.cpp
+++ b/src/animationstation/effects/statictheme.cpp
@@ -3,10 +3,10 @@
 #include "enums.pb.h"
 
 StaticTheme::StaticTheme(PixelMatrix &matrix) : Animation(matrix) {
-  AnimationOptions & animationOptions = Storage::getInstance().getAnimationOptions();
-  if (animationOptions.themeIndex >= themes.size()) {
-    animationOptions.themeIndex = 0;
-  }
+	AnimationOptions & animationOptions = Storage::getInstance().getAnimationOptions();
+	if (animationOptions.themeIndex >= themes.size()) {
+		animationOptions.themeIndex = 0;
+	}
 
 	const std::map<uint32_t, RGB> themeGuiltyGearTypeA({
 		{ GAMEPAD_MASK_DU, ColorWhite },
@@ -277,7 +277,7 @@ StaticTheme::StaticTheme(PixelMatrix &matrix) : Animation(matrix) {
 		{ GAMEPAD_MASK_L2, ColorMagenta },
 	});
 
-  LEDOptions & ledOptions = Storage::getInstance().getLedOptions();
+  	LEDOptions & ledOptions = Storage::getInstance().getLedOptions();
 	themeStaticRainbow[GAMEPAD_MASK_DU] = (ledOptions.ledLayout == BUTTON_LAYOUT_STICKLESS) ? ColorGreen : ColorOrange;
 
 	ClearThemes();


### PR DESCRIPTION
Fixed missing custom theme pressed lights

I missed this when I was doing the LED overhaul