### PR TITLE
Allows mapping mouse to gamepad left/right stick

### DIFF
--- a/headers/addons/keyboard_host.h
+++ b/headers/addons/keyboard_host.h
@@ -15,6 +15,14 @@
 #define KEYBOARD_HOST_PIN_5V -1
 #endif
 
+#ifndef KEYBOARD_HOST_MOUSE_SENSITIVITY
+#define KEYBOARD_HOST_MOUSE_SENSITIVITY 50
+#endif
+
+#ifndef KEYBOARD_HOST_MOUSE_MOVEMENT
+#define KEYBOARD_HOST_MOUSE_MOVEMENT 0
+#endif
+
 // KeyboardHost Module Name
 #define KeyboardHostName "KeyboardHost"
 

--- a/headers/addons/keyboard_host_listener.h
+++ b/headers/addons/keyboard_host_listener.h
@@ -39,6 +39,7 @@ private:
     void preprocess_report();
     void process_kbd_report(uint8_t dev_addr, hid_keyboard_report_t const *report);
     void process_mouse_report(uint8_t dev_addr, hid_mouse_report_t const *report);
+    uint16_t scaleMouseToJoystick(int8_t mouseVal);
     KeyboardButtonMapping _keyboard_host_mapDpadUp;
     KeyboardButtonMapping _keyboard_host_mapDpadDown;
     KeyboardButtonMapping _keyboard_host_mapDpadLeft;
@@ -75,7 +76,6 @@ private:
     uint32_t mouseResetMS;
     uint32_t mouseResetNextTimer;
     int16_t joystickMid;
-    int32_t mouseScaleFactor;
     int16_t mouseX;
     int16_t mouseY;
     int16_t mouseZ;

--- a/headers/addons/keyboard_host_listener.h
+++ b/headers/addons/keyboard_host_listener.h
@@ -69,6 +69,13 @@ private:
     uint16_t mouseLeftMapping;
     uint16_t mouseMiddleMapping;
     uint16_t mouseRightMapping;
+    uint32_t mouseSensitivity;
+    uint8_t mouseMovementMode;
+    float mouseSensitivityScale;
+    uint32_t mouseResetMS;
+    uint32_t mouseResetNextTimer;
+    int16_t joystickMid;
+    int32_t mouseScaleFactor;
     int16_t mouseX;
     int16_t mouseY;
     int16_t mouseZ;

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -736,6 +736,8 @@ message KeyboardHostOptions
     optional uint32 mouseLeft = 5;
     optional uint32 mouseMiddle = 6;
     optional uint32 mouseRight = 7;
+    optional uint32 mouseSensitivity = 8;
+    optional MouseMovementMode movementMode = 9;
 }
 
 message GamepadUSBHostOptions

--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -607,3 +607,12 @@ enum GPEventType
     GP_EVENT_SYSTEM_REBOOT = 13;
     GP_EVENT_MENU_NAVIGATE = 14;
 };
+
+enum MouseMovementMode
+{
+    option (nanopb_enumopt).long_names = false;
+
+    MOUSE_MOVEMENT_NONE = 0;
+    MOUSE_MOVEMENT_LEFT_ANALOG = 1;
+    MOUSE_MOVEMENT_RIGHT_ANALOG = 2;
+};

--- a/src/addons/keyboard_host_listener.cpp
+++ b/src/addons/keyboard_host_listener.cpp
@@ -2,9 +2,12 @@
 #include "drivermanager.h"
 #include "storagemanager.h"
 #include "class/hid/hid_host.h"
+#include <algorithm>
 
 #define DEV_ADDR_NONE 0xFF
 #define MOUSE_SCALE_FACTOR (GAMEPAD_JOYSTICK_MID / 127)
