### PR TITLE
Add GPIO28 and 29 to I2C block 0

### DIFF
--- a/www/src/Data/Peripherals.ts
+++ b/www/src/Data/Peripherals.ts
@@ -2,7 +2,7 @@ export const I2C_BLOCKS = [
 	{
 		label: 'i2c0',
 		value: 0,
-		pins: { sda: [0, 4, 8, 12, 16, 20], scl: [1, 5, 9, 13, 17, 21] },
+		pins: { sda: [0, 4, 8, 12, 16, 20, 28], scl: [1, 5, 9, 13, 17, 21, 29] },
 	},
 	{
 		label: 'i2c1',


### PR DESCRIPTION
Allows the user to select GPIO pins 28 and 29 for I2C block 0 in the web configuration tool, Waveshare Pico Zero specific change since said pins are to easier to access (depending on mounting) compared to pins 17 to 25.