### PR TITLE
Fix GPGFX_TinySSD1306::getPixel returning the wrong bit and reading past the frame buffer

### DIFF
--- a/src/interfaces/i2c/ssd1306/tiny_ssd1306.cpp
+++ b/src/interfaces/i2c/ssd1306/tiny_ssd1306.cpp
@@ -125,10 +125,12 @@ uint32_t GPGFX_TinySSD1306::getPixel(uint8_t x, uint8_t y) {
             x+=2;
         }
 
+        if (x>=MAX_SCREEN_WIDTH) return result;
+
 		row=((y/8)*MAX_SCREEN_WIDTH)+x;
 		bitIndex=y % 8;
 
-        result = (frameBuffer[row] >> bitIndex) && 0x01;
+        result = (frameBuffer[row] >> bitIndex) & 0x01;
 	}
 
     return result;


### PR DESCRIPTION
## Fixes for two bugs in `GPGFX_TinySSD1306::getPixel()`

Claude assisted, issue found/reviewed by me.

I found this issue when I was trying to build out an in-webconfig Layout preview (I don't think this is very valuable, since I imagine most people just preview on device, but happy to open a feature PR if there's demand). AFAICT, `getPixel()` wasn't called today so this was latent.

This is possibly related to #1238 and maybe #1254?

<img width="1301" height="748" alt="image" src="https://github.com/user-attachments/assets/2e7d7704-c0c6-4ffc-b6b9-df4b92becdfe" />


-------------------

`GPGFX_TinySSD1306::getPixel()` has two bugs, both present since the function was added in #1254.

First, it uses a logical `&&` where it needs a bitwise `&`:

```cpp
result = (frameBuffer[row] >> bitIndex) && 0x01;
```

The SSD1306 packs eight vertical pixels into each byte, so shifting right by `bitIndex` and testing for non-zero reports a pixel as lit whenever any pixel below it in the same byte is lit. One lit pixel reads back as a run extending to the top of its eight-row page.

Second, it never clamps `x` after the SH1106 column offset. On a panel detected as 132x64 it does `x+=2` to match that addressing, the same as `drawPixel()` does, but `drawPixel()` follows the offset with `if (x>=MAX_SCREEN_WIDTH) return;` and `getPixel()` does not. So x=126 and x=127 index columns 128 and 129 of the page, which in the last page is `frameBuffer[1024]` and `[1025]`, past the end of a 1024-byte array. The call returns whatever follows the buffer in memory.

Neither bug has been visible until now because nothing in the firmware calls `getPixel()`. The driver only writes pixels and pushes the buffer out over I2C. I hit both while prototyping an endpoint that reads the framebuffer back so the web configurator can mirror the display: the first drew every element vertically smeared, and the second put stray pixels in the bottom-right corner, exactly where the read runs off the end.

The SH1106 offset in `getPixel()` also came from #1254, which is what closed #1238, the same panel drawing past its right edge. That work gave the write path the clamp and missed the read path.

Tested on an SH1106 128x64 by reading the framebuffer back and decoding it. Before, elements smeared upward within each eight-row band and lit pixels appeared at x=126-127 in the bottom band only. After, the decoded frame matches the panel and the corner is clean. Nothing else calls `getPixel()`, so there is no effect on current rendering.
