### PR TITLE
Add per-profile SOCD cleaning settings to address #1187

### DIFF
--- a/headers/gamepad.h
+++ b/headers/gamepad.h
@@ -203,16 +203,15 @@ public:
 
 	uint32_t lastReinitProfileNumber = 0;
 
-	// These are special to SOCD
-	inline static const SOCDMode resolveSOCDMode(const GamepadOptions& options) {
-		return (options.socdMode == SOCD_MODE_BYPASS &&
-				(options.inputMode == INPUT_MODE_PS3 ||
-				options.inputMode == INPUT_MODE_SWITCH ||
-				options.inputMode == INPUT_MODE_SWITCH_PRO ||
-				options.inputMode == INPUT_MODE_NEOGEO ||
-				options.inputMode == INPUT_MODE_PS4)) ?
-			SOCD_MODE_NEUTRAL : options.socdMode;
-	};
+	// These are special to SOCD.
+	// Resolution order: SOCD slider addon > profile override > global.
+	static const SOCDMode resolveSOCDMode(const GamepadOptions& options);
+	// Stored value of the effective SOCD source (no input-mode coercion).
+	static const SOCDMode readSOCDMode(const GamepadOptions& options);
+	// Write the effective SOCD source: profile override when active (and the
+	// slider addon is disabled), the global otherwise. Never creates an override.
+	// Note: setSOCDMode() always writes the global (the slider addon relies on this).
+	void applySOCDMode(SOCDMode mode);
 
 private:
 	void processHotkeyAction(GamepadHotkey action);

--- a/headers/storagemanager.h
+++ b/headers/storagemanager.h
@@ -63,6 +63,7 @@ public:
 	void setFunctionalPinMappings();
 	void setBootModeFunctionalPinMappings();
 	char* currentProfileLabel();
+	ProfileSettings* getCurrentProfileSettings(); // active profile's settings, nullptr if profile number is invalid
 
 	void ResetSettings(); 				// EEPROM Reset Feature
 

--- a/lib/lwip-port/lwipopts.h
+++ b/lib/lwip-port/lwipopts.h
@@ -62,6 +62,10 @@
 #define LWIP_HTTPD_SUPPORT_V09          0
 #define LWIP_HTTPD_SUPPORT_11_KEEPALIVE 0 // Causes lockups with CGI requests
 #define LWIP_HTTPD_ABORT_ON_CLOSE_MEM_ERROR 1
+// API responses are heap strings freed on connection close (fs_close_custom
+// in webconfig.cpp). lwIP's default queues custom-file data by reference,
+// assuming it lives in ROM, so copy it here to avoid sending freed memory.
+#define HTTP_IS_DATA_VOLATILE(hs)       TCP_WRITE_FLAG_COPY
 
 #define LWIP_SINGLE_NETIF               1
 

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -212,11 +212,19 @@ message GpioMappingInfo
     optional uint32 customButtonMask = 4;
 }
 
+message ProfileSettings
+{
+    optional bool socdEnabled = 1 [default = false];
+    optional SOCDMode socdMode = 2;
+}
+
 message GpioMappings
 {
     repeated GpioMappingInfo pins = 1 [(nanopb).max_count = 30];
     optional string profileLabel = 2 [(nanopb).max_length = 16];
     optional bool enabled = 3 [default = false];
+    // Field 4 is reserved for PR #1566 (per-profile keyboardMapping).
+    optional ProfileSettings settings = 5;
 }
 
 

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -322,6 +322,14 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.gamepadOptions, usbProductID, DEFAULT_USB_PRODUCT_ID);
     INIT_UNSET_PROPERTY(config.gamepadOptions, miniMenuGamepadInput, MINI_MENU_GAMEPAD_INPUT);
 
