### PR TITLE
Add support for GP2040-CE as a PS4 auth provider

### DIFF
--- a/headers/tusb_config.h
+++ b/headers/tusb_config.h
@@ -147,7 +147,7 @@
 //--------------------------------------------------------------------
 
 // Size of buffer to hold descriptors and other data used for enumeration
-#define CFG_TUH_ENUMERATION_BUFSIZE 256
+#define CFG_TUH_ENUMERATION_BUFSIZE 512
 
 #define CFG_TUH_HUB                 1
 // max device support (excluding hub device)

--- a/src/drivers/ps4/PS4AuthUSBListener.cpp
+++ b/src/drivers/ps4/PS4AuthUSBListener.cpp
@@ -24,7 +24,7 @@ void PS4AuthUSBListener::process() {
             // Once Console is ready with the nonce, begin!
             if ( ps4AuthData->passthrough_state == GPAuthState::send_auth_console_to_dongle ) {
                 memcpy(report_buffer, output_0xf3, sizeof(output_0xf3));
-                host_get_report(PS4AuthReport::PS4_RESET_AUTH, report_buffer, sizeof(output_0xf3));
+                host_get_report(PS4AuthReport::PS4_RESET_AUTH, report_buffer, sizeof(output_0xf3) + 1);
             }
             break;
         case PS4State::receiving_nonce:


### PR DESCRIPTION
Increases the size of the buffer used for storing the report descriptor of the connected device and fixes the request length for 0xF3 GET_REPORT.

This lets us daisy chain controllers, plugging the auth dongle into the last one in the chain.