### PR TITLE
Fixes dpad to analog being interrupted by mouse movement input to resolve #1515

### DIFF
--- a/src/addons/keyboard_host_listener.cpp
+++ b/src/addons/keyboard_host_listener.cpp
@@ -174,13 +174,20 @@ uint8_t KeyboardHostListener::getKeycodeFromModifier(uint8_t modifier) {
 
 void KeyboardHostListener::preprocess_report()
 {
-
-  _keyboard_host_state.dpad = 0;
   _keyboard_host_state.buttons = 0;
-  _keyboard_host_state.lx = joystickMid;
-  _keyboard_host_state.ly = joystickMid;
-  _keyboard_host_state.rx = joystickMid;
-  _keyboard_host_state.ry = joystickMid;
+  // --- preprocess only select analog movements --- // (by Pelsin)
+  if (mouseMovementMode == MOUSE_MOVEMENT_LEFT_ANALOG) {
+    _keyboard_host_state.lx = joystickMid;
+    _keyboard_host_state.ly = joystickMid;
+  } else if (mouseMovementMode == MOUSE_MOVEMENT_RIGHT_ANALOG) {
+    _keyboard_host_state.rx = joystickMid;
+    _keyboard_host_state.ry = joystickMid;
+  } else {
+    _keyboard_host_state.lx = joystickMid;
+    _keyboard_host_state.ly = joystickMid;
+    _keyboard_host_state.rx = joystickMid;
+    _keyboard_host_state.ry = joystickMid;
+  }
   _keyboard_host_state.lt = 0;
   _keyboard_host_state.rt = 0;
 }
@@ -189,6 +196,8 @@ void KeyboardHostListener::preprocess_report()
 void KeyboardHostListener::process_kbd_report(uint8_t dev_addr, hid_keyboard_report_t const *report)
 {
   preprocess_report();
+  // move this preprocess dpad reset only to kbd_report (so as to not have it run on mouse input, by Fran89)
+  _keyboard_host_state.dpad = 0;
 
   // make this 13 instead of 7 to include modifier bitfields from hid_keyboard_modifier_bm_t
   for(uint8_t i=0; i<13; i++)
@@ -261,7 +270,7 @@ void KeyboardHostListener::process_mouse_report(uint8_t dev_addr, hid_mouse_repo
   }
 
   mouseResetNextTimer = getMillis() + mouseResetMS;
-
+  //-------- report correct analog move --------// (by Pelsin)
   if (mouseMovementMode == MOUSE_MOVEMENT_LEFT_ANALOG) {
     _keyboard_host_state.lx = scaleMouseToJoystick(report->x);
     _keyboard_host_state.ly = scaleMouseToJoystick(report->y);


### PR DESCRIPTION
This is my attempt to fix the problem of the dpad interruption whenever the mouse report movement input. The issue lies in the preprocess_report function. Inside it uses a function to zero out the dpad input, no doubt useful when keyboard input is pressed, however the mouse_report() also uses it when updating right analog input and thus both dpad to left analog and mouse right analog cannot be used at the same time (extremely useful for mapping first-person shooters, to gyro controls on Switch). I have included Pelsin's updated code and moved the dpad zero function to the line after the preprocess call on kbd_report() and it seems to have fixed the problem.

However, I believe this need testing as I'm not sure of potential conflicts, or edge-cases that might arise from this change in code. I'm only pull requesting it so that others might test it, or help in fixing this. Currently, I have tested it very limitedly on both PC and Switch.