### PR TITLE
Add no USB Data detected screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ src/display/ui/screens/RestartScreen.cpp
 src/display/ui/screens/StatsScreen.cpp
 src/display/ui/screens/SplashScreen.cpp
 src/display/ui/screens/DisplaySaverScreen.cpp
+src/display/ui/screens/NoUSBDetectedScreen.cpp
 src/display/GPGFX.cpp
 src/display/GPGFX_UI.cpp
 src/drivermanager.cpp

--- a/headers/display/GPGFX_UI_screens.h
+++ b/headers/display/GPGFX_UI_screens.h
@@ -9,13 +9,15 @@ enum DisplayMode {
     DISPLAY_SAVER,
     STATS,
     MAIN_MENU,
-    RESTART
+    RESTART,
+    NO_USB_DETECTED
 };
 
 #include "ui/screens/ButtonLayoutScreen.h"
 #include "ui/screens/ConfigScreen.h"
 #include "ui/screens/DisplaySaverScreen.h"
 #include "ui/screens/MainMenuScreen.h"
+#include "ui/screens/NoUSBDetectedScreen.h"
 #include "ui/screens/PinViewerScreen.h"
 #include "ui/screens/RestartScreen.h"
 #include "ui/screens/SplashScreen.h"

--- a/headers/display/ui/screens/NoUSBDetectedScreen.h
+++ b/headers/display/ui/screens/NoUSBDetectedScreen.h
@@ -1,0 +1,19 @@
+#ifndef _NOUSBDETECTED_H_
+#define _NOUSBDETECTED_H_
+
+#include "GPGFX_UI_widgets.h"
+
+class NoUSBDetectedScreen : public GPScreen {
+    public:
+        NoUSBDetectedScreen() {}
+        NoUSBDetectedScreen(GPGFX* renderer) { setRenderer(renderer); }
+        virtual ~NoUSBDetectedScreen() {}
+        virtual int8_t update();
+        virtual void init();
+        virtual void shutdown();
+
+    protected:
+        virtual void drawScreen();
+};
+
+#endif

--- a/src/addons/display.cpp
+++ b/src/addons/display.cpp
@@ -110,6 +110,9 @@ bool DisplayAddon::updateDisplayScreen() {
         case STATS:
             gpScreen = new StatsScreen(gpDisplay);
             break;
+        case NO_USB_DETECTED:
+            gpScreen = new NoUSBDetectedScreen(gpDisplay);
+            break;
         case RESTART:
             gpScreen = new RestartScreen(gpDisplay, bootMode);
             break;
@@ -176,6 +179,18 @@ void DisplayAddon::process() {
     if (gpDisplay->getDriver() == nullptr ||
         (!configMode && isDisplayPowerOff())) {
         return;
+    }
+
+    if (currDisplayMode != SPLASH) {
+        if (!tud_ready()) {
+            if (currDisplayMode != NO_USB_DETECTED) {
+                currDisplayMode = NO_USB_DETECTED;
+                updateDisplayScreen();
+            }
+        } else if (currDisplayMode == NO_USB_DETECTED) {
+            currDisplayMode = BUTTONS;
+            updateDisplayScreen();
+        }
     }
 
     // Core0 requested a new display mode

--- a/src/display/ui/screens/NoUSBDetectedScreen.cpp
+++ b/src/display/ui/screens/NoUSBDetectedScreen.cpp
@@ -1,0 +1,24 @@
+#include "NoUSBDetectedScreen.h"
+
+#include "BitmapScreens.h"
+
+#include "pico/stdlib.h"
+#include "system.h"
+
+void NoUSBDetectedScreen::init() {
+    getRenderer()->clearScreen();
+}
+
+void NoUSBDetectedScreen::shutdown() {
+    clearElements();
+}
+
+void NoUSBDetectedScreen::drawScreen() {
+    getRenderer()->drawSprite((uint8_t *)bitmapGP2040Logo, 128, 35, 10, 0, 2, 1);
+    getRenderer()->drawText(1, 6, "No USB Data Detected");
+    getRenderer()->drawText(1, 7, "Check Cable and Port");
+}
+
+int8_t NoUSBDetectedScreen::update() {
+    return -1; // -1 means no change in screen state
+}


### PR DESCRIPTION
This PR adds a screen that will pop up if no USB data is detected.  This is used to help diagnose bad USB cables and ports.