### PR TITLE
Fix GamepadUSBHostListener::unmount() not checking dev_addr

### DIFF
--- a/src/addons/gamepad_usb_host_listener.cpp
+++ b/src/addons/gamepad_usb_host_listener.cpp
@@ -108,8 +108,8 @@ void GamepadUSBHostListener::xmount(uint8_t dev_addr, uint8_t instance, uint8_t 
 }
 
 void GamepadUSBHostListener::unmount(uint8_t dev_addr) {
-    if ( _controller_host == nullptr ) return;
-    
+    if ( _controller_host == nullptr || _controller_dev_addr != dev_addr ) return;
+
     _controller_host->shutdown();
     delete _controller_host;
     _controller_host = nullptr;


### PR DESCRIPTION
`GamepadUSBHostListener::unmount()` shuts down and deletes `_controller_host` whenever it's non-null, without ever checking that the `dev_addr` being unmounted is the one it's actually hosting. Every other callback in this class (`report_received`, `set_report_complete`, `get_report_complete`) does compare `_controller_dev_addr == dev_addr` before touching the host, so this one method is the odd one out.

The reason this actually bites: `USBHostManager` broadcasts every HID/XInput unmount callback to *all* registered listeners, not just the one that owns that device. If someone has both the Keyboard Host addon and the Gamepad USB Host addon enabled (e.g. a hub feeding a keyboard/mouse plus a PS4/PS5/Switch Pro controller into the same host port), unplugging the keyboard fires `unmount(keyboard_dev_addr)` on every listener, including `GamepadUSBHostListener`. Since it never checks the address, it tears down its own still-connected controller session in response to an unrelated device going away — the controller has to be physically replugged to come back.

`KeyboardHostListener::unmount()` already handles this correctly by comparing against its own `_keyboard_dev_addr`/`_mouse_dev_addr`, and there's precedent for this exact class of bug being fixed there before (#1177). `GamepadUSBHostListener` is a newer file (from the USB Host Rework in #1672) that just never got the same guard added.

Fix is one line, adding the same address check the sibling methods already use:

```cpp
void GamepadUSBHostListener::unmount(uint8_t dev_addr) {
    if ( _controller_host == nullptr || _controller_dev_addr != dev_addr ) return;
    ...
```

I don't have the pico-sdk/arm-none-eabi toolchain set up locally to build the full firmware, so I verified this with a small native harness instead: copied the current `unmount()` body and the `USBHostManager` broadcast loop verbatim into a standalone C++ program, mounted a fake keyboard and a fake controller with different dev_addrs, then fed the keyboard's dev_addr through the same broadcast-to-all-listeners path the real firmware uses. With the current code the controller host gets destroyed even though it wasn't the device that unmounted; with the one-line fix it's left alone, and unmounting the controller's own dev_addr still tears it down correctly.
