### PR TITLE
Fix: run input driver processAux() before addons on Core 1

### DIFF
--- a/src/gp2040aux.cpp
+++ b/src/gp2040aux.cpp
@@ -52,13 +52,21 @@ void GP2040Aux::setup() {
 
 void GP2040Aux::run() {
 	while (1) {
-		// Pre, Process, and Post
 		addons.PreprocessAddons();
-		addons.ProcessAddons();
 
-		// Run auxiliary functions for input driver on Core1
+		// Run auxiliary input driver functions (e.g. P5General auth USB
+		// listener servicing hash_pending round-trips to the dongle)
+		// BEFORE ProcessAddons() so the auth pipeline gets a turn at the
+		// start of every Core 1 iteration. Otherwise a long display I2C
+		// write inside ProcessAddons() (~10 ms at 1 MHz, ~25 ms at 400 kHz)
+		// stalls the auth listener, causing hash_pending to stay set and
+		// delaying HID reports to the PS5 by 1-2+ frames. Drivers without
+		// an auxiliary step provide a no-op processAux(), so this ordering
+		// is safe for all driver modes.
 		if ( inputDriver != nullptr ) {
 			inputDriver->processAux();
 		}
+
+		addons.ProcessAddons();
 	}
 }


### PR DESCRIPTION
## Summary

On Core 1, `GP2040Aux::run()` calls `addons.ProcessAddons()` before
`inputDriver->processAux()`. When an external-authentication driver
(P5General) services its USB dongle handshake inside `processAux()`, a
blocking display I²C write inside `ProcessAddons()` (~25 ms for a full
SSD1306 framebuffer at the 400 kHz default) stalls the auth pipeline.
`hash_pending` stays set, so Core 0's `process()` returns early and HID
reports to the PS5 are delayed by 1–2+ frames.

This is the root cause behind the note in #1546: *"I2C0 must be
disabled; otherwise the report rate will be extremely low — cause not
yet identified."*

This PR reorders the Core 1 loop to service `processAux()` **before**
`ProcessAddons()`, so the auth handshake gets a turn at the start of
every iteration and is no longer gated behind the display write.

## Why this is safe

- Pure scheduling change — no new state, no new code paths.
- `ProcessAddons()` still runs every iteration, immediately after `processAux()`.
- Drivers without an auxiliary step inherit a no-op `processAux()`, so
  behavior is unchanged for XInput, PS4, Switch, Switch Pro, Xbox One, etc.
- No shared state between the auth pipeline and the addons it's reordered against.

## Testing

Validated on hardware with a P5General dongle on a PS5:
- Haute42 COSMOX (mine)
- RP2040 Advanced Breakout Board – USB Passthrough (community-validated)

In testing, this scheduling change — combined with a 30 fps display cap
and a 1 MHz I²C bump (submitted as separate follow-up PRs) — brought
OLED-enabled input latency to parity with running the OLED disabled:
single-frame taps register as single frames and quarter-circle motions
land consistently. I'm submitting the scheduling fix first as the
foundational, most universal piece; the auth pipeline can only benefit
from running earlier, and the follow-ups stack on top.

## Follow-ups (separate PRs)
- Configurable display frame interval (default 30 fps) to reduce Core 1
  occupancy by the display addon.
- Per-board I²C0 Fast Mode Plus (1 MHz) for boards with an SSD1306/SH1106
  OLED + USB auth.