+    // per-profile settings (profile 1 lives in gpioMappings, 2-6 in profileOptions)
+    INIT_UNSET_PROPERTY(config.gpioMappings.settings, socdEnabled, false);
+    INIT_UNSET_PROPERTY(config.gpioMappings.settings, socdMode, SOCD_MODE_NEUTRAL);
+    for (size_t i = 0; i < sizeof(config.profileOptions.gpioMappingsSets) / sizeof(config.profileOptions.gpioMappingsSets[0]); i++) {
+        INIT_UNSET_PROPERTY(config.profileOptions.gpioMappingsSets[i].settings, socdEnabled, false);
+        INIT_UNSET_PROPERTY(config.profileOptions.gpioMappingsSets[i].settings, socdMode, SOCD_MODE_NEUTRAL);
+    }
+
     // hotkeyOptions
     HotkeyOptions& hotkeyOptions = config.hotkeyOptions;
     INIT_UNSET_PROPERTY(hotkeyOptions.hotkey01, auxMask, HOTKEY_01_AUX_MASK);

--- a/src/display/ui/screens/MainMenuScreen.cpp
+++ b/src/display/ui/screens/MainMenuScreen.cpp
@@ -75,8 +75,8 @@ void MainMenuScreen::init() {
     prevDpadMode = Storage::getInstance().GetGamepad()->getOptions().dpadMode;
     updateDpadMode = Storage::getInstance().GetGamepad()->getOptions().dpadMode;
     
-    prevSocdMode = Storage::getInstance().GetGamepad()->getOptions().socdMode;
-    updateSocdMode = Storage::getInstance().GetGamepad()->getOptions().socdMode;
+    prevSocdMode = Gamepad::readSOCDMode(Storage::getInstance().GetGamepad()->getOptions());
+    updateSocdMode = prevSocdMode;
     
     prevProfile = Storage::getInstance().GetGamepad()->getOptions().profileNumber;
     updateProfile = Storage::getInstance().GetGamepad()->getOptions().profileNumber;
@@ -351,7 +351,7 @@ int32_t MainMenuScreen::currentDpadMode() {
 void MainMenuScreen::selectSOCDMode() {
     if (currentMenu->at(gpMenu->getIndex()).optionValue != -1) {
         SOCDMode valueToSave = (SOCDMode)currentMenu->at(gpMenu->getIndex()).optionValue;
-        prevSocdMode = Storage::getInstance().GetGamepad()->getOptions().socdMode;
+        prevSocdMode = Gamepad::readSOCDMode(Storage::getInstance().GetGamepad()->getOptions());
         updateSocdMode = valueToSave;
 
         chooseAndReturn();
@@ -394,7 +394,10 @@ void MainMenuScreen::saveOptions() {
             saveHasChanged = true;
         }
         if (prevSocdMode != updateSocdMode) {
-            options.socdMode = updateSocdMode;
+            // write the profile override when active, the global otherwise.
+            // this runs before the profile change below, because the override
+            // is looked up through the current profile number
+            Storage::getInstance().GetGamepad()->applySOCDMode(updateSocdMode);
             saveHasChanged = true;
         }
         if (prevProfile != updateProfile) {

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -25,6 +25,29 @@ uint64_t getMicro() {
 	return to_us_since_boot(get_absolute_time());
 }
 
+const SOCDMode Gamepad::readSOCDMode(const GamepadOptions& options) {
+	// The SOCD slider addon rewrites the global mode every loop while enabled;
+	// physical slider position beats any per-profile override.
+	if (!Storage::getInstance().getAddonOptions().socdSliderOptions.enabled) {
+		const ProfileSettings* profileSettings = Storage::getInstance().getCurrentProfileSettings();
+		if (profileSettings != nullptr && profileSettings->socdEnabled) {
+			return profileSettings->socdMode;
+		}
+	}
+	return options.socdMode;
+}
+
+const SOCDMode Gamepad::resolveSOCDMode(const GamepadOptions& options) {
+	SOCDMode mode = readSOCDMode(options);
+	return (mode == SOCD_MODE_BYPASS &&
+			(options.inputMode == INPUT_MODE_PS3 ||
+			options.inputMode == INPUT_MODE_SWITCH ||
+			options.inputMode == INPUT_MODE_SWITCH_PRO ||
+			options.inputMode == INPUT_MODE_NEOGEO ||
+			options.inputMode == INPUT_MODE_PS4)) ?
+		SOCD_MODE_NEUTRAL : mode;
+}
+
 Gamepad::Gamepad() :
 	options(Storage::getInstance().getGamepadOptions())
 	, hotkeyOptions(Storage::getInstance().getHotkeyOptions())
@@ -457,6 +480,21 @@ void Gamepad::clearRumbleState() {
 	auxState.haptics.rightTrigger.intensity = 0;
 }
 
+void Gamepad::applySOCDMode(SOCDMode mode) {
+	// Write to the source of the effective value: the profile override when one
+	// is active, the global otherwise. A hotkey never creates an override.
+	// While the slider addon is enabled it owns the effective mode; write the
+	// global, as stock firmware does, and leave the stored override alone.
+	if (!Storage::getInstance().getAddonOptions().socdSliderOptions.enabled) {
+		ProfileSettings* profileSettings = Storage::getInstance().getCurrentProfileSettings();
+		if (profileSettings != nullptr && profileSettings->socdEnabled) {
+			profileSettings->socdMode = mode;
+			return;
+		}
+	}
+	options.socdMode = mode;
+}
+
 /**
  * @brief Take a hotkey action if it hasn't already been taken, modifying state/options appropriately.
  */
@@ -546,31 +584,31 @@ void Gamepad::processHotkeyAction(GamepadHotkey action) {
 			break;
 		case HOTKEY_SOCD_UP_PRIORITY:
 			if (action != lastAction) {
-				options.socdMode = SOCD_MODE_UP_PRIORITY;
+				applySOCDMode(SOCD_MODE_UP_PRIORITY);
 				reqSave = true;
 			}
 			break;
 		case HOTKEY_SOCD_NEUTRAL:
 			if (action != lastAction) {
-				options.socdMode = SOCD_MODE_NEUTRAL;
+				applySOCDMode(SOCD_MODE_NEUTRAL);
 				reqSave = true;
 			}
 			break;
 		case HOTKEY_SOCD_LAST_INPUT:
 			if (action != lastAction) {
-				options.socdMode = SOCD_MODE_SECOND_INPUT_PRIORITY;
+				applySOCDMode(SOCD_MODE_SECOND_INPUT_PRIORITY);
 				reqSave = true;
 			}
 			break;
 		case HOTKEY_SOCD_FIRST_INPUT:
 			if (action != lastAction) {
-				options.socdMode = SOCD_MODE_FIRST_INPUT_PRIORITY;
+				applySOCDMode(SOCD_MODE_FIRST_INPUT_PRIORITY);
 				reqSave = true;
 			}
 			break;
 		case HOTKEY_SOCD_BYPASS:
 			if (action != lastAction) {
-				options.socdMode = SOCD_MODE_BYPASS;
+				applySOCDMode(SOCD_MODE_BYPASS);
 				reqSave = true;
 			}
 			break;

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -108,6 +108,19 @@ char* Storage::currentProfileLabel() {
 		return this->config.profileOptions.gpioMappingsSets[config.gamepadOptions.profileNumber-2].profileLabel;
 }
 
+/**
+ * @brief Return the current profile's settings.
+ */
+ProfileSettings* Storage::getCurrentProfileSettings() {
+	uint32_t profileNumber = config.gamepadOptions.profileNumber;
+	if (profileNumber == 1)
+		return &config.gpioMappings.settings;
+	else if (profileNumber >= 2 && profileNumber <= config.profileOptions.gpioMappingsSets_count + 1)
+		return &config.profileOptions.gpioMappingsSets[profileNumber - 2].settings;
+	else
+		return nullptr;
+}
+
 void Storage::setFunctionalPinMappings()
 {
 	GpioMappingInfo* alts = nullptr;

--- a/src/webconfig.cpp
+++ b/src/webconfig.cpp
@@ -587,6 +587,15 @@ std::string setProfileOptions()
         strncpy(profileOptions.gpioMappingsSets[altsIndex].profileLabel, alt["profileLabel"], profileLabelSize - 1);
         profileOptions.gpioMappingsSets[altsIndex].profileLabel[profileLabelSize - 1] = '\0';
         profileOptions.gpioMappingsSets[altsIndex].enabled = alt["enabled"];
+        if (alt["socdEnabled"] != nullptr) {
+            profileOptions.gpioMappingsSets[altsIndex].settings.socdEnabled = alt["socdEnabled"];
+        }
+        if (alt["socdMode"] != nullptr) {
+            const int socdMode = alt["socdMode"];
+            if (socdMode >= SOCD_MODE_UP_PRIORITY && socdMode <= SOCD_MODE_BYPASS) {
+                profileOptions.gpioMappingsSets[altsIndex].settings.socdMode = (SOCDMode)socdMode;
+            }
+        }
 
         profileOptions.gpioMappingsSets_count = ++altsIndex;
         if (altsIndex > 4) break;
@@ -598,7 +607,7 @@ std::string setProfileOptions()
 
 std::string getProfileOptions()
 {
-    const size_t capacity = JSON_OBJECT_SIZE(500);
+    const size_t capacity = JSON_OBJECT_SIZE(700);
     DynamicJsonDocument doc(capacity);
 
     const auto writePinDoc = [&](const int item, const char* key, const GpioMappingInfo& value) -> void
@@ -651,6 +660,8 @@ std::string getProfileOptions()
         writePinDoc(i, "pin29", profileOptions.gpioMappingsSets[i].pins[29]);
         writeDoc(doc, "alternativePinMappings", i, "profileLabel", profileOptions.gpioMappingsSets[i].profileLabel);
         doc["alternativePinMappings"][i]["enabled"] = profileOptions.gpioMappingsSets[i].enabled;
+        doc["alternativePinMappings"][i]["socdEnabled"] = profileOptions.gpioMappingsSets[i].settings.socdEnabled;
+        doc["alternativePinMappings"][i]["socdMode"] = (int)profileOptions.gpioMappingsSets[i].settings.socdMode;
     }
 
     return serialize_json(doc);
@@ -1139,6 +1150,15 @@ std::string setPinMappings()
     strncpy(gpioMappings.profileLabel, doc["profileLabel"], profileLabelSize - 1);
     gpioMappings.profileLabel[profileLabelSize - 1] = '\0';
     gpioMappings.enabled = doc["enabled"];
+    if (doc["socdEnabled"] != nullptr) {
+        gpioMappings.settings.socdEnabled = doc["socdEnabled"];
+    }
+    if (doc["socdMode"] != nullptr) {
+        const int socdMode = doc["socdMode"];
+        if (socdMode >= SOCD_MODE_UP_PRIORITY && socdMode <= SOCD_MODE_BYPASS) {
+            gpioMappings.settings.socdMode = (SOCDMode)socdMode;
+        }
+    }
 
     EventManager::getInstance().triggerEvent(new GPStorageSaveEvent(true));
 
@@ -1192,6 +1212,8 @@ std::string getPinMappings()
 
     writeDoc(doc, "profileLabel", gpioMappings.profileLabel);
     doc["enabled"] = gpioMappings.enabled;
+    doc["socdEnabled"] = gpioMappings.settings.socdEnabled;
+    doc["socdMode"] = (int)gpioMappings.settings.socdMode;
 
     return serialize_json(doc);
 }

--- a/www/src/Locales/en/PinMapping.jsx
+++ b/www/src/Locales/en/PinMapping.jsx
@@ -7,6 +7,10 @@ export default {
 	'profile-label-title': 'Profile name',
 	'profile-label-description':
 		'Max 16 characters. Printable ASCII characters allowed.',
+	'profile-socd-mode-title': 'SOCD Cleaning Mode',
+	'profile-socd-use-global': 'Use global setting',
+	'profile-socd-slider-note':
+		'The SOCD slider add-on is enabled. The slider hardware overrides this setting.',
 	'profile-pin-mapping-title': '{{profileLabel}} - GPIO Pin Mapping',
 	'profile-label-default': 'Profile {{profileNumber}}',
 	'profile-add-button': '+ Add Profile',

--- a/www/src/Pages/BootModeMapping.tsx
+++ b/www/src/Pages/BootModeMapping.tsx
@@ -104,7 +104,7 @@ function PinSelect({ mappingKey }: { mappingKey: string }) {
 	// Need the profile pin mapping to determine which pins are assigned to addons or reserved,
 	// relying on the assumption that these are the same across all profiles.
 	const profilePins: { [key: string]: MaskPayload } = useProfilesStore(
-		useShallow((state) => omit(state.profiles[0], ['profileLabel', 'enabled'])),
+		useShallow((state) => omit(state.profiles[0], ['profileLabel', 'enabled', 'socdEnabled', 'socdMode'])),
 	);
 
 	const { t } = useTranslation('');

--- a/www/src/Pages/PinMapping.tsx
+++ b/www/src/Pages/PinMapping.tsx
@@ -163,6 +163,65 @@ const ProfileLabel = memo(function ProfileLabel({
 	);
 });
 
+const SOCD_OPTION_KEYS = [
+	'up-priority',
+	'neutral',
+	'last-win',
+	'first-win',
+	'off',
+]; // index == SOCDMode enum value
+
+const ProfileSocdSelect = memo(function ProfileSocdSelect({
+	profileIndex,
+	sliderEnabled,
+}: {
+	profileIndex: number;
+	sliderEnabled: boolean;
+}) {
+	const { t } = useTranslation('');
+	const setProfileSocd = useProfilesStore((state) => state.setProfileSocd);
+	const socdEnabled = useProfilesStore(
+		(state) => state.profiles[profileIndex].socdEnabled,
+	);
+	const socdMode = useProfilesStore(
+		(state) => state.profiles[profileIndex].socdMode,
+	);
+
+	const onChange = useCallback(
+		(event: React.ChangeEvent<HTMLSelectElement>) => {
+			const value = parseInt(event.target.value, 10);
+			if (value < 0) {
+				setProfileSocd(profileIndex, false, 0);
+			} else {
+				setProfileSocd(profileIndex, true, value);
+			}
+		},
+		[],
+	);
+
+	return (
+		<div>
+			<Form.Label>{t('PinMapping:profile-socd-mode-title')}</Form.Label>
+			<Form.Select
+				value={socdEnabled ? socdMode : -1}
+				onChange={onChange}
+			>
+				<option value={-1}>{t('PinMapping:profile-socd-use-global')}</option>
+				{SOCD_OPTION_KEYS.map((key, value) => (
+					<option key={key} value={value}>
+						{t(`SettingsPage:socd-cleaning-mode-options.${key}`)}
+					</option>
+				))}
+			</Form.Select>
+			{sliderEnabled && (
+				<Form.Text muted>
+					{t('PinMapping:profile-socd-slider-note')}
+				</Form.Text>
+			)}
+		</div>
+	);
+});
+
 const PinSelectList = memo(function PinSelectList({
 	profileIndex,
 }: {
@@ -172,7 +231,12 @@ const PinSelectList = memo(function PinSelectList({
 
 	const pins = useProfilesStore(
 		useShallow((state) =>
-			omit(state.profiles[profileIndex], ['profileLabel', 'enabled']),
+			omit(state.profiles[profileIndex], [
+				'profileLabel',
+				'enabled',
+				'socdEnabled',
+				'socdMode',
+			]),
 		),
 	);
 	const { t } = useTranslation('');
@@ -290,6 +354,7 @@ const PinSection = memo(function PinSection({
 		});
 
 	const [activeProfile, setActiveProfile] = useState(0);
+	const [sliderEnabled, setSliderEnabled] = useState(false);
 
 	const { updateUsedPins, buttonLabels, setLoading } = useContext(AppContext);
 	const { buttonLabelType, swapTpShareLabels } = buttonLabels;
@@ -318,6 +383,12 @@ const PinSection = memo(function PinSection({
 		getActiveProfile();
 	}, []);
 
+	useEffect(() => {
+		WebApi.getAddonsOptions(() => {}).then((options) =>
+			setSliderEnabled(Boolean(options?.SliderSOCDInputEnabled)),
+		);
+	}, []);
+
 	return (
 		<>
 			<div className="alert alert-warning">
@@ -340,6 +411,10 @@ const PinSection = memo(function PinSection({
 					<Row>
 						<Col md={7}>
 							<ProfileLabel profileIndex={profileIndex} />
+							<ProfileSocdSelect
+								profileIndex={profileIndex}
+								sliderEnabled={sliderEnabled}
+							/>
 						</Col>
 						{profileIndex > 0 && (
 							<Col className='order-first order-md-last'>

--- a/www/src/Store/useProfilesStore.ts
+++ b/www/src/Store/useProfilesStore.ts
@@ -47,6 +47,8 @@ export type PinsType = {
 	pin29: MaskPayload;
 	profileLabel: string;
 	enabled: boolean;
+	socdEnabled: boolean;
+	socdMode: number;
 };
 
 type State = {
@@ -66,6 +68,11 @@ type Actions = {
 	fetchProfiles: () => void;
 	saveProfiles: () => Promise<object>;
 	setProfileLabel: (profileIndex: number, profileLabel: string) => void;
+	setProfileSocd: (
+		profileIndex: number,
+		socdEnabled: boolean,
+		socdMode: number,
+	) => void;
 	setProfilePin: SetProfilePinType;
 	toggleProfileEnabled: (profileIndex: number) => void;
 };
@@ -139,6 +146,16 @@ const useProfilesStore = create<State & Actions>()((set, get) => ({
 		set((state) => {
 			const profiles = [...state.profiles];
 			profiles[profileIndex] = { ...profiles[profileIndex], profileLabel };
+			return { profiles };
+		}),
+	setProfileSocd: (profileIndex, socdEnabled, socdMode) =>
+		set((state) => {
+			const profiles = [...state.profiles];
+			profiles[profileIndex] = {
+				...profiles[profileIndex],
+				socdEnabled,
+				socdMode,
+			};
 			return { profiles };
 		}),
 	saveProfiles: async () => {


### PR DESCRIPTION
Addresses the SOCD portion of #1187.

Full disclosure, this was specced out with Claude Fable, with first initial review by myself.

## Summary

Each profile can now override the global SOCD cleaning mode. A profile without an override uses the global setting, exactly as before. The Pin Mapping page gets a per-profile SOCD dropdown.

- New proto message `ProfileSettings { socdEnabled, socdMode }` as `GpioMappings.settings` (field 5; field 4 stays reserved for #1566). `socdEnabled == false` means "use the global setting".
- Resolution order: SOCD slider add-on (hardware) > profile override > global. The bypass-to-neutral guard for PS3/Switch/NeoGeo/PS4 is unchanged.
- SOCD hotkeys and the on-device display menu write to the effective source: the profile when its override is active, the global otherwise. Neither ever creates an override, and neither touches overrides while the slider add-on owns the mode.
- Web API: the pin-mapping and profile endpoints carry `socdEnabled`/`socdMode`. Setters apply the keys only when present and in range, so older payloads leave stored overrides unchanged. `getProfileOptions` JSON capacity grows 500 -> 700 slots (the old budget overflowed at 4+ profiles with the new keys).

## Web server fix

On-device testing exposed a latent webconfig bug: API responses are heap strings freed on connection close, but lwIP's httpd queues data by reference (assuming ROM), so a freed buffer can hit the wire as garbage. Fixed by setting `HTTP_IS_DATA_VOLATILE` to `TCP_WRITE_FLAG_COPY` in `lib/lwip-port/lwipopts.h`. This may also fix rare corrupted webconfig responses on current firmware.

## Design notes

- #1187 suggested `ProfileOptions`, but profile 1 lives outside it (`config.gpioMappings`), so the settings nest under `GpioMappings` to give every profile the same shape.
- New/copied profiles inherit the source profile's SOCD override, matching how pins and labels copy.
- Compatibility: old configs behave identically (override defaults off); downgrade is safe (unknown field is skipped); `Config_size` 21267 -> 21303 (+36 bytes, budget 32756); no migration.

## Testing

CI: all boards compile ([fork run](https://github.com/j-zhao/GP2040-CE/actions/runs/31723715750)). Local: nanopb regen, `npm run build-proto`, `npx vite build`.

On-device checklist:

- [ ] Profile switch changes effective SOCD (display widget confirms).
- [ ] Hotkey writes the profile when overridden, else the global.
- [ ] Slider wins over an overridden profile.
- [ ] Settings survive reboot and backup/restore; restoring a pre-feature backup preserves overrides.
- [ ] Web UI round-trips "Use Global" and each mode for all profiles; Pin Mapping loads with zero alternative profiles.
- [ ] OLED menu shows the effective mode under an override; a menu edit changes the override, not the global.
- [ ] A menu session changing both profile and SOCD mode writes the mode to the newly selected profile.

<img width="985" height="1164" alt="image" src="https://github.com/user-attachments/assets/186a54f3-a857-4ab2-9a04-18383260c059" />
