### PR TITLE
Update layout manage to fallback if no ALT layout exists

### DIFF
--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -2,6 +2,7 @@
 
 #include "config.pb.h"
 #include "enums.pb.h"
+#include "layoutmanager.h"
 #include "pb_encode.h"
 #include "pb_decode.h"
 #include "pb_common.h"
@@ -420,6 +421,20 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.displayOptions, deprecatedI2cSpeed, I2C_SPEED);
     INIT_UNSET_PROPERTY(config.displayOptions, buttonLayout, BUTTON_LAYOUT);
     INIT_UNSET_PROPERTY(config.displayOptions, buttonLayoutRight, BUTTON_LAYOUT_RIGHT);
+
+    // If the stored layout is a board-defined ALT not compiled into the flashed board configuration, reset to board default
+    if (config.displayOptions.buttonLayout >= BUTTON_LAYOUT_BOARD_DEFINED_ALT0_A &&
+        config.displayOptions.buttonLayout <= BUTTON_LAYOUT_BOARD_DEFINED_ALT7_A &&
+        LayoutManager::getInstance().getLeftLayout((ButtonLayout)config.displayOptions.buttonLayout).empty()) {
+        config.displayOptions.buttonLayout = BUTTON_LAYOUT;
+        }
+
+    if (config.displayOptions.buttonLayoutRight >= BUTTON_LAYOUT_BOARD_DEFINED_ALT0_B &&
+        config.displayOptions.buttonLayoutRight <= BUTTON_LAYOUT_BOARD_DEFINED_ALT7_B &&
+        LayoutManager::getInstance().getRightLayout((ButtonLayout)config.displayOptions.buttonLayoutRight).empty()) {
+        config.displayOptions.buttonLayoutRight = BUTTON_LAYOUT_RIGHT;
+        }
+
     INIT_UNSET_PROPERTY(config.displayOptions, turnOffWhenSuspended, DISPLAY_TURN_OFF_WHEN_SUSPENDED);
     INIT_UNSET_PROPERTY(config.displayOptions, inputMode, DISPLAY_INPUT_MODE);
     INIT_UNSET_PROPERTY(config.displayOptions, turboMode, DISPLAY_TURBO_MODE);

--- a/src/layoutmanager.cpp
+++ b/src/layoutmanager.cpp
@@ -9,13 +9,20 @@ LayoutManager::LayoutList LayoutManager::getLayoutA() {
     if (options.buttonLayoutOrientation != BUTTON_ORIENTATION_DEFAULT) {
         uint16_t layoutRight = options.buttonLayoutRight;
         LayoutManager::LayoutList rightLayout = getRightLayout(layoutRight);
+        if (rightLayout.empty() && layoutRight >= BUTTON_LAYOUT_BOARD_DEFINED_ALT0_B && layoutRight <= BUTTON_LAYOUT_BOARD_DEFINED_ALT7_B) {
+            rightLayout = drawBoardDefinedB();
+        }
         if (options.buttonLayoutOrientation == BUTTON_ORIENTATION_SWITCHED) {
             return adjustByOffset(rightLayout, -64);
         } else {
             return adjustByOffset(flipHorizontally(rightLayout, 64, 0, 128, 0), -64);
         }
     } else {
-        return getLeftLayout(layoutLeft);
+        LayoutList layout = getLeftLayout(layoutLeft);
+        if (layout.empty() && layoutLeft >= BUTTON_LAYOUT_BOARD_DEFINED_ALT0_A && layoutLeft <= BUTTON_LAYOUT_BOARD_DEFINED_ALT7_A) {
+            return drawBoardDefinedA();
+        }
+        return layout;
     }
 }
 
@@ -25,13 +32,19 @@ LayoutManager::LayoutList LayoutManager::getLayoutB() {
     if (options.buttonLayoutOrientation != BUTTON_ORIENTATION_DEFAULT) {
         uint16_t layoutLeft = options.buttonLayout;
         LayoutManager::LayoutList leftLayout = getLeftLayout(layoutLeft);
+        if (leftLayout.empty() && layoutLeft >= BUTTON_LAYOUT_BOARD_DEFINED_ALT0_A && layoutLeft <= BUTTON_LAYOUT_BOARD_DEFINED_ALT7_A) {
+            leftLayout = drawBoardDefinedA();
+        }
         if (options.buttonLayoutOrientation == BUTTON_ORIENTATION_SWITCHED) {
             return adjustByOffset(leftLayout, 64);
         } else {
             return adjustByOffset(flipHorizontally(leftLayout, 0, 0, 64, 0), 64);
         }
     } else {
-        return getRightLayout(layoutRight);
+        LayoutList layout = getRightLayout(layoutRight);
+        if (layout.empty() && layoutRight >= BUTTON_LAYOUT_BOARD_DEFINED_ALT0_B && layoutRight <= BUTTON_LAYOUT_BOARD_DEFINED_ALT7_B)
+            return drawBoardDefinedB();
+        return layout;
     }
 }
 


### PR DESCRIPTION
This PR allows layout manage to fallback if you overwrite a firmware with another version that does not have the available and currently set ALT display layout