### PR TITLE
Add kotkey and GPIO toggle to enable and disable left and right analog

### DIFF
--- a/headers/addons/analog.h
+++ b/headers/addons/analog.h
@@ -147,7 +147,12 @@ private:
     uint16_t map(uint16_t x, uint16_t in_min, uint16_t in_max, uint16_t out_min, uint16_t out_max);
     float magnitudeCalculation(int stick_num, adc_instance & adc_inst);
     void radialDeadzone(int stick_num, adc_instance & adc_inst);
+    void processStickToggles(Gamepad * gamepad);
     adc_instance adc_pairs[ADC_COUNT];
+    Mask_t toggleLeftMask = 0;
+    Mask_t toggleRightMask = 0;
+    bool toggleLeftWasPressed = false;
+    bool toggleRightWasPressed = false;
 };
 
 #endif  // _Analog_H_

--- a/proto/config.proto
+++ b/proto/config.proto
@@ -439,6 +439,8 @@ message AnalogOptions
     optional uint32 joystick_center_y = 25;
     optional uint32 joystick_center_x2 = 26;
     optional uint32 joystick_center_y2 = 27;
+    optional bool analogLeftEnabled = 28;
+    optional bool analogRightEnabled = 29;
 }
 
 message TurboOptions

--- a/proto/enums.proto
+++ b/proto/enums.proto
@@ -361,6 +361,8 @@ enum GpioAction
     MODE_WHEEL_PEDAL_GAS         = 128;
     MODE_WHEEL_PEDAL_BRAKE       = 129;
     MODE_WHEEL_PEDAL_CLUTCH      = 130;
+    TOGGLE_LEFT_ANALOG           = 131;
+    TOGGLE_RIGHT_ANALOG          = 132;
 }
 
 enum GpioDirection
@@ -463,6 +465,8 @@ enum GamepadHotkey
     HOTKEY_RS_RIGHT              = 85;
     HOTKEY_REBOOT_WEBCONFIG      = 86;
     HOTKEY_REBOOT_USB            = 87;
+    HOTKEY_TOGGLE_LEFT_ANALOG    = 88;
+    HOTKEY_TOGGLE_RIGHT_ANALOG   = 89;
 }
 
 enum AnimationEffects

--- a/src/addons/analog.cpp
+++ b/src/addons/analog.cpp
@@ -5,6 +5,7 @@
 #include "helper.h"
 #include "storagemanager.h"
 #include "drivermanager.h"
+#include "GPStorageSaveEvent.h"
 
 #include <math.h>
 