+#define GAMEPAD_JOYSTICK_MIN_I32 static_cast<int32_t>(GAMEPAD_JOYSTICK_MIN)
+#define GAMEPAD_JOYSTICK_MAX_I32 static_cast<int32_t>(GAMEPAD_JOYSTICK_MAX)
 
 void KeyboardHostListener::setup() {
   const KeyboardHostOptions& keyboardHostOptions = Storage::getInstance().getAddonOptions().keyboardHostOptions;
@@ -233,8 +236,7 @@ void KeyboardHostListener::process_kbd_report(uint8_t dev_addr, hid_keyboard_rep
 
 uint16_t KeyboardHostListener::scaleMouseToJoystick(int8_t mouseVal) {
   int32_t result = joystickMid + (int32_t)mouseVal * mouseSensitivityScale * MOUSE_SCALE_FACTOR;
-  return result < GAMEPAD_JOYSTICK_MIN ? GAMEPAD_JOYSTICK_MIN :
-          (result > GAMEPAD_JOYSTICK_MAX ? GAMEPAD_JOYSTICK_MAX : result);
+  return std::clamp(result, GAMEPAD_JOYSTICK_MIN_I32, GAMEPAD_JOYSTICK_MAX_I32);
 }
 
 void KeyboardHostListener::process_mouse_report(uint8_t dev_addr, hid_mouse_report_t const * report)

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -825,6 +825,10 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions.mapping, keyButtonR3, KEY_BUTTON_R3);
     INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions.mapping, keyButtonA1, KEY_BUTTON_A1);
     INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions.mapping, keyButtonA2, KEY_BUTTON_A2);
+    INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions, mouseLeft, 0);
+    INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions, mouseMiddle, 0);
+    INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions, mouseRight, 0);
+    INIT_UNSET_PROPERTY(config.addonOptions.keyboardHostOptions, mouseSensitivity, KEYBOARD_HOST_MOUSE_SENSITIVITY);
 
     // addonOptions.focusModeOptions
     INIT_UNSET_PROPERTY(config.addonOptions.focusModeOptions, enabled, !!FOCUS_MODE_ENABLED);
@@ -1387,7 +1391,7 @@ void migrateTurboPinToGpio(Config& config) {
         }
         turboOptions.deprecatedButtonPin = -1; // set our turbo options to -1 for subsequent calls
     }
-    
+
     // Make sure we set PWM mode if we are using led pin
     if ( turboOptions.turboLedType == PLED_TYPE_NONE && isValidPin(turboOptions.ledPin) ) {
         turboOptions.turboLedType = PLED_TYPE_PWM;

--- a/src/webconfig.cpp
+++ b/src/webconfig.cpp
@@ -1265,7 +1265,7 @@ std::string getKeyMappings()
     writeDoc(doc, "E10", keyboardMapping.keyButtonE10);
     writeDoc(doc, "E11", keyboardMapping.keyButtonE11);
     writeDoc(doc, "E12", keyboardMapping.keyButtonE12);
-    
+
     return serialize_json(doc);
 }
 
@@ -1596,7 +1596,7 @@ std::string setAddonOptions()
     docToPin(turboOptions.shmupDialPin, doc, "pinShmupDial");
     docToValue(turboOptions.turboLedType, doc, "turboLedType");
     docToValue(turboOptions.turboLedIndex, doc, "turboLedIndex");
-    docToValue(turboOptions.turboLedColor, doc, "turboLedColor");    
+    docToValue(turboOptions.turboLedColor, doc, "turboLedColor");
     docToValue(turboOptions.enabled, doc, "TurboInputEnabled");
 
     WiiOptions& wiiOptions = Storage::getInstance().getAddonOptions().wiiOptions;
@@ -1633,6 +1633,8 @@ std::string setAddonOptions()
     docToValue(keyboardHostOptions.mouseLeft, doc, "keyboardHostMouseLeft");
     docToValue(keyboardHostOptions.mouseMiddle, doc, "keyboardHostMouseMiddle");
     docToValue(keyboardHostOptions.mouseRight, doc, "keyboardHostMouseRight");
+    docToValue(keyboardHostOptions.mouseSensitivity, doc, "keyboardHostMouseSensitivity");
+    docToValue(keyboardHostOptions.movementMode, doc, "keyboardHostMouseMovement");
 
     GamepadUSBHostOptions& gamepadUSBHostOptions = Storage::getInstance().getAddonOptions().gamepadUSBHostOptions;
     docToValue(gamepadUSBHostOptions.enabled, doc, "GamepadUSBHostAddonEnabled");
