### PR TITLE
Update Nintendo Switch Pro input mode to not allow SOCD none

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -201,6 +201,7 @@ public:
 		return (options.socdMode == SOCD_MODE_BYPASS &&
 				(options.inputMode == INPUT_MODE_PS3 ||
 				options.inputMode == INPUT_MODE_SWITCH ||
+				options.inputMode == INPUT_MODE_SWITCH_PRO ||
 				options.inputMode == INPUT_MODE_NEOGEO ||
 				options.inputMode == INPUT_MODE_PS4)) ?
 			SOCD_MODE_NEUTRAL : options.socdMode;

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -49,7 +49,7 @@ export default {
 	},
 	'socd-cleaning-mode-label': 'SOCD Cleaning Mode',
 	'socd-cleaning-mode-note':
-		'Note: PS4, PS3, Nintendo Switch, and mini series modes do not support setting SOCD Cleaning to Off and will default to Neutral SOCD Cleaning mode.',
+		'Note: PS4, PS3, Nintendo Switch, Nintendo Switch Pro, and mini series modes do not support setting SOCD Cleaning to Off and will default to Neutral SOCD Cleaning mode.',
 	'socd-cleaning-mode-options': {
 		'up-priority': 'Up Priority',
 		neutral: 'Neutral',


### PR DESCRIPTION
This PR Updated the Nintendo Switch Pro input mode to not allow SOCD none.  Currently Nintendo Switch Pro mode allows for SOCD none which was causing inconsistent inputs on a game-by-game basis when SOCD was set to none.