### PR TITLE
Haute42COSMOX X: set I2C0 to 1 MHz (Fast Mode Plus)

### DIFF
--- a/configs/Haute42COSMOX/BoardConfig.h
+++ b/configs/Haute42COSMOX/BoardConfig.h
@@ -103,6 +103,10 @@
  #define I2C0_ENABLED 1
  #define I2C0_PIN_SDA 0
  #define I2C0_PIN_SCL 1
+ // Bump I2C0 to Fast Mode Plus (1 MHz) so the SSD1306 framebuffer write
+ // (~1024 bytes) blocks Core 1 for ~10 ms instead of ~25 ms. This reduces
+ // the P5General auth stall window when the OLED display is enabled.
+ #define I2C0_SPEED 1000000
  #define SPLASH_MODE SPLASH_MODE_STATIC
  #define SPLASH_DURATION 3000
  


### PR DESCRIPTION
## Summary

Sets `I2C0_SPEED` to 1 MHz (Fast Mode Plus) for the Haute42 COSMOX. The
board drives an SSD1306 OLED on I²C0; at the 400 kHz default a full
framebuffer write blocks Core 1 for ~25 ms. SSD1306 and SH1106
controllers both support 1 MHz (Fast Mode Plus) per their datasheets. At
1 MHz the write drops to ~10 ms, which shrinks the window during which an
external-auth driver's `processAux()` (P5General) can be stalled on
Core 1.

Complements the Core 1 scheduling fix (#1659) and the display frame
interval PR.

## Testing

Hardware-validated on the Haute42 COSMOX with a P5General dongle on a
PS5: OLED renders correctly at 1 MHz, no display artifacts, input latency
at parity with the OLED disabled. The same 1 MHz value was independently
validated by a community member on the RP2040 Advanced Breakout Board –
USB Passthrough; I've scoped this PR to the COSMOX X only and leave the
other board to its owner.

No effect on auth methods that don't use Core 1 round-trips.