### PR TITLE
use the original dpad input, not the modified dpad output, in hotkeys

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -69,7 +69,7 @@ public:
 	 * @brief Check for a dpad press. Used by `pressed[Dpad]` helper methods.
 	 */
 	inline bool __attribute__((always_inline)) pressedDpad(const uint8_t mask) {
-		return (state.dpad & mask) == mask;
+		return (state.dpadOriginal & mask) == mask;
 	}
 
 	/**

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -277,9 +277,6 @@ void Gamepad::process()
 		state.dpad = filterToFourWayMode(state.dpad);
 	}
 
-	// hold current dpad state regardless of input
-	state.dpadOriginal = state.dpad;
-
 	// stash digital-only dpad state for later
 	uint8_t dpadOnlyMask = ((state.dpadOriginal & 0xF0) >> 4);
 
@@ -372,6 +369,9 @@ void Gamepad::read()
 		| ((values & mapButtonE11->pinMask) ? mapButtonE11->buttonMask : 0)
 		| ((values & mapButtonE12->pinMask) ? mapButtonE12->buttonMask : 0)
 	;
+
+	// hold current dpad state regardless of input mode -> output, which is determined in process()
+	state.dpadOriginal = state.dpad;
 
 	// set the effective dpad mode based on settings + overrides
 	if (values & mapButtonDP->pinMask)	activeDpadMode = DpadMode::DPAD_MODE_DIGITAL;


### PR DESCRIPTION
hotkey processing used to be before the core gamepad process, so it was reading the unmodified dpad input, but #1593 moved hotkey processing to after, so what it ends up reading is the output, which gets bits masked off of it when in LS/RS mode (so as to not do a double output of a direction in LS and DP outputs, when that's likely not intended). all the code involved here makes sense, but it broke in tandem as an order of operations sequence.

this separates the concerns by having the hotkey dpad read use dpadOriginal, which is only used for the display, but is exactly what we need --- the dpad input element, untouched by gamepad output processing. I moved where dpadOriginal gets set in order to make its purpose clearer --- it happens on read(), now, not process()ing.

fixes #1634