### PR TITLE
Prevents BOARD_LED_PIN from being overwritten in BOARD_LED add-on

### DIFF
--- a/headers/addons/board_led.h
+++ b/headers/addons/board_led.h
@@ -20,11 +20,14 @@
 // BoardLed Module Name
 #define OnBoardLedName "OnBoardLed"
 
-#ifdef PICO_DEFAULT_LED_PIN
 #ifndef BOARD_LED_PIN
+#ifdef PICO_DEFAULT_LED_PIN
 #define BOARD_LED_PIN PICO_DEFAULT_LED_PIN
+#else
+#define BOARD_LED_PIN 25
 #endif
 #endif
+
 #define BLINK_INTERVAL_USB_UNMOUNTED 200
 #define BLINK_INTERVAL_CONFIG_MODE 1000
 

--- a/headers/addons/board_led.h
+++ b/headers/addons/board_led.h
@@ -20,8 +20,10 @@
 // BoardLed Module Name
 #define OnBoardLedName "OnBoardLed"
 
+#ifdef PICO_DEFAULT_LED_PIN
 #ifndef BOARD_LED_PIN
 #define BOARD_LED_PIN PICO_DEFAULT_LED_PIN
+#endif
 #endif
 #define BLINK_INTERVAL_USB_UNMOUNTED 200
 #define BLINK_INTERVAL_CONFIG_MODE 1000

--- a/headers/addons/board_led.h
+++ b/headers/addons/board_led.h
@@ -21,7 +21,7 @@
 #define OnBoardLedName "OnBoardLed"
 
 #ifndef BOARD_LED_PIN
-#define BOARD_LED_PIN 25
+#define BOARD_LED_PIN PICO_DEFAULT_LED_PIN
 #endif
 #define BLINK_INTERVAL_USB_UNMOUNTED 200
 #define BLINK_INTERVAL_CONFIG_MODE 1000

--- a/headers/addons/board_led.h
+++ b/headers/addons/board_led.h
@@ -20,7 +20,9 @@
 // BoardLed Module Name
 #define OnBoardLedName "OnBoardLed"
 
+#ifndef BOARD_LED_PIN
 #define BOARD_LED_PIN 25
+#endif
 #define BLINK_INTERVAL_USB_UNMOUNTED 200
 #define BLINK_INTERVAL_CONFIG_MODE 1000
 


### PR DESCRIPTION
Currently, the `BOARD_LED_PIN` gets overwritten by the board LED add-on. This fix prevents this from happening.


