### PR TITLE
Add configurable display frame interval (default 30fps)

### DIFF
--- a/headers/addons/display.h
+++ b/headers/addons/display.h
@@ -66,6 +66,10 @@
 #define DISPLAY_SAVER_TIMEOUT 0
 #endif
 
+#ifndef DISPLAY_FRAME_INTERVAL_MS
+#define DISPLAY_FRAME_INTERVAL_MS 33 // ~30fps display update rate
+#endif
+
 #ifndef BUTTON_LAYOUT
 #define BUTTON_LAYOUT BUTTON_LAYOUT_STICK
 #endif
@@ -239,6 +243,7 @@ private:
     int32_t displaySaverTimer;
     uint8_t displayIsPowerOn = 1;
     uint32_t prevMillis;
+    uint32_t prevDrawMillis = 0;
     std::string statusBar;
     bool configMode;
     GPGFX* gpDisplay;

--- a/src/addons/display.cpp
+++ b/src/addons/display.cpp
@@ -205,6 +205,14 @@ void DisplayAddon::process() {
         return;
     }
 
+    // Rate-limit the expensive draw path to ~30fps so Core1
+    // is free for processAux() (auth handshake) on other iterations
+    uint32_t now = getMillis();
+    if ((now - prevDrawMillis) < DISPLAY_FRAME_INTERVAL_MS) {
+        return;
+    }
+    prevDrawMillis = now;
+
     // Core0 requested a new display mode
     if (nextDisplayMode != currDisplayMode ) {
         currDisplayMode = nextDisplayMode;


### PR DESCRIPTION
## Summary

`DisplayAddon::process()` runs on Core 1 and writes the full framebuffer
to the OLED over a blocking I²C transfer on every loop iteration. This
caps the redraw to a configurable interval, `DISPLAY_FRAME_INTERVAL_MS`
(default 33 ms ≈ 30 fps), so Core 1 spends fewer iterations blocked on
the display and more available for other per-iteration work e.g.
servicing an external-auth driver's `processAux()` (companion to the
Core 1 scheduling fix in #1659).

## Details

- New `#ifndef DISPLAY_FRAME_INTERVAL_MS` define (default 33), boards can override.
- New `prevDrawMillis` member; the gate sits **after** the existing
  power-off / `isDisplayPowerOff()` check so display-saver timing is unaffected.
- 30 fps is imperceptible on a 128×64 monochrome OLED for status/menu/button display.

## Note on scope

This changes the redraw cadence for **all** boards with a display. If
you'd prefer this be opt-in rather than a global default, I'm happy to
flip it so the default is unlimited and boards opt in by defining
`DISPLAY_FRAME_INTERVAL_MS`

## Testing

Validated alongside #1659 on Haute42 COSMOX and an RP2040 Advanced
Breakout Board with a P5General dongle on a PS5. Display updates remain
smooth; splash, button display, mode indicator, and screen saver all
behave normally.
