### PR TITLE
Fix for truncation/corruption on long json responses in webconfig

### DIFF
--- a/src/webconfig.cpp
+++ b/src/webconfig.cpp
@@ -261,7 +261,7 @@ int set_file_data(fs_file* file, const DataAndStatusCode& dataAndStatusCode)
     
     file->data = returnData->c_str();
     file->len = returnData->size();
-    file->index = file->len;
+    file->index = 0;
     file->http_header_included = true;
     file->pextension = returnData;  // store for cleanup
     file->is_custom_file = 1;


### PR DESCRIPTION
## Description
Fixed truncated/corrupted json responses. In webconfig.cpp set_file_data() had a line which set the file index to its length. I think this was accidentally working, but with long json responses was causing responses to get truncated (I was observing a single character getting cut off the json response, the closing bracket). It's possible the index was wrapping around back around via a modulus operation somewhere, but set to 1 instead of 0. Looking at the dependency, the index should indicate how much of the file has been sent out so far, which I believe should always start at zero, as we are initializing the response here.

## Proposed Changes
-  file->index = 0

## Type of Change
- [X ] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Instructions
Testing is difficult here in the main branch, as our json responses aren't usually long enough to trigger the original bug, but I and other developers have noticed the bug with features that return longer responses (Pod, for example).