### PR TITLE
Add build method using Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,5 @@ modules/Custom.cmake
 cmake-*
 env.ini
 
-# Container
-.devcontainer
-*Dockerfile
-*docker-compose.yml
 www/src_gen/enums.ts
 /lib/NeoPico/src/generated/ws2812.pio.h

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  gp2040-ce-build:
+    image: gp2040-ce-build-image
+    container_name: gp2040-ce-build-container
+    build:
+      context: .
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    environment:
+      - GP2040_BOARDCONFIG=${GP2040_BOARDCONFIG:-Pico}
+      - PICO_BOARD=${PICO_BOARD:-pico}
+      - SKIP_WEBBUILD=${SKIP_WEBBUILD:-FALSE}
+      - SKIP_SUBMODULES=${SKIP_SUBMODULES:-FALSE}
+    command: >
+      bash -c "rm -rf build &&
+        mkdir build &&
+        cd build &&
+        cmake .. &&
+        make"
+
+    

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-rm -rf build 
-mkdir build 
-cd build 
-cmake .. 
-make

--- a/dockerfile
+++ b/dockerfile
@@ -35,7 +35,3 @@ RUN apt-get update && apt-get install -y \
 RUN git config --global --add safe.directory /workspace
 RUN git config --global --add safe.directory /workspace/lib/pico_pio_usb
 RUN git config --global --add safe.directory /workspace/lib/tinyusb
-
-WORKDIR /workspace
-
-CMD ["/workspace/docker/build.sh"]


### PR DESCRIPTION
Add a method for compiling using Docker containers, due to the difficulties that can be encountered with dependencies on different operating systems.

To compile and generate the `.uf2` files:
`docker compose up --build`

Alternatively, you can add environment variables as arguments, like this:
`GP2040_BOARDCONFIG='Pico' PICO_BOARD='pico' docker compose up --build`

Tested on Linux (Manjaro) and Windows.

MacOS testing is still pending.

Site PR: https://github.com/OpenStickCommunity/Site/pull/115