### PR TITLE
:bug: Fix Macro D-Pad inputs being dropped & clearly separate physical vs processed D-Pad checks

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -69,6 +69,13 @@ public:
 	 * @brief Check for a dpad press. Used by `pressed[Dpad]` helper methods.
 	 */
 	inline bool __attribute__((always_inline)) pressedDpad(const uint8_t mask) {
+		return (state.dpad & mask) == mask;
+	}
+
+	/**
+	 * @brief Check for a raw, physical dpad press. Unaffected by macros, SOCD, or D-pad modes. Typically used for hotkey detection.
+	 */
+	inline bool __attribute__((always_inline)) pressedDpadPhysical(const uint8_t mask) {
 		return (state.dpadOriginal & mask) == mask;
 	}
 
@@ -84,7 +91,7 @@ public:
 	 */
 	inline bool __attribute__((always_inline)) pressedHotkey(const HotkeyEntry &hotkey) {
 		return (hotkey.action != 0 && pressedButton(hotkey.buttonsMask) &&
-				pressedDpad(hotkey.dpadMask) && pressedAux(hotkey.auxMask));
+				pressedDpadPhysical(hotkey.dpadMask) && pressedAux(hotkey.auxMask));
 	}
 
 	/**

--- a/src/addons/reactiveleds.cpp
+++ b/src/addons/reactiveleds.cpp
@@ -52,10 +52,10 @@ void ReactiveLEDAddon::process() {
         if (isValidPin(ledPins[led].pinNumber) && ledPins[led].action != GpioAction::NONE) {
             ledPins[led].currUpdate = currUpdate;
             switch (ledPins[led].action) {
-                case BUTTON_PRESS_UP: setLEDByMode(ledPins[led], gamepad->pressedDpad(GAMEPAD_MASK_UP)); break;
-                case BUTTON_PRESS_DOWN: setLEDByMode(ledPins[led], gamepad->pressedDpad(GAMEPAD_MASK_DOWN)); break;
-                case BUTTON_PRESS_LEFT: setLEDByMode(ledPins[led], gamepad->pressedDpad(GAMEPAD_MASK_LEFT)); break;
-                case BUTTON_PRESS_RIGHT: setLEDByMode(ledPins[led], gamepad->pressedDpad(GAMEPAD_MASK_RIGHT)); break;
+                case BUTTON_PRESS_UP: setLEDByMode(ledPins[led], gamepad->pressedDpadPhysical(GAMEPAD_MASK_UP)); break;
+                case BUTTON_PRESS_DOWN: setLEDByMode(ledPins[led], gamepad->pressedDpadPhysical(GAMEPAD_MASK_DOWN)); break;
+                case BUTTON_PRESS_LEFT: setLEDByMode(ledPins[led], gamepad->pressedDpadPhysical(GAMEPAD_MASK_LEFT)); break;
+                case BUTTON_PRESS_RIGHT: setLEDByMode(ledPins[led], gamepad->pressedDpadPhysical(GAMEPAD_MASK_RIGHT)); break;
                 case BUTTON_PRESS_B1: setLEDByMode(ledPins[led], gamepad->pressedButton(GAMEPAD_MASK_B1)); break;
                 case BUTTON_PRESS_B2: setLEDByMode(ledPins[led], gamepad->pressedButton(GAMEPAD_MASK_B2)); break;
                 case BUTTON_PRESS_B3: setLEDByMode(ledPins[led], gamepad->pressedButton(GAMEPAD_MASK_B3)); break;

--- a/src/display/ui/elements/GPButton.cpp
+++ b/src/display/ui/elements/GPButton.cpp
@@ -76,7 +76,7 @@ void GPButton::draw() {
         turboState = (getGamepad()->turboState.buttons & this->_inputMask);
     } else if (_inputType == GP_ELEMENT_DIR_BUTTON) {
         // direction button mask
-        buttonState = getProcessedGamepad()->pressedDpad(this->_inputMask);
+        buttonState = getProcessedGamepad()->pressedDpadPhysical(this->_inputMask);
         useMask = true;
 
         if ((this->_inputMask & GAMEPAD_MASK_UP) == GAMEPAD_MASK_UP) {

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -277,11 +277,13 @@ void Gamepad::process()
 		state.dpad = filterToFourWayMode(state.dpad);
 	}
 
+	uint8_t currentDpadSnapshot = state.dpad;
+
 	// stash digital-only dpad state for later
-	uint8_t dpadOnlyMask = ((state.dpadOriginal & 0xF0) >> 4);
+	uint8_t dpadOnlyMask = ((currentDpadSnapshot & 0xF0) >> 4);
 
 	// and mask out the mode-specific mask
-	uint8_t dpadModeMask = (state.dpadOriginal & 0x0F);
+	uint8_t dpadModeMask = (currentDpadSnapshot & 0x0F);
 
 	// set dpad back to dpad mode-specific state
 	state.dpad = dpadModeMask;


### PR DESCRIPTION
### Describe the bug
This PR fixes a bug introduced by the recent hotkey D-pad fix (PR #1635 / Issue #1634),addons (such as Input Macros) that inject D-Pad inputs were having their directional outputs completely overwritten and ignored. This occurred because recent hotkey/UI fixes relied on state.dpadOriginal for masking and checking inputs. Since state.dpadOriginal is captured before PreprocessAddons(), any D-pad inputs injected by macros were being erased during Gamepad::process(), and the USB output was blind to them.

### Root Cause
In PR #1635, state.dpadOriginal = state.dpad; was moved to Gamepad::read() to ensure hotkey processing uses unmodified physical inputs. This successfully fixed the hotkey issues.
﻿
However, Gamepad::process() was still using state.dpadOriginal to calculate dpadOnlyMask and dpadModeMask.
The execution order in the main loop is:

1. read() -> state.dpadOriginal is set (contains ONLY raw physical inputs).
2. ﻿PreprocessAddons() -> Addons (like Macros) inject D-pad inputs into state.dpad.
3. ﻿process() -> Uses state.dpadOriginal to create masks, and then executes state.dpad = dpadModeMask;.

﻿
Because state.dpadOriginal does not contain the Addon-injected inputs, state.dpad = dpadModeMask; completely overwrites and erases any D-pad modifications made by macros/addons.

### The Fix
This PR cleanly separates the "processed game output" from the "raw physical input". It fixes the macro direction issue while keeping hotkeys, LEDs, and UI strictly tied to physical presses:

gamepad.cpp: Introduced a local currentDpadSnapshot in process() to calculate dpadOnlyMask and dpadModeMask. This carries macro-injected D-Pad states safely through the masking pipeline without erasing them.

gamepad.h:

Restored pressedDpad() to return state.dpad (so the USB driver outputs the correct macro inputs).

Added a new pressedDpadPhysical() method returning state.dpadOriginal.

Updated pressedHotkey() to use pressedDpadPhysical().

reactiveleds.cpp & GPButton.cpp: Updated the Reactive LEDs and OLED display to explicitly use pressedDpadPhysical().

### Result

Macros injecting D-Pad inputs now correctly output to the game.

Hotkeys continue to safely ignore macro inputs (preventing accidental mode switches).

Reactive LEDs and OLED displays continue to honestly reflect only raw physical button presses, preserving the original intent of previous display/hotkey fixes.

### Testing
Compiled and tested locally. Verified that macros fire correctly, hotkeys work as intended, and displays/LEDs react only to physical inputs.