### PR TITLE
Extend the range of characters for profile names

### DIFF
--- a/www/src/Locales/en/PinMapping.jsx
+++ b/www/src/Locales/en/PinMapping.jsx
@@ -6,7 +6,7 @@ export default {
 	'pin-pressed': 'Pressed GPIO Pin: {{pressedPin}}',
 	'profile-label-title': 'Profile name',
 	'profile-label-description':
-		'Max 16 characters. Letters, numbers, and spaces allowed.',
+		'Max 16 characters. Printable ASCII characters allowed.',
 	'profile-pin-mapping-title': '{{profileLabel}} - GPIO Pin Mapping',
 	'profile-label-default': 'Profile {{profileNumber}}',
 	'profile-add-button': '+ Add Profile',

--- a/www/src/Locales/es-MX/PinMapping.jsx
+++ b/www/src/Locales/es-MX/PinMapping.jsx
@@ -6,7 +6,7 @@ export default {
 	'pin-pressed': 'Pin presionado: {{pressedPin}}',
 	'profile-label-title': 'Nombre del perfil',
 	'profile-label-description':
-		'Máximo 16 caracteres. Se permiten letras, números y espacios.',
+		'Máximo 16 caracteres. Se permiten caracteres ASCII imprimibles.',
 	'profile-pin-mapping-title': '{{profileLabel}} - Mapeo de Pines GPIO',
 	'profile-label-default': 'Perfil {{profileNumber}}',
 	'profile-add-button': '+ Añadir Perfil',

--- a/www/src/Locales/fr-FR/PinMapping.jsx
+++ b/www/src/Locales/fr-FR/PinMapping.jsx
@@ -6,7 +6,7 @@ export default {
 	'pin-pressed': 'Broche GPIO activée : {{pressedPin}}',
 	'profile-label-title': 'Nom du profil',
 	'profile-label-description':
-		'16 caractères maximum. Lettres, chiffres et espaces autorisés.',
+		'16 caractères maximum. Les caractères ASCII imprimables sont autorisés.',
 	'profile-pin-mapping-title': '{{profileLabel}} - Mappage des broches GPIO',
 	'profile-label-default': 'Profil {{profileNumber}}',
 	'profile-add-button': '+ Ajouter un profil',

--- a/www/src/Locales/ja-JP/PinMapping.jsx
+++ b/www/src/Locales/ja-JP/PinMapping.jsx
@@ -5,7 +5,8 @@ export default {
 	'pin-viewer': '端子確認',
 	'pin-pressed': 'このボタンの配線先は {{pressedPin}} 番端子です！',
 	'profile-label-title': 'プロファイル名',
-	'profile-label-description': '最大１６文字。半角英数とスペースのみ。',
+	'profile-label-description':
+		'最大16文字。印字可能なASCII文字を使用できます。',
 	'profile-pin-mapping-title': '{{profileLabel}} - 端子割当',
 	'profile-label-default': 'プロファイル {{profileNumber}}',
 	'profile-add-button': '+ プロファイル追加',

--- a/www/src/Locales/ko-KR/PinMapping.jsx
+++ b/www/src/Locales/ko-KR/PinMapping.jsx
@@ -6,7 +6,7 @@ export default {
 	'pin-pressed': '눌린 핀: {{pressedPin}}',
 	'profile-label-title': '프로필 이름',
 	'profile-label-description':
-		'최대 16자(영문)로 문자, 숫자, 공백을 사용할 수 있습니다.',
+		'최대 16자. 인쇄 가능한 ASCII 문자를 사용할 수 있습니다.',
 	'profile-pin-mapping-title': '{{profileLabel}} - GPIO 핀 매핑',
 	'profile-label-default': '프로필 {{profileNumber}}',
 	'profile-add-button': '+ 프로필 추가',

--- a/www/src/Locales/tr-TR/PinMapping.jsx
+++ b/www/src/Locales/tr-TR/PinMapping.jsx
@@ -6,7 +6,7 @@ export default {
 	'pin-pressed': 'Basılan GPIO Pini: {{pressedPin}}',
 	'profile-label-title': 'Profil adı',
 	'profile-label-description':
-		'En fazla 16 karakter. Harf, rakam ve boşluklara izin verilir.',
+		'En fazla 16 karakter. Yazdırılabilir ASCII karakterlerine izin verilir.',
 	'profile-pin-mapping-title': '{{profileLabel}} - GPIO Pin Eşlemesi',
 	'profile-label-default': 'Profil {{profileNumber}}',
 	'profile-add-button': '+ Profil Ekle',

--- a/www/src/Locales/zh-CN/PinMapping.jsx
+++ b/www/src/Locales/zh-CN/PinMapping.jsx
@@ -6,7 +6,7 @@ export default {
 	'pin-pressed': '当前按下的 GPIO 引脚：{{pressedPin}}',
 	'profile-label-title': '配置文件名称',
 	'profile-label-description':
-		'最多 16 个字符。支持字母、数字和空格。',
+		'最多 16 个字符。支持可打印 ASCII 字符。',
 	'profile-pin-mapping-title': '{{profileLabel}} - GPIO 引脚映射',
 	'profile-label-default': '配置文件 {{profileNumber}}',
 	'profile-add-button': '+ 添加配置文件',

--- a/www/src/Pages/PinMapping.tsx
+++ b/www/src/Pages/PinMapping.tsx
@@ -140,7 +140,7 @@ const ProfileLabel = memo(function ProfileLabel({
 		(event: React.ChangeEvent<HTMLInputElement>) =>
 			setProfileLabel(
 				profileIndex,
-				event.target.value.replace(/[^a-zA-Z0-9\s]/g, ''),
+				event.target.value.replace(/[^\x20-\x7e]/g, ''),
 			),
 		[],
 	);
@@ -156,7 +156,7 @@ const ProfileLabel = memo(function ProfileLabel({
 				})}
 				onChange={onLabelChange}
 				maxLength={16}
-				pattern="[a-zA-Z0-9\s]+"
+				pattern="[\x20-\x7e]+"
 			/>
 			<Form.Text muted>{t('PinMapping:profile-label-description')}</Form.Text>
 		</div>


### PR DESCRIPTION
This PR extends the usable characters for the profile name field from `a-zA-Z0-9` to `\x20-\x7e` which includes, I believe, all of the normally used characters.

Please note that this was a quick one line fix after reading about it but I did use Claude to do a quick translation on the web-config stuff to other languages.