@@ -2056,6 +2058,8 @@ std::string getAddonOptions()
     writeDoc(doc, "keyboardHostMouseLeft", keyboardHostOptions.mouseLeft);
     writeDoc(doc, "keyboardHostMouseMiddle", keyboardHostOptions.mouseMiddle);
     writeDoc(doc, "keyboardHostMouseRight", keyboardHostOptions.mouseRight);
+    writeDoc(doc, "keyboardHostMouseSensitivity", keyboardHostOptions.mouseSensitivity);
+    writeDoc(doc, "keyboardHostMouseMovement", keyboardHostOptions.movementMode);
 
     const GamepadUSBHostOptions& gamepadUSBHostOptions = Storage::getInstance().getAddonOptions().gamepadUSBHostOptions;
     writeDoc(doc, "GamepadUSBHostAddonEnabled", gamepadUSBHostOptions.enabled);

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -512,6 +512,8 @@ app.get('/api/getAddonsOptions', (req, res) => {
 		keyboardHostMouseLeft: 0,
 		keyboardHostMouseMiddle: 0,
 		keyboardHostMouseRight: 0,
+		keyboardHostMouseSensitivity: 50,
+		keyboardHostMouseMovement: 0,
 		AnalogInputEnabled: 1,
 		BoardLedAddonEnabled: 1,
 		FocusModeAddonEnabled: 1,

--- a/www/src/Addons/Keyboard.tsx
+++ b/www/src/Addons/Keyboard.tsx
@@ -1,12 +1,13 @@
 import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { FormCheck, Row, FormLabel } from 'react-bootstrap';
+import { FormCheck, Row, FormLabel, Form } from 'react-bootstrap';
 import { NavLink } from 'react-router-dom';
 import * as yup from 'yup';
 
 import Section from '../Components/Section';
 
 import FormSelect from '../Components/FormSelect';
+import FormControl from '../Components/FormControl';
 import KeyboardMapper from '../Components/KeyboardMapper';
 import { baseButtonMappings } from '../Services/WebApi';
 import { AppContext } from '../Contexts/AppContext';
@@ -40,6 +41,8 @@ export const keyboardScheme = {
 			'KeyboardHostAddonEnabled',
 			BUTTON_MASKS_OPTIONS,
 		),
+	keyboardHostMouseSensitivity: yup.number().required().min(1).max(100),
+	keyboardHostMouseMovement: yup.string().required().oneOf(['0', '1', '2']),
 };
 
 export const keyboardState = {
@@ -48,6 +51,8 @@ export const keyboardState = {
 	keyboardHostMouseMiddle: 0,
 	keyboardHostMouseRight: 0,
 	KeyboardHostAddonEnabled: 0,
+	keyboardHostMouseSensitivity: 0,
+	keyboardHostMouseMovement: 0,
 };
 
 const excludedButtons = [
@@ -86,15 +91,16 @@ const Keyboard = ({
 	};
 
 	return (
-		<Section title={
-			<a
-				href="https://gp2040-ce.info/add-ons/keyboard-host"
-				target="_blank"
-				className="text-reset text-decoration-none"
-			>
-				{t('AddonsConfig:keyboard-host-header-text')}
-			</a>
-		}
+		<Section
+			title={
+				<a
+					href="https://gp2040-ce.info/add-ons/keyboard-host"
+					target="_blank"
+					className="text-reset text-decoration-none"
+				>
+					{t('AddonsConfig:keyboard-host-header-text')}
+				</a>
+			}
 		>
 			<div
 				id="KeyboardHostAddonOptions"
@@ -103,7 +109,10 @@ const Keyboard = ({
 				}
 			>
 				<div className="alert alert-info" role="alert">
-					The D+ and Enable 5V pins and GPIO Pin Order are configured in <a href="../peripheral-mapping" className="alert-link">Peripheral Mapping</a>
+					The D+ and Enable 5V pins and GPIO Pin Order are configured in{' '}
+					<a href="../peripheral-mapping" className="alert-link">
+						Peripheral Mapping
+					</a>
 				</div>
 				<Row className="mb-3">
 					<p>{t('AddonsConfig:keyboard-host-sub-header-text')}</p>
@@ -168,6 +177,71 @@ const Keyboard = ({
 								</option>
 							))}
 						</FormSelect>
+					</div>
+					<div className="col-sm-12 mb-2">
+						<Form.Label>{`${t('AddonsConfig:keyboard-host-mouse-sensitivity')}: ${values.keyboardHostMouseSensitivity}%`}</Form.Label>
+						<Form.Range
+							name="keyboardHostMouseSensitivity"
+							id={`keyboardHostMouseSensitivity`}
+							min={1}
+							max={100}
+							step={1}
+							value={values.keyboardHostMouseSensitivity}
+							onChange={handleChange}
+						/>
+					</div>
+					<div className="col-sm-12 mb-2">
+						<Form.Label>
+							{t('AddonsConfig:keyboard-host-mouse-movement')}
+						</Form.Label>
+						<div className="d-flex gap-3">
+							<FormCheck
+								type="radio"
+								id="mouseMovementNone"
+								label={t('AddonsConfig:keyboard-host-mouse-movement-none')}
+								name="keyboardHostMouseMovement"
+								value={0}
+								checked={values.keyboardHostMouseMovement === 0}
+								onChange={(e) => {
+									setFieldValue(
+										'keyboardHostMouseMovement',
+										parseInt(e.target.value),
+									);
+								}}
+							/>
+							<FormCheck
+								type="radio"
+								id="mouseMovementLeftAnalog"
+								label={t(
+									'AddonsConfig:keyboard-host-mouse-movement-left-analog',
+								)}
+								name="keyboardHostMouseMovement"
+								value={1}
+								checked={values.keyboardHostMouseMovement === 1}
+								onChange={(e) => {
+									setFieldValue(
+										'keyboardHostMouseMovement',
+										parseInt(e.target.value),
+									);
+								}}
+							/>
+							<FormCheck
+								type="radio"
+								id="mouseMovementRightAnalog"
+								label={t(
+									'AddonsConfig:keyboard-host-mouse-movement-right-analog',
+								)}
+								name="keyboardHostMouseMovement"
+								value={2}
+								checked={values.keyboardHostMouseMovement === 2}
+								onChange={(e) => {
+									setFieldValue(
+										'keyboardHostMouseMovement',
+										parseInt(e.target.value),
+									);
+								}}
+							/>
+						</div>
 					</div>
 				</Row>
 			</div>

--- a/www/src/Locales/en/AddonsConfig.jsx
+++ b/www/src/Locales/en/AddonsConfig.jsx
@@ -138,6 +138,11 @@ export default {
 	'keyboard-host-left-mouse': 'Left',
 	'keyboard-host-middle-mouse': 'Middle',
 	'keyboard-host-right-mouse': 'Right',
+	'keyboard-host-mouse-sensitivity': 'Mouse Sensitivity',
+	'keyboard-host-mouse-movement': 'Mouse Movement',
+	'keyboard-host-mouse-movement-none': 'None',
+	'keyboard-host-mouse-movement-left-analog': 'Left Analog',
+	'keyboard-host-mouse-movement-right-analog': 'Right Analog',
 	'pin-config-moved-to-core-text':
 		'Note: GPIO pins for this add-on are configured in <0>GPIO Pin Mapping</0>',
 	'input-history-header-text': 'Input History',


### PR DESCRIPTION
Keyboard host addon settings:
<img width="922" height="275" alt="Screenshot 2025-08-19 at 22 50 38" src="https://github.com/user-attachments/assets/d0f1d5d0-907b-4299-8085-c831039bf181" />

Example playing witcher on ps5:
https://github.com/user-attachments/assets/d89693fb-5c2d-4586-bda8-4d1339cfcbaa

