### PR TITLE
Fixed REVERSE_X_DEFAULT typo in identifier

### DIFF
--- a/headers/addons/reverse.h
+++ b/headers/addons/reverse.h
@@ -17,7 +17,7 @@
 #define REVERSE_LED_PIN -1
 #endif
 
-#ifndef REVERSE_UP_DEFUALT
+#ifndef REVERSE_UP_DEFAULT
 #define REVERSE_UP_DEFAULT 0
 #endif
 
@@ -29,7 +29,7 @@
 #define REVERSE_LEFT_DEFAULT 0
 #endif
 
-#ifndef REVERSE_RIGHT_DEFUALT
+#ifndef REVERSE_RIGHT_DEFAULT
 #define REVERSE_RIGHT_DEFAULT 0
 #endif
 


### PR DESCRIPTION
2 liner typo fix.  I ran into this compilation issue when trying to compile a custom config and the compiler identified two places where the identifier was being defined.