### PR TITLE
Bump actions, inline pico-sdk build step, fix GCC MD5 mismatch issue

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -93,16 +93,27 @@ jobs:
 
       #Global Setup
       - name: Checkout GP2040-CE
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Setup SDK pipeline
-        uses: Fortinbra/RaspberryPiPicoBuild@v7
+      - name: arm-none-eabi-gcc GNU Arm Embedded Toolchain
+        uses: carlosperate/arm-none-eabi-gcc-action@v1.11.1
+
+      - name: Checkout pico-sdk/2.1.1
+        uses: actions/checkout@v6.0.1
+        with:
+          repository: raspberrypi/pico-sdk
+          ref: 2.1.1
+          path: pico-sdk
+
+      - name: Checkout pico-sdk submodules
+        working-directory: ${{github.workspace}}/pico-sdk
+        run: git submodule update --init
 
       - name: Download a Build Artifact
-        uses: actions/download-artifact@v4.1.2
+        uses: actions/download-artifact@v7.0.0
         with:
           name: fsData
           path: ${{github.workspace}}/lib/httpd/
@@ -121,7 +132,7 @@ jobs:
         run: GP2040_BOARDCONFIG=${{ matrix.GP2040_BOARDCONFIG }} cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel ${{steps.core_count.outputs.output}}
 
       - name: Upload Pico Artifact
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: GP2040-CE - ${{ matrix.GP2040_BOARDCONFIG }}
           path: ${{github.workspace}}/build/GP2040-CE_*_${{ matrix.GP2040_BOARDCONFIG }}.uf2
@@ -129,7 +140,7 @@ jobs:
 
       - name: Upload .elf Artifact
         if: ${{ matrix.GP2040_BOARDCONFIG == 'Pico'}}
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: elf
           path: ${{github.workspace}}/build/GP2040-CE_*_${{ matrix.GP2040_BOARDCONFIG }}.elf

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v6.0.1
 
     - name: Use Node.js
-      uses: actions/setup-node@v4.4.0
+      uses: actions/setup-node@v6.1.0
       with:
         node-version: '20.x'
         cache: 'npm'
@@ -30,7 +30,7 @@ jobs:
       run: CI=false npm run build --if-present
 
     - name: Upload www Artifact
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@v6.0.0
       with:
         name: fsData
         path: ${{github.workspace}}/lib/httpd/fsdata.c


### PR DESCRIPTION
Currently, new forks can't compile with GH actions because of:
https://github.com/carlosperate/arm-none-eabi-gcc-action/issues/74

We have a cache for gcc-arm-none-eabi since 6 months back, hence it working for us: https://github.com/OpenStickCommunity/GP2040-CE/actions/caches

This also inlines the build steps that previously where in: https://github.com/Fortinbra/RaspberryPiPicoBuild