### PR TITLE
Update wording for GPIO Pin instances

### DIFF
--- a/src/display/ui/screens/ConfigScreen.cpp
+++ b/src/display/ui/screens/ConfigScreen.cpp
@@ -40,8 +40,8 @@ void ConfigScreen::drawScreen() {
     getRenderer()->drawText(0, 1, version);
     getRenderer()->drawText(0, 2, "[http://192.168.7.1]");
     getRenderer()->drawText(0, 3, "Preview:");
-    getRenderer()->drawText(3, 4, "  B1 > Button");
-    getRenderer()->drawText(3, 5, "  B2 > Splash");
-    getRenderer()->drawText(3, 6, "  R2 > Pin Viewer");
-    getRenderer()->drawText(3, 7, "  L2 > Stats");
+    getRenderer()->drawText(0, 4, " B1 > Button");
+    getRenderer()->drawText(0, 5, " B2 > Splash");
+    getRenderer()->drawText(0, 6, " R2 > GPIO Pin Viewer");
+    getRenderer()->drawText(0, 7, " L2 > Stats");
 }

--- a/src/display/ui/screens/PinViewerScreen.cpp
+++ b/src/display/ui/screens/PinViewerScreen.cpp
@@ -15,12 +15,12 @@ void PinViewerScreen::drawScreen() {
     Mask_t pinValues = ~gpio_get_all();
     GpioMappingInfo* pinMappings = Storage::getInstance().getProfilePinMappings();
 
-    std::string pinsPressed = "PIN: ";
-    std::string pinsInUse = "In Use: ";
-    std::string pinsUndefined = "Undef: ";
-    std::string buttonsPressed = "BTN: ";
+    std::string pinsPressed = "GPIO Pin : ";
+    std::string pinsInUse = "In Use   : ";
+    std::string pinsUndefined = "Undefined: ";
+    std::string buttonsPressed = "Button   : ";
 
-    getRenderer()->drawText(5, 0, "[Pin Viewer]");
+    getRenderer()->drawText(2, 0, "[GPIO Pin Viewer]");
 
     for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++) {
         if ((pinMappings[pin].action > 0) && (pinMappings[pin].action != GpioAction::CUSTOM_BUTTON_COMBO)) {

--- a/www/src/Locales/en/PinMapping.jsx
+++ b/www/src/Locales/en/PinMapping.jsx
@@ -1,9 +1,9 @@
 export default {
-	'sub-header-text': `Use GPIO Pin Viewer to see button to GPIO pin connection.`,
+	'sub-header-text': `Use GPIO Pin Viewer to see button to GPIO Pin connection.`,
 	'alert-text':
 		"Mapping buttons to pins that aren't connected or available can leave the device in non-functional state. To clear the invalid configuration go to the <2>Reset Settings</2> page.",
 	'pin-viewer': 'GPIO Pin viewer',
-	'pin-pressed': 'Pressed pin: {{pressedPin}}',
+	'pin-pressed': 'Pressed GPIO Pin: {{pressedPin}}',
 	'profile-label-title': 'Profile name',
 	'profile-label-description':
 		'Max 16 characters. Letters, numbers, and spaces allowed.',


### PR DESCRIPTION
This PR updates instances of `Pin' to be `GPIO Pin` to be more clear in the web-config.  

This also updates what shows on a connected OLED to match.