### PR TITLE
Fix for wrong font size in SNES add-on configuration

### DIFF
--- a/www/src/Addons/SNES.tsx
+++ b/www/src/Addons/SNES.tsx
@@ -22,16 +22,15 @@ const SNES = ({ values, errors, handleChange, handleCheckbox }) => {
 			<div id="SNESpadAddonOptions" hidden={!values.SNESpadAddonEnabled}>
 				<Row>
 					<Trans ns="AddonsConfig" i18nKey="snes-extension-sub-header-text">
-						<h3>Currently Supported Controllers</h3>
+						<p>Note: If the display is enabled at the same time, this add-on will be disabled.</p>
+						<p>Currently supported controllers:</p>
 						<p>
-							SNES pad: D-Pad Supported. B = B1, A = B2, Y = B3, X = B4, L = L1,
-							R = R1, Select = S1, Start = S2
+							SNES pad: D-pad supported. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2
+							<br/>
+							SNES mouse: Analog stick supported. Left Click = B1, Right Click = B2
+							<br/>
+							NES: D-pad supported. B = B1, A = B2, Select = S1, Start = S2
 						</p>
-						<p>
-							SNES mouse: Analog Stick Supported. Left Click = B1, Right Click =
-							B2
-						</p>
-						<p>NES: D-Pad Supported. B = B1, A = B2, Select = S1, Start = S2</p>
 					</Trans>
 				</Row>
 				<Row className="mb-3">

--- a/www/src/Addons/Wii.tsx
+++ b/www/src/Addons/Wii.tsx
@@ -353,7 +353,7 @@ const Wii = ({
 				<Row>
 					<Trans ns="WiiAddon" i18nKey="sub-header-text">
 						<p>
-							Note: If the Display is enabled at the same time, this Addon will
+							Note: If the display is enabled at the same time, this add-on will
 							be disabled.
 						</p>
 					</Trans>

--- a/www/src/Locales/de-DE/AddonsConfig.jsx
+++ b/www/src/Locales/de-DE/AddonsConfig.jsx
@@ -114,7 +114,7 @@ export default {
 	'ps4-mode-signature-label': 'Signatur (256 Bytes in Binär)',
 	'snes-extension-header-text': 'SNES-Erweiterungskonfiguration',
 	'snes-extension-sub-header-text':
-		'<0>Hinweis: Falls das Display zur gleichen Zeit aktiviert ist, wird diese Addon deaktiviert.</0> <1>Derzeit unterstützte Controller</1> <0>SNES pad: D-Pad Unterstützung. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2</0> <0>SNES maus: Analog Stick Unterstützt. Linksklick = B1, Rechtsklick = B2</0> <0>NES: D-Pad Unterstützt. B = B1, A = B2, Select = S1, Start = S2</0>',
+		'<0>Hinweis: Falls das Display zur gleichen Zeit aktiviert ist, wird dieses Add-On deaktiviert.</0> <1>Derzeit unterstützte Controller:</1> <2>SNES-Pad: D-Pad-Unterstützung. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2<br/>SNES-Maus: Analog-Stick-Unterstützung. Linksklick = B1, Rechtsklick = B2<br/>NES: D-Pad-Unterstützung. B = B1, A = B2, Select = S1, Start = S2</2>',
 	'snes-extension-clock-pin-label': 'Takt Pin',
 	'snes-extension-latch-pin-label': 'Latch Pin',
 	'snes-extension-data-pin-label': 'Daten Pin',

--- a/www/src/Locales/en/Addons/WiiAddon.jsx
+++ b/www/src/Locales/en/Addons/WiiAddon.jsx
@@ -1,7 +1,7 @@
 export default {
 	'header-text': 'Wii Extension',
 	'sub-header-text':
-		'<0>Note: If the Display is enabled at the same time, this Addon will be disabled.</0>',
+		'<0>Note: If the display is enabled at the same time, this add-on will be disabled.</0>',
 	'sda-pin-label': 'I2C SDA Pin',
 	'scl-pin-label': 'I2C SCL Pin',
 	'block-label': 'I2C Block',

--- a/www/src/Locales/en/AddonsConfig.jsx
+++ b/www/src/Locales/en/AddonsConfig.jsx
@@ -124,7 +124,8 @@ export default {
 	'ps4-mode-signature-label': 'Signature (256 Bytes in Binary)',
 	'snes-extension-header-text': 'SNES Extension Configuration',
 	'snes-extension-sub-header-text':
-		'<0>Note: If the display is enabled at the same time, this add-on will be disabled.</0> <1>Currently supported controllers:</1> <2>SNES pad: D-pad supported. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2<br/>SNES mouse: Analog stick supported. Left Click = B1, Right Click = B2<br/>NES: D-pad supported. B = B1, A = B2, Select = S1, Start = S2</2>',	'snes-extension-clock-pin-label': 'Clock GPIO Pin',
+		'<0>Note: If the display is enabled at the same time, this add-on will be disabled.</0> <1>Currently supported controllers:</1> <2>SNES pad: D-pad supported. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2<br/>SNES mouse: Analog stick supported. Left Click = B1, Right Click = B2<br/>NES: D-pad supported. B = B1, A = B2, Select = S1, Start = S2</2>',
+	'snes-extension-clock-pin-label': 'Clock GPIO Pin',
 	'snes-extension-latch-pin-label': 'Latch GPIO Pin',
 	'snes-extension-data-pin-label': 'Data GPIO Pin',
 	'focus-mode-header-text': 'Focus Mode Configuration',

--- a/www/src/Locales/en/AddonsConfig.jsx
+++ b/www/src/Locales/en/AddonsConfig.jsx
@@ -124,8 +124,7 @@ export default {
 	'ps4-mode-signature-label': 'Signature (256 Bytes in Binary)',
 	'snes-extension-header-text': 'SNES Extension Configuration',
 	'snes-extension-sub-header-text':
-		'<0>Note: If the Display is enabled at the same time, this Addon will be disabled.</0> <1>Currently Supported Controllers</1> <0>SNES pad: D-Pad Supported. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2</0> <0>SNES mouse: Analog Stick Supported. Left Click = B1, Right Click = B2</0> <0>NES: D-Pad Supported. B = B1, A = B2, Select = S1, Start = S2</0>',
-	'snes-extension-clock-pin-label': 'Clock GPIO Pin',
+		'<0>Note: If the display is enabled at the same time, this add-on will be disabled.</0> <1>Currently supported controllers:</1> <2>SNES pad: D-pad supported. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2<br/>SNES mouse: Analog stick supported. Left Click = B1, Right Click = B2<br/>NES: D-pad supported. B = B1, A = B2, Select = S1, Start = S2</2>',	'snes-extension-clock-pin-label': 'Clock GPIO Pin',
 	'snes-extension-latch-pin-label': 'Latch GPIO Pin',
 	'snes-extension-data-pin-label': 'Data GPIO Pin',
 	'focus-mode-header-text': 'Focus Mode Configuration',

--- a/www/src/Locales/ja-JP/AddonsConfig.jsx
+++ b/www/src/Locales/ja-JP/AddonsConfig.jsx
@@ -123,7 +123,7 @@ export default {
 	'ps4-mode-signature-label': '署名ファイル (256バイトバイナリー)',
 	'snes-extension-header-text': 'スーパーファミコン拡張設定',
 	'snes-extension-sub-header-text':
-		'<0>注：ディスプレイと同時に有効化した場合、このAdd-onは無効化されます</0> <1>現在サポートされているコントローラ</1> <0>スーパーファミコンコントローラ(SNES)：十字キー対応、B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2</0> <0>スーパーファミコンマウス: アナログスティック対応。 左クリック = B1, 右クリック = B2</0> <0>ファミコン(NES): 十字キー対応、 B = B1, A = B2, Select = S1, Start = S2</0>',
+		'<0>注：ディスプレイと同時に有効化した場合、このAdd-onは無効化されます</0> <1>現在サポートされているコントローラ</1> <2>スーパーファミコンコントローラ(SNES)：十字キー対応、B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2<br/>スーパーファミコンマウス: アナログスティック対応。 左クリック = B1, 右クリック = B2<br/>ファミコン(NES): 十字キー対応、 B = B1, A = B2, Select = S1, Start = S2</2>',
 	'snes-extension-clock-pin-label': 'Clock 端子',
 	'snes-extension-latch-pin-label': 'Latch 端子',
 	'snes-extension-data-pin-label': 'Data 端子',

--- a/www/src/Locales/ko-KR/AddonsConfig.jsx
+++ b/www/src/Locales/ko-KR/AddonsConfig.jsx
@@ -118,7 +118,7 @@ export default {
 	'ps4-mode-signature-label': '서명파일 (256바이트 바이너리)',
 	'snes-extension-header-text': '슈퍼 패미컴 확장 설정',
 	'snes-extension-sub-header-text':
-		'<0>참고 ：디스플레이가 동시에 활성화되면 현재 애드온은 비활성화됩니다</0> <1>현재 지원되는 컨트롤러</1> <0>슈퍼 패미컴 컨트롤러(SNES)：D-패드 대응, B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, 셀렉트 = S1, 스타트 = S2</0> <0>슈퍼 패미컴 마우스: 아날로그 스틱 대응. 좌 클릭 = B1, 우 클릭 = B2</0> <0>패미컴(NES): D-패드 대응, B = B1, A = B2, 셀렉트 = S1, 스타트 = S2</0>',
+		'<0>참고 ：디스플레이가 동시에 활성화되면 현재 애드온은 비활성화됩니다</0> <1>현재 지원되는 컨트롤러</1> <2>슈퍼 패미컴 컨트롤러(SNES)：D-패드 대응, B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, 셀렉트 = S1, 스타트 = S2<br/>슈퍼 패미컴 마우스: 아날로그 스틱 대응. 좌 클릭 = B1, 우 클릭 = B2<br/>패미컴(NES): D-패드 대응, B = B1, A = B2, 셀렉트 = S1, 스타트 = S2</2>',
 	'snes-extension-clock-pin-label': 'Clock 핀',
 	'snes-extension-latch-pin-label': 'Latch 핀',
 	'snes-extension-data-pin-label': 'Data 핀',

--- a/www/src/Locales/pt-BR/AddonsConfig.jsx
+++ b/www/src/Locales/pt-BR/AddonsConfig.jsx
@@ -121,7 +121,7 @@ export default {
 	'wii-extension-speed-label': 'Velocidade I2C',
 	'snes-extension-header-text': 'Configuração de Extensão SNES',
 	'snes-extension-sub-header-text':
-		'<0>Observação: se a Tela estiver habilitada ao mesmo tempo, este complemento será desativado.</0> <1>Controladores Atualmente Suportados</1> <0>Controle SNES: Suporta D-Pad. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Selecionar = S1, Iniciar = S2</0> <0>Mouse SNES: Suporta Stick Analógico. Clique Esquerdo = B1, Clique Direito = B2</0> <0>NES: Suporta D-Pad. B = B1, A = B2, Selecionar = S1, Iniciar = S2</0>',
+		'<0>Observação: se a Tela estiver habilitada ao mesmo tempo, este complemento será desativado.</0> <1>Controladores Atualmente Suportados</1> <2>Controle SNES: Suporta D-Pad. B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Selecionar = S1, Iniciar = S2<br/>Mouse SNES: Suporta Stick Analógico. Clique Esquerdo = B1, Clique Direito = B2<br/>NES: Suporta D-Pad. B = B1, A = B2, Selecionar = S1, Iniciar = S2</2>',
 	'snes-extension-clock-pin-label': 'Pino de Clock',
 	'snes-extension-latch-pin-label': 'Pino de Latch',
 	'snes-extension-data-pin-label': 'Pino de Dados',

--- a/www/src/Locales/zh-CN/AddonsConfig.jsx
+++ b/www/src/Locales/zh-CN/AddonsConfig.jsx
@@ -113,7 +113,7 @@ export default {
 	'ps4-mode-signature-label': '签名 (256 字节的二进制文件)',
 	'snes-extension-header-text': 'SNES 扩展配置',
 	'snes-extension-sub-header-text':
-		'<0>注意： 如果同时启用了显示屏功能, 此插件将会被禁用。</0> <1>当前已支持的控制器</1> <0>SNES pad：支持十字键。 B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2</0> <0>SNES mouse：支持模拟摇杆。 Left Click = B1, Right Click = B2</0> <0>NES：支持十字键。 B = B1, A = B2, Select = S1, Start = S2</0>',
+		'<0>注意： 如果同时启用了显示屏功能, 此插件将会被禁用。</0> <1>当前已支持的控制器</1> <2>SNES pad：支持十字键。 B = B1, A = B2, Y = B3, X = B4, L = L1, R = R1, Select = S1, Start = S2<br/>SNES mouse：支持模拟摇杆。 Left Click = B1, Right Click = B2<br/>NES：支持十字键。 B = B1, A = B2, Select = S1, Start = S2</2>',
 	'snes-extension-clock-pin-label': 'Clock 引脚',
 	'snes-extension-latch-pin-label': 'Latch 引脚',
 	'snes-extension-data-pin-label': 'Data 引脚',


### PR DESCRIPTION
This PR fixes https://github.com/OpenStickCommunity/GP2040-CE/issues/1362

1. HTML font size now in line with other add-ons
2. Fixed corresponding replacement tags in i18n files
3. Added missing first paragraph from the en i18n to SNES.tsx
4. Fixed a spelling inconsistency (also for Wii add-on which uses identical string)
5. Fixed some mistakes in the German SNES string