### PR TITLE
Make sure to reset ordering when creating the ledmap

### DIFF
--- a/www/src/Pages/LEDConfigPage.jsx
+++ b/www/src/Pages/LEDConfigPage.jsx
@@ -187,7 +187,7 @@ const getLedButtons = (buttonLabels, map, excludeNulls, swapTpShareLabels) => {
 const createLedMap = (ledButtons, clear) => {
 	if (!ledButtons) return;
 	return ledButtons.reduce(
-		(acc, btn) => ({ ...acc, [btn.id]: clear ? null : btn.value }),
+		(acc, btn, index) => ({ ...acc, [btn.id]: clear ? null : index }),
 		{},
 	);
 };


### PR DESCRIPTION
Moving non-last assigned button breaks the chain.

The was the result of disabling left. Notice how down should start at 0 and not 1

``` json
{
    "S1": null,
    "S2": null,
    "Left": null,
    "Down": 1,
    "Right": 2,
    "Up": 3,
    "B3": 4,
    "B4": 5,
    "R1": 6,
    "L1": 7,
    "B1": 8,
    "B2": 9,
    "R2": 10,
    "L2": 11,
    "A1": 12,
    "L3": 13,
    "R3": 14,
    "A2": 15
}
```