### PR TITLE
Assignable Hotkey Actions for web-config and USB mode

### DIFF
--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -461,6 +461,8 @@ enum GamepadHotkey
     HOTKEY_RS_DOWN               = 83;
     HOTKEY_RS_LEFT               = 84;
     HOTKEY_RS_RIGHT              = 85;
+    HOTKEY_REBOOT_WEBCONFIG      = 86;
+    HOTKEY_REBOOT_USB            = 87;
 }
 
 enum AnimationEffects

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -577,6 +577,16 @@ void Gamepad::processHotkeyAction(GamepadHotkey action) {
 				System::reboot(System::BootMode::DEFAULT);
 			}
 			break;
+		case HOTKEY_REBOOT_WEBCONFIG:
+			if (action != lastAction) {
+				System::reboot(System::BootMode::WEBCONFIG);
+			}
+			break;
+		case HOTKEY_REBOOT_USB:
+			if (action != lastAction) {
+				System::reboot(System::BootMode::USB);
+			}
+			break;
 		case HOTKEY_SAVE_CONFIG:
 			if (action != lastAction) {
 				Storage::getInstance().save(true);

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -136,6 +136,8 @@ export default {
 		'load-profile-5': 'Load Profile #5',
 		'load-profile-6': 'Load Profile #6',
 		'reboot-default': 'Reboot GP2040-CE',
+		'reboot-webconfig': 'Reboot GP2040-CE into web-config mode',
+		'reboot-usb': 'Reboot GP2040-CE into BOOTSEL/USB mode',
 		'save-config': 'Save Config',
 		'next-profile': 'Next Profile',
 		'previous-profile': 'Previous Profile',

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -322,6 +322,8 @@ const HOTKEY_ACTIONS = [
 	{ labelKey: 'hotkey-actions.r3-button', value: 20 },
 	{ labelKey: 'hotkey-actions.touchpad-button', value: 21 },
 	{ labelKey: 'hotkey-actions.reboot-default', value: 22 },
+	{ labelKey: 'hotkey-actions.reboot-webconfig', value: 86 },
+	{ labelKey: 'hotkey-actions.reboot-usb', value: 87 },
 	{ labelKey: 'hotkey-actions.save-config', value: 43 },
 	{ labelKey: 'hotkey-actions.b1-button', value: 23 },
 	{ labelKey: 'hotkey-actions.b2-button', value: 24 },


### PR DESCRIPTION
I'm building a joystick with only 3 physical buttons (B1, B2 and Fn) and would like to be able to access both web-config and USB mode without having to open the case and access the physical buttons on the RP2040 Mini Breakout Board I am using.

There is already a hotkey action for **Reboot GP2040** (reboots into default/controller mode). This PR adds hotkey actions for **Reboot GP2040 into web-config mode** and **Reboot GP2040 into BOOTSEL/USB mode**.

Build tested and working as intended on the RP2040 Mini Breakout Board v7.5E Passthrough Edition.
