### PR TITLE
Fix PS4 sensor data incorrect descriptor and alignment

### DIFF
--- a/headers/drivers/ps4/PS4Descriptors.h
+++ b/headers/drivers/ps4/PS4Descriptors.h
@@ -135,7 +135,7 @@ typedef struct __attribute__((packed, aligned(1))) {
 } PSSensor;
 
 typedef struct __attribute__((packed, aligned(1))){
-    uint16_t battery;
+    uint8_t temperature;
     PSSensor gyroscope;
     PSSensor accelerometer;
     uint8_t misc[4];

--- a/headers/gamepad/GamepadAuxState.h
+++ b/headers/gamepad/GamepadAuxState.h
@@ -131,8 +131,8 @@ struct GamepadAuxSensors
     GamepadAux3DRelativeSensor mouse;
 
     GamepadAux3DSensor touchpad[GAMEPAD_AUX_MAX_TOUCHPADS];
-    GamepadAux3DSensor gyroscope;
-    GamepadAux3DSensor accelerometer;
+    GamepadAux3DRelativeSensor gyroscope;
+    GamepadAux3DRelativeSensor accelerometer;
     GamepadAux3DSensor magnetometer;
     GamepadAux4DSensor timeOfFlight;
 

--- a/src/drivers/ps4/PS4Driver.cpp
+++ b/src/drivers/ps4/PS4Driver.cpp
@@ -662,15 +662,15 @@ bool PS4Driver::process(Gamepad * gamepad) {
     }
 
     if (gamepad->auxState.sensors.accelerometer.enabled) {
-        ps4Report.gamepad.sensorData.accelerometer.x = ((gamepad->auxState.sensors.accelerometer.x & 0xFF) << 8) | ((gamepad->auxState.sensors.accelerometer.x & 0xFF00) >> 8);
-        ps4Report.gamepad.sensorData.accelerometer.y = ((gamepad->auxState.sensors.accelerometer.y & 0xFF) << 8) | ((gamepad->auxState.sensors.accelerometer.y & 0xFF00) >> 8);
-        ps4Report.gamepad.sensorData.accelerometer.z = ((gamepad->auxState.sensors.accelerometer.z & 0xFF) << 8) | ((gamepad->auxState.sensors.accelerometer.z & 0xFF00) >> 8);
+        ps4Report.gamepad.sensorData.accelerometer.x = gamepad->auxState.sensors.accelerometer.x;
+        ps4Report.gamepad.sensorData.accelerometer.y = gamepad->auxState.sensors.accelerometer.y;
+        ps4Report.gamepad.sensorData.accelerometer.z = gamepad->auxState.sensors.accelerometer.z;
     }
 
     if (gamepad->auxState.sensors.gyroscope.enabled) {
-        ps4Report.gamepad.sensorData.gyroscope.x = ((gamepad->auxState.sensors.gyroscope.x & 0xFF) << 8) | ((gamepad->auxState.sensors.gyroscope.x & 0xFF00) >> 8);
-        ps4Report.gamepad.sensorData.gyroscope.y = ((gamepad->auxState.sensors.gyroscope.y & 0xFF) << 8) | ((gamepad->auxState.sensors.gyroscope.y & 0xFF00) >> 8);
-        ps4Report.gamepad.sensorData.gyroscope.z = ((gamepad->auxState.sensors.gyroscope.z & 0xFF) << 8) | ((gamepad->auxState.sensors.gyroscope.z & 0xFF00) >> 8);
+        ps4Report.gamepad.sensorData.gyroscope.x = gamepad->auxState.sensors.gyroscope.x;
+        ps4Report.gamepad.sensorData.gyroscope.y = gamepad->auxState.sensors.gyroscope.y;
+        ps4Report.gamepad.sensorData.gyroscope.z = gamepad->auxState.sensors.gyroscope.z;
     }
 
     // Wake up TinyUSB device


### PR DESCRIPTION
The PS4 sensor data descriptor started with an incorrectly sized field, causing the data to be offset by a single byte. The byte order swap in the driver was presumably added after a observation that the fields seemed in a different byte order, while actually it was the bytes from two different fields being combined.

This makes the gyro/accelerator work correctly, as well as all the other fields that follow them.

Note: I haven't actually tested this with one of the already supported IMU drivers (I think it's just the Wii?), only with my custom build using a QMI8658 (see #1161).

(Fun fact, not spotting this earlier was the reason I never finished that PR. With this fixed it actually works quite well now, and I hope it may also help others working on other IMUs.)