### PR TITLE
Remove "Pr:" from top display bar

### DIFF
--- a/src/display/ui/screens/ButtonLayoutScreen.cpp
+++ b/src/display/ui/screens/ButtonLayoutScreen.cpp
@@ -245,7 +245,7 @@ void ButtonLayoutScreen::generateHeader() {
     if (showMacroMode && macroEnabled) statusBar += " M";
 
     if (showProfileMode) {
-        statusBar += " Pr:";
+        statusBar += " ";
 
         std::string profile;
         profile.assign(storage.currentProfileLabel(), strlen(storage.currentProfileLabel()));


### PR DESCRIPTION
This PR will remove the "Pr:" leading characters from displaying when you choose to display the profile name.  This will give players more character spaces to have their profile names shown.