### PR TITLE
Fix for broken nanopb build process

### DIFF
--- a/lib/nanopb/extra/requirements.txt
+++ b/lib/nanopb/extra/requirements.txt
@@ -1,2 +1,2 @@
 protobuf>=3.19
-grpcio-tools>=1.47.0
+grpcio-tools==1.71.0


### PR DESCRIPTION
Forces grpcio-tools to 1.71.0 to prevent breakage of protobuf build process. Temporary fix suggestion c/o @bvoo.