@@ -20,6 +21,18 @@ bool AnalogInput::available() {
 
 void AnalogInput::setup() {
     const AnalogOptions& analogOptions = Storage::getInstance().getAddonOptions().analogOptions;
+
+    toggleLeftMask = 0;
+    toggleRightMask = 0;
+    GpioMappingInfo* pinMappings = Storage::getInstance().getProfilePinMappings();
+    for (Pin_t pin = 0; pin < (Pin_t)NUM_BANK0_GPIOS; pin++)
+    {
+        switch (pinMappings[pin].action) {
+            case GpioAction::TOGGLE_LEFT_ANALOG:    toggleLeftMask |= 1 << pin; break;
+            case GpioAction::TOGGLE_RIGHT_ANALOG:   toggleRightMask |= 1 << pin; break;
+            default:                                break;
+        }
+    }
     
     // Setup our ADC Pair of Sticks
     adc_pairs[0].x_pin = analogOptions.analogAdc1PinX;
@@ -90,6 +103,9 @@ void AnalogInput::setup() {
 
 void AnalogInput::process() {
     Gamepad * gamepad = Storage::getInstance().GetGamepad();
+    const AnalogOptions& analogOptions = Storage::getInstance().getAddonOptions().analogOptions;
+
+    processStickToggles(gamepad);
     
     uint32_t joystickMid = GAMEPAD_JOYSTICK_MID;
     uint32_t joystickMax = GAMEPAD_JOYSTICK_MAX;
@@ -141,12 +157,47 @@ void AnalogInput::process() {
         }
 
         if (adc_pairs[i].analog_dpad == DpadMode::DPAD_MODE_LEFT_ANALOG) {
+            if (!analogOptions.analogLeftEnabled) continue;
             gamepad->state.lx = clampedX;
             gamepad->state.ly = clampedY;
         } else if (adc_pairs[i].analog_dpad == DpadMode::DPAD_MODE_RIGHT_ANALOG) {
+            if (!analogOptions.analogRightEnabled) continue;
             gamepad->state.rx = clampedX;
             gamepad->state.ry = clampedY;
         }
+    }
+}
+
+void AnalogInput::processStickToggles(Gamepad * gamepad) {
+    if (!toggleLeftMask && !toggleRightMask) return;
+
+    AnalogOptions& analogOptions = Storage::getInstance().getAddonOptions().analogOptions;
+    GamepadOptions& gamepadOptions = Storage::getInstance().getGamepadOptions();
+    bool reqSave = false;
+
+    const bool leftPressed = toggleLeftMask && (gamepad->debouncedGpio & toggleLeftMask);
+    if (leftPressed && !toggleLeftWasPressed) {
+        analogOptions.analogLeftEnabled = !analogOptions.analogLeftEnabled;
+        // Turning the stick back on releases the d-pad from standing in for it
+        if (analogOptions.analogLeftEnabled && gamepadOptions.dpadMode == DPAD_MODE_LEFT_ANALOG) {
+            gamepadOptions.dpadMode = DPAD_MODE_DIGITAL;
+        }
+        reqSave = true;
+    }
+    toggleLeftWasPressed = leftPressed;
+
+    const bool rightPressed = toggleRightMask && (gamepad->debouncedGpio & toggleRightMask);
+    if (rightPressed && !toggleRightWasPressed) {
+        analogOptions.analogRightEnabled = !analogOptions.analogRightEnabled;
+        if (analogOptions.analogRightEnabled && gamepadOptions.dpadMode == DPAD_MODE_RIGHT_ANALOG) {
+            gamepadOptions.dpadMode = DPAD_MODE_DIGITAL;
+        }
+        reqSave = true;
+    }
+    toggleRightWasPressed = rightPressed;
+
+    if (reqSave) {
+        EventManager::getInstance().triggerEvent(new GPStorageSaveEvent(true));
     }
 }
 

--- a/src/config_utils.cpp
+++ b/src/config_utils.cpp
@@ -636,6 +636,8 @@ void ConfigUtils::initUnsetPropertiesWithDefaults(Config& config)
     INIT_UNSET_PROPERTY(config.addonOptions.analogOptions, outer_deadzone2, DEFAULT_OUTER_DEADZONE2);
     INIT_UNSET_PROPERTY(config.addonOptions.analogOptions, auto_calibrate2, !!AUTO_CALIBRATE2_ENABLED);
     INIT_UNSET_PROPERTY(config.addonOptions.analogOptions, forced_circularity2, !!FORCED_CIRCULARITY2_ENABLED);
+    INIT_UNSET_PROPERTY(config.addonOptions.analogOptions, analogLeftEnabled, true);
+    INIT_UNSET_PROPERTY(config.addonOptions.analogOptions, analogRightEnabled, true);
 
     // addonOptions.turboOptions
     INIT_UNSET_PROPERTY(config.addonOptions.turboOptions, enabled, !!TURBO_ENABLED);

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -574,6 +574,27 @@ void Gamepad::processHotkeyAction(GamepadHotkey action) {
 				reqSave = true;
 			}
 			break;
+		case HOTKEY_TOGGLE_LEFT_ANALOG:
+			if (action != lastAction) {
+				AnalogOptions& analogOptions = Storage::getInstance().getAddonOptions().analogOptions;
+				analogOptions.analogLeftEnabled = !analogOptions.analogLeftEnabled;
+				// Turning the stick back on releases the d-pad from standing in for it
+				if (analogOptions.analogLeftEnabled && options.dpadMode == DPAD_MODE_LEFT_ANALOG) {
+					options.dpadMode = DPAD_MODE_DIGITAL;
+				}
+				reqSave = true;
+			}
+			break;
+		case HOTKEY_TOGGLE_RIGHT_ANALOG:
+			if (action != lastAction) {
+				AnalogOptions& analogOptions = Storage::getInstance().getAddonOptions().analogOptions;
+				analogOptions.analogRightEnabled = !analogOptions.analogRightEnabled;
+				if (analogOptions.analogRightEnabled && options.dpadMode == DPAD_MODE_RIGHT_ANALOG) {
+					options.dpadMode = DPAD_MODE_DIGITAL;
+				}
+				reqSave = true;
+			}
+			break;
 		case HOTKEY_REBOOT_DEFAULT:
 			if (action != lastAction) {
 				System::reboot(System::BootMode::DEFAULT);

--- a/src/webconfig.cpp
+++ b/src/webconfig.cpp
@@ -1756,6 +1756,8 @@ std::string setAddonOptions()
     docToValue(analogOptions.smoothing_factor2, doc, "smoothing_factor2");
     docToValue(analogOptions.analog_error, doc, "analog_error");
     docToValue(analogOptions.analog_error2, doc, "analog_error2");
+    docToValue(analogOptions.analogLeftEnabled, doc, "analogLeftEnabled");
+    docToValue(analogOptions.analogRightEnabled, doc, "analogRightEnabled");
     docToValue(analogOptions.enabled, doc, "AnalogInputEnabled");
 
     BootselButtonOptions& bootselButtonOptions = Storage::getInstance().getAddonOptions().bootselButtonOptions;
@@ -2214,6 +2216,8 @@ std::string getAddonOptions()
     writeDoc(doc, "smoothing_factor2", analogOptions.smoothing_factor2);
     writeDoc(doc, "analog_error", analogOptions.analog_error);
     writeDoc(doc, "analog_error2", analogOptions.analog_error2);
+    writeDoc(doc, "analogLeftEnabled", analogOptions.analogLeftEnabled);
+    writeDoc(doc, "analogRightEnabled", analogOptions.analogRightEnabled);
     writeDoc(doc, "AnalogInputEnabled", analogOptions.enabled);
 
     const BootselButtonOptions& bootselButtonOptions = Storage::getInstance().getAddonOptions().bootselButtonOptions;

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -516,6 +516,8 @@ app.get('/api/getAddonsOptions', (req, res) => {
 		keyboardHostMouseRight: 0,
 		keyboardHostMouseSensitivity: 50,
 		keyboardHostMouseMovement: 0,
+		analogLeftEnabled: 1,
+		analogRightEnabled: 1,
 		AnalogInputEnabled: 1,
 		BoardLedAddonEnabled: 1,
 		FocusModeAddonEnabled: 1,

--- a/www/src/Addons/Analog.tsx
+++ b/www/src/Addons/Analog.tsx
@@ -44,6 +44,14 @@ const ANALOG_ERROR_RATES = [
 
 export const analogScheme = {
 	AnalogInputEnabled: yup.number().required().label('Analog Input Enabled'),
+	analogLeftEnabled: yup
+		.number()
+		.label('Left Analog Stick Enabled')
+		.validateRangeWhenValue('AnalogInputEnabled', 0, 1),
+	analogRightEnabled: yup
+		.number()
+		.label('Right Analog Stick Enabled')
+		.validateRangeWhenValue('AnalogInputEnabled', 0, 1),
 	analogAdc1PinX: yup
 		.number()
 		.label('Analog Stick 1 Pin X')
@@ -153,6 +161,8 @@ export const analogScheme = {
 
 export const analogState = {
 	AnalogInputEnabled: 0,
+	analogLeftEnabled: 1,
+	analogRightEnabled: 1,
 	analogAdc1PinX: -1,
 	analogAdc1PinY: -1,
 	analogAdc1Mode: 1,
@@ -180,6 +190,10 @@ export const analogState = {
 	analog_error: 1,
 	analog_error2: 1,
 };
+
+// Each ADC pair drives whichever stick its mode is set to
+const stickEnabledKey = (mode) =>
+	Number(mode) === 2 ? 'analogRightEnabled' : 'analogLeftEnabled';
 
 const Analog = ({ values, errors, handleChange, handleCheckbox, setFieldValue }: AddonPropTypes) => {
 	const { usedPins } = useContext(AppContext);
@@ -219,6 +233,19 @@ const Analog = ({ values, errors, handleChange, handleCheckbox, setFieldValue }:
 							eventKey="analog1Config"
 							title={t('AddonsConfig:analog-adc-1')}
 						>
+							<FormCheck
+								label={t(
+									`AddonsConfig:${stickEnabledKey(values.analogAdc1Mode) === 'analogRightEnabled' ? 'analog-right-stick-enabled' : 'analog-left-stick-enabled'}`,
+								)}
+								type="switch"
+								id="analogAdc1StickEnabled"
+								className="col-sm-4 mb-3 ms-3"
+								isInvalid={false}
+								checked={Boolean(values[stickEnabledKey(values.analogAdc1Mode)])}
+								onChange={() =>
+									handleCheckbox(stickEnabledKey(values.analogAdc1Mode))
+								}
+							/>
 							<Row className="mb-3">
 								<FormSelect
 									label={t('AddonsConfig:analog-adc-1-pin-x-label')}
@@ -504,6 +531,19 @@ const Analog = ({ values, errors, handleChange, handleCheckbox, setFieldValue }:
 							eventKey="analog2Config"
 							title={t('AddonsConfig:analog-adc-2')}
 						>
+							<FormCheck
+								label={t(
+									`AddonsConfig:${stickEnabledKey(values.analogAdc2Mode) === 'analogRightEnabled' ? 'analog-right-stick-enabled' : 'analog-left-stick-enabled'}`,
+								)}
+								type="switch"
+								id="analogAdc2StickEnabled"
+								className="col-sm-4 mb-3 ms-3"
+								isInvalid={false}
+								checked={Boolean(values[stickEnabledKey(values.analogAdc2Mode)])}
+								onChange={() =>
+									handleCheckbox(stickEnabledKey(values.analogAdc2Mode))
+								}
+							/>
 							<Row className="mb-3">
 								<FormSelect
 									label={t('AddonsConfig:analog-adc-2-pin-x-label')}

--- a/www/src/Locales/en/AddonsConfig.jsx
+++ b/www/src/Locales/en/AddonsConfig.jsx
@@ -15,6 +15,8 @@ export default {
 	'analog-header-text': 'Analog',
 	'analog-warning':
 		'Note: Analog sticks will override gamepad Left-Stick and Right-Stick inputs when enabled',
+	'analog-left-stick-enabled': 'Left Analog Stick Enabled',
+	'analog-right-stick-enabled': 'Right Analog Stick Enabled',
 	'analog-available-pins-text': 'Available GPIO pins: {{pins}}',
 	'analog-available-pins-option-not-set': 'None',
 	'analog-adc-1': 'Analog Stick 1',

--- a/www/src/Locales/en/PinMapping.jsx
+++ b/www/src/Locales/en/PinMapping.jsx
@@ -90,6 +90,8 @@ export default {
 		ANALOG_DIRECTION_RS_Y_POS: 'Right Analog Stick Y+ (Down)',
 		ANALOG_DIRECTION_MOD_LOW: 'Analog Stick Tilt 1',
 		ANALOG_DIRECTION_MOD_HIGH: 'Analog Stick Tilt 2',
+		TOGGLE_LEFT_ANALOG: 'Toggle Left Analog Stick',
+		TOGGLE_RIGHT_ANALOG: 'Toggle Right Analog Stick',
 		BUTTON_PRESS_INPUT_REVERSE: 'Reverse Input',
 		SUSTAIN_FOCUS_MODE: 'Focus Mode Enable',
 		SUSTAIN_4_8_WAY_MODE: 'Toggle 4-Way Mode',

--- a/www/src/Locales/en/Proto/GpioAction.jsx
+++ b/www/src/Locales/en/Proto/GpioAction.jsx
@@ -70,6 +70,8 @@ export default {
 	'ANALOG_DIRECTION_RS_Y_POS': 'Right Analog Stick Y+',
 	'ANALOG_DIRECTION_MOD_LOW': 'Analog Stick Tilt 1',
 	'ANALOG_DIRECTION_MOD_HIGH': 'Analog Stick Tilt 2',
+	'TOGGLE_LEFT_ANALOG': 'Toggle Left Analog Stick',
+	'TOGGLE_RIGHT_ANALOG': 'Toggle Right Analog Stick',
 	'BUTTON_PRESS_INPUT_REVERSE': 'Reverse Input',
 	'SUSTAIN_FOCUS_MODE': 'Focus Mode Enable',
 	'SUSTAIN_4_8_WAY_MODE': 'Toggle 4-Way Mode',

--- a/www/src/Locales/en/SettingsPage.jsx
+++ b/www/src/Locales/en/SettingsPage.jsx
@@ -159,6 +159,8 @@ export default {
 		'rs-down': 'Right Stick Down',
 		'rs-left': 'Right Stick Left',
 		'rs-right': 'Right Stick Right',
+		'toggle-left-analog': 'Toggle Left Analog Stick',
+		'toggle-right-analog': 'Toggle Right Analog Stick',
 	},
 	'forced-setup-mode-label': 'Forced Setup Mode',
 	'forced-setup-mode-options': {

--- a/www/src/Pages/SettingsPage.jsx
+++ b/www/src/Pages/SettingsPage.jsx
@@ -278,6 +278,8 @@ const HOTKEY_ACTIONS = [
 	{ labelKey: 'hotkey-actions.rs-down', value: 83 },
 	{ labelKey: 'hotkey-actions.rs-left', value: 84 },
 	{ labelKey: 'hotkey-actions.rs-right', value: 85 },
+	{ labelKey: 'hotkey-actions.toggle-left-analog', value: 88 },
+	{ labelKey: 'hotkey-actions.toggle-right-analog', value: 89 },
 ];
 
 const FORCED_SETUP_MODES = [


### PR DESCRIPTION
This draft PR allows you to assign a hotkey or GPIO to enable or disable the left or right analog.  This would then allow you to change the main stick into left or right stick mode.  In the event that left or right analog sticks are enabled while the stick is in the mode of the analog stick that is being enabled again, the main stick will flip back to being in dpad mode.