### PR TITLE
Fix for rndis crashing the i2c

### DIFF
--- a/lib/rndis/rndis.c
+++ b/lib/rndis/rndis.c
@@ -213,8 +213,8 @@ void tud_network_init_cb(void)
 
 int rndis_init(void)
 {
-  /* initialize TinyUSB */
-  tusb_init();
+  ///* initialize TinyUSB */
+  //tusb_init();
 
   /* initialize lwip, dhcp-server, dns-server, and http */
   init_lwip();

--- a/lib/rndis/rndis.c
+++ b/lib/rndis/rndis.c
@@ -213,6 +213,7 @@ void tud_network_init_cb(void)
 
 int rndis_init(void)
 {
+  // Removed as rndis defect 07-08-2025 as we need to setup TinyUSB to non-default values
   ///* initialize TinyUSB */
   //tusb_init();
 

--- a/src/drivers/net/NetDriver.cpp
+++ b/src/drivers/net/NetDriver.cpp
@@ -54,8 +54,6 @@ void NetDriver::initialize() {
         .xfer_cb          = netd_xfer_cb,
         .sof              = NULL,
     };
-
-    //rndis_init();
 }
 
 // Run RNDIS task from web config

--- a/src/drivers/net/NetDriver.cpp
+++ b/src/drivers/net/NetDriver.cpp
@@ -55,7 +55,7 @@ void NetDriver::initialize() {
         .sof              = NULL,
     };
 
-    rndis_init();
+    //rndis_init();
 }
 
 // Run RNDIS task from web config

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -36,6 +36,8 @@
 #include "pico/time.h"
 #include "hardware/adc.h"
 
+#include "rndis.h"
+
 // TinyUSB
 #include "tusb.h"
 
@@ -271,6 +273,10 @@ void GP2040::run() {
 
 	// Initialize our USB manager
 	USBHostManager::getInstance().start();
+
+	if (configMode == true ) {
+		rndis_init();
+	}
 
 	while (1) { // LOOP
 		this->getReinitGamepad(gamepad);


### PR DESCRIPTION
Moving rndis init slightly and removing tusb_inint from the rndis driver and lib

This was an issue with tinyusb ports being wrong when rndis_init would call tusb_init(); (thank you Peter Harper